### PR TITLE
fix(backend): close access-control gaps, fix auth/upload bugs, add public API for bosan.cz

### DIFF
--- a/backend/src/api/account/controllers/login.controller.ts
+++ b/backend/src/api/account/controllers/login.controller.ts
@@ -90,9 +90,9 @@ export class LoginController {
 
 		const loginCode = this.hashService.generateRandomString();
 
-		this.users.updateUser(user.id, {
+		await this.users.updateUser(user.id, {
 			loginCode: loginCode,
-			loginCodeExp: DateTime.local().toISO(),
+			loginCodeExp: DateTime.local().plus({ minutes: 30 }).toISO(),
 		});
 
 		const mail = SendLoginLinkMailTemplate(user.email, {
@@ -113,14 +113,15 @@ export class LoginController {
 
 		LoginLinkPermission.canOrThrow(req);
 
-		if (DateTime.fromISO(user.loginCodeExp).diffNow().milliseconds < 0) {
-			throw new ForbiddenException("Login code expired");
-		}
-
-		this.users.updateUser(user.id, {
+		// invalidate the code first so it is strictly single-use even if issuing the session below fails
+		await this.users.updateUser(user.id, {
 			loginCode: null,
 			loginCodeExp: null,
 		});
+
+		if (DateTime.fromISO(user.loginCodeExp).diffNow().milliseconds < 0) {
+			throw new ForbiddenException("Login code expired");
+		}
 
 		await this.setLoginToken(res, user);
 

--- a/backend/src/api/albums/controllers/albums.controller.ts
+++ b/backend/src/api/albums/controllers/albums.controller.ts
@@ -34,6 +34,8 @@ export class AlbumsController {
 	@AcLinks(AlbumsListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(AlbumResponse), isArray: true })
 	async listAlbums(@Req() req: Request, @Query() query: AlbumListQuery): Promise<AlbumResponse[]> {
+		AlbumsListPermission.canOrThrow(req);
+
 		const options: GetAlbumsOptions = {
 			limit: query.limit,
 			offset: query.offset,
@@ -127,6 +129,11 @@ export class AlbumsController {
 	@AcLinks(AlbumPhotosPermission)
 	@ApiResponse({ status: 200, type: WithLinks(PhotoResponse), isArray: true })
 	async getAlbumPhotos(@Param("id") id: number, @Req() req: Request): Promise<PhotoResponse[]> {
+		const album = await this.albums.getAlbum(id);
+		if (!album) throw new NotFoundException();
+
+		AlbumPhotosPermission.canOrThrow(req, album);
+
 		return this.photos.getPhotos({ album: id });
 	}
 

--- a/backend/src/api/albums/controllers/photos.controller.ts
+++ b/backend/src/api/albums/controllers/photos.controller.ts
@@ -45,6 +45,8 @@ export class PhotosController {
 	@AcLinks(PhotosListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(PhotoResponse), isArray: true })
 	async listPhotos(@Req() req: Request) {
+		PhotosListPermission.canOrThrow(req);
+
 		return this.photos.getPhotos();
 	}
 

--- a/backend/src/api/events/acl/events.acl.ts
+++ b/backend/src/api/events/acl/events.acl.ts
@@ -9,7 +9,7 @@ import { EventResponse } from "../dto/event.dto";
 export const isMyEvent = (doc: Pick<Event, "attendees"> | undefined, req: Request) =>
 	doc?.attendees?.some((l) => l.memberId === req.user?.memberId && l.type === "leader") ?? false;
 
-export const EventsListPermission = new Permission({
+export const EventsListPermission = new Permission<void>({
 	linkTo: RootResponse,
 	contains: EventResponse,
 

--- a/backend/src/api/events/controllers/events.controller.ts
+++ b/backend/src/api/events/controllers/events.controller.ts
@@ -58,6 +58,8 @@ export class EventsController {
 		@Token() token: TokenData,
 		@Query() query: ListEventsQuery,
 	): Promise<EventResponse[]> {
+		EventsListPermission.canOrThrow(req);
+
 		const options: GetEventsOptions = {
 			...query,
 		};
@@ -66,8 +68,6 @@ export class EventsController {
 			if (!token.memberId) throw new ConflictException("Cannot show my events, user is not linked to a member.");
 			options.memberId = token.memberId;
 		}
-
-		// FIXME: add ACL logic - filter evens based on role
 
 		return this.events.getEvents(options);
 	}

--- a/backend/src/api/members/controllers/groups.controller.ts
+++ b/backend/src/api/members/controllers/groups.controller.ts
@@ -37,6 +37,8 @@ export class GroupsController {
 	@AcLinks(GroupListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(GroupResponse), isArray: true })
 	async listGroups(@Req() req: Request, @Query() query: ListGroupsQuery): Promise<GroupResponse[]> {
+		GroupListPermission.canOrThrow(req);
+
 		return this.groups.getGroups(query);
 	}
 
@@ -69,7 +71,7 @@ export class GroupsController {
 
 		GroupEditPermission.canOrThrow(req, group);
 
-		await this.groups.updateGroup(id, req.body);
+		await this.groups.updateGroup(id, body);
 	}
 
 	@Delete(":id")

--- a/backend/src/api/members/controllers/member-insurance-card.controller.ts
+++ b/backend/src/api/members/controllers/member-insurance-card.controller.ts
@@ -1,4 +1,5 @@
 import {
+	BadRequestException,
 	Controller,
 	Delete,
 	Get,
@@ -32,6 +33,10 @@ import {
 	MemberInsuranceCardUploadPermission,
 } from "../acl/member-insurance-card.acl";
 
+// Restrict to non-active document types. Serving an uploaded .svg/.html inline on the
+// app origin would let it run as stored XSS, so those must never be accepted.
+const ALLOWED_INSURANCE_CARD_TYPES = ["pdf", "jpg", "jpeg", "png"];
+
 @Controller("members/:id/insurance-card")
 @UseGuards(UserGuard)
 @AcController()
@@ -59,6 +64,8 @@ export class MemberInsuranceCardController {
 
 		res.setHeader("Content-Disposition", `inline; filename="insurance_card.${member.insuranceCardFile}"`);
 		res.setHeader("Content-Type", contentType(member.insuranceCardFile) || "application/octet-stream");
+		// never let the browser sniff/execute the stored file as something active
+		res.setHeader("X-Content-Type-Options", "nosniff");
 
 		createReadStream(path).pipe(res);
 	}
@@ -90,7 +97,13 @@ export class MemberInsuranceCardController {
 
 		MemberInsuranceCardUploadPermission.canOrThrow(req, member);
 
-		const ext = extname(file.originalname).slice(1);
+		if (!file) throw new BadRequestException("Missing file.");
+
+		const ext = extname(file.originalname).slice(1).toLowerCase();
+		if (!ALLOWED_INSURANCE_CARD_TYPES.includes(ext)) {
+			throw new BadRequestException(`Unsupported file type. Allowed: ${ALLOWED_INSURANCE_CARD_TYPES.join(", ")}.`);
+		}
+
 		const path = this.getInsuraceCardPath(member.id, ext);
 
 		try {

--- a/backend/src/api/members/controllers/members-export.controller.ts
+++ b/backend/src/api/members/controllers/members-export.controller.ts
@@ -6,7 +6,7 @@ import { UserGuard } from "src/auth/guards/user.guard";
 import { MembersRepository } from "src/models/members/repositories/members.repository";
 import { MembersExportService } from "src/models/members/services/members-export.service";
 import { pipeline } from "stream/promises";
-import { MembersExportPermission, MembersListPermission } from "../acl/members.acl";
+import { MembersExportPermission } from "../acl/members.acl";
 import { MembersListQuery } from "../dto/member.dto";
 
 @Controller("members/export")
@@ -31,9 +31,9 @@ export class MembersExportController {
 		},
 	})
 	async exportMembersXlsx(@Req() req: Request, @Query() query: MembersListQuery, @Res() res: Response) {
-		const members = await this.members.getMembers(query);
-		MembersListPermission.canOrThrow(req);
+		MembersExportPermission.canOrThrow(req);
 
+		const members = await this.members.getMembers(query);
 		const xlsx = await this.membersExportService.exportXlsx(members);
 
 		res.setHeader("Content-Disposition", "attachment; filename=" + "bo-databaze.xlsx");

--- a/backend/src/api/members/controllers/members.controller.ts
+++ b/backend/src/api/members/controllers/members.controller.ts
@@ -36,6 +36,8 @@ export class MembersController {
 	@AcLinks(MembersListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(MemberResponse), isArray: true })
 	async listMembers(@Req() req: Request, @Query() query: MembersListQuery): Promise<MemberResponse[]> {
+		MembersListPermission.canOrThrow(req);
+
 		const members = await this.members.getMembers({
 			...query,
 			limit: query.limit ?? 25,

--- a/backend/src/api/public/acl/public.acl.ts
+++ b/backend/src/api/public/acl/public.acl.ts
@@ -1,0 +1,46 @@
+import { Permission } from "src/access-control/schema/route-acl";
+import { RootResponse } from "src/api/root/dto/root-response";
+
+/**
+ * Access control for the unauthenticated public API consumed by the bosan.cz website.
+ *
+ * These permissions exist so the routes are advertised on the API root `_links`
+ * (that is how the bosan.cz ApiService discovers resource URLs). They are open to
+ * everyone (`verejnost`) and intentionally do NOT set `contains` so the
+ * AcLinksInterceptor leaves the hand-built legacy response shape untouched.
+ *
+ * The `name` matches the resource key the bosan.cz frontend looks up, and `path`
+ * emits a `{id}` URI template (bosan.cz expands `{...}` placeholders client-side).
+ */
+
+export const PublicProgramPermission = new Permission<void>({
+	linkTo: RootResponse,
+	name: "program",
+	allowed: { verejnost: true },
+});
+
+export const PublicGalleryPermission = new Permission<void>({
+	linkTo: RootResponse,
+	name: "gallery",
+	allowed: { verejnost: true },
+});
+
+export const PublicGalleryRecentPermission = new Permission<void>({
+	linkTo: RootResponse,
+	name: "gallery:recent",
+	allowed: { verejnost: true },
+});
+
+export const PublicGalleryAlbumPermission = new Permission<void>({
+	linkTo: RootResponse,
+	name: "galleryalbum",
+	allowed: { verejnost: true },
+	path: () => "gallery/{id}",
+});
+
+export const PublicGalleryAlbumPreviewPermission = new Permission<void>({
+	linkTo: RootResponse,
+	name: "galleryalbum:preview",
+	allowed: { verejnost: true },
+	path: () => "gallery/{id}/preview",
+});

--- a/backend/src/api/public/controllers/public.controller.ts
+++ b/backend/src/api/public/controllers/public.controller.ts
@@ -1,12 +1,123 @@
-import { Controller, Get } from "@nestjs/common";
-import { ApiTags } from "@nestjs/swagger";
+import {
+	Controller,
+	Get,
+	NotFoundException,
+	NotImplementedException,
+	Param,
+	Query,
+	Req,
+	Res,
+} from "@nestjs/common";
+import { ApiExcludeController } from "@nestjs/swagger";
+import { Request, Response } from "express";
+import { createReadStream } from "fs";
+import { contentType } from "mime-types";
+import { extname } from "path";
+import { AcController, AcLinks } from "src/access-control/access-control-lib";
+import { PhotoSizes } from "src/api/albums/dto/photo.dto";
+import { AlbumStatus } from "src/models/albums/entities/album.entity";
+import { AlbumsRepository } from "src/models/albums/repositories/albums.repository";
+import { PhotosRepository } from "src/models/albums/repositories/photos.repository";
+import { PhotosFilesService } from "src/models/albums/services/photos-files.service";
+import {
+	PublicGalleryAlbumPermission,
+	PublicGalleryAlbumPreviewPermission,
+	PublicGalleryPermission,
+	PublicGalleryRecentPermission,
+	PublicProgramPermission,
+} from "../acl/public.acl";
+import { PublicGalleryQuery, PublicProgramQuery } from "../dto/public.dto";
+import { PublicService } from "../services/public.service";
 
+/**
+ * Unauthenticated public API consumed by the bosan.cz website. Returns the legacy
+ * response shapes (string `_id`s, photo `sizes`, `_links`) so the existing website
+ * frontend keeps working against the rewritten backend without changes on its side.
+ *
+ * Excluded from the internal OpenAPI docs — it is a stable external contract, not
+ * part of the HATEOAS/AC-lib surface the internal SDK is generated from.
+ */
 @Controller("public")
-@ApiTags("Public")
+@AcController()
+@ApiExcludeController()
 export class PublicController {
-	@Get()
-	getProgram() {}
+	constructor(
+		private readonly publicService: PublicService,
+		private readonly albums: AlbumsRepository,
+		private readonly photos: PhotosRepository,
+		private readonly photosFiles: PhotosFilesService,
+	) {}
 
-	@Get()
-	getGallery() {}
+	@Get("program")
+	@AcLinks(PublicProgramPermission)
+	async getProgram(@Req() req: Request, @Query() query: PublicProgramQuery) {
+		return this.publicService.getProgram({
+			limit: query.limit,
+			dateFrom: query.dateFrom,
+			dateTill: query.dateTill,
+		});
+	}
+
+	@Get("program/:id/registration")
+	async getProgramRegistration() {
+		// The internal registration PDF lives behind auth; a dedicated public download can be
+		// wired here once the storage location for public registrations is confirmed.
+		throw new NotImplementedException("Public registration download is not available yet.");
+	}
+
+	@Get("gallery")
+	@AcLinks(PublicGalleryPermission)
+	async getGallery(@Req() req: Request, @Query() query: PublicGalleryQuery) {
+		return this.publicService.getGallery();
+	}
+
+	@Get("gallery/recent")
+	@AcLinks(PublicGalleryRecentPermission)
+	async getGalleryRecent(@Req() req: Request, @Query() query: PublicGalleryQuery) {
+		return this.publicService.getRecentGallery(query.limit);
+	}
+
+	@Get("gallery/:id")
+	@AcLinks(PublicGalleryAlbumPermission)
+	async getGalleryAlbum(@Param("id") id: number) {
+		return this.publicService.getAlbum(id);
+	}
+
+	@Get("gallery/:id/preview")
+	@AcLinks(PublicGalleryAlbumPreviewPermission)
+	async getGalleryAlbumPreview(@Param("id") id: number) {
+		return this.publicService.getAlbum(id, { preview: true });
+	}
+
+	@Get("gallery/:id/download")
+	async downloadAlbum() {
+		// bosan.cz always renders the album download link, so the route must exist; ZIP
+		// streaming needs an archiver dependency which is a follow-up decision.
+		throw new NotImplementedException("Album ZIP download is not available yet.");
+	}
+
+	@Get("photos/:id/image/:size")
+	async getPhotoImage(@Param("id") id: number, @Param("size") size: PhotoSizes, @Res() res: Response): Promise<void> {
+		if (!Object.values(PhotoSizes).includes(size)) throw new NotFoundException("Unknown image size.");
+
+		const photo = await this.photos.getPhoto(id);
+		if (!photo) throw new NotFoundException();
+
+		// only expose photos that belong to a published album
+		const album = await this.albums.getAlbum(photo.albumId);
+		if (!album || album.status !== AlbumStatus.public) throw new NotFoundException();
+
+		const ext = extname(photo.name);
+		const path = this.photosFiles.getImagePath(photo.albumId, photo.id, size, ext);
+
+		try {
+			await this.photosFiles.fileExists(path);
+		} catch {
+			throw new NotFoundException("Image file not found.");
+		}
+
+		res.setHeader("Content-Type", contentType(ext) || "application/octet-stream");
+		res.setHeader("Cache-Control", "public, max-age=86400");
+		createReadStream(path).pipe(res);
+	}
 }

--- a/backend/src/api/public/dto/public.dto.ts
+++ b/backend/src/api/public/dto/public.dto.ts
@@ -1,0 +1,14 @@
+import { Type } from "class-transformer";
+import { IsDateString, IsInt, IsOptional, IsString } from "class-validator";
+
+export class PublicProgramQuery {
+	@IsOptional() @Type(() => Number) @IsInt() limit?: number;
+	@IsOptional() @IsDateString() dateFrom?: string;
+	@IsOptional() @IsDateString() dateTill?: string;
+}
+
+export class PublicGalleryQuery {
+	@IsOptional() @Type(() => Number) @IsInt() limit?: number;
+	// accepted for backwards compatibility with the website (e.g. "-dateFrom"); ordering is fixed server-side
+	@IsOptional() @IsString() sort?: string;
+}

--- a/backend/src/api/public/public.module.ts
+++ b/backend/src/api/public/public.module.ts
@@ -1,9 +1,13 @@
 import { Module } from "@nestjs/common";
+import { AlbumsModelModule } from "src/models/albums/albums-model.module";
 import { EventsModelModule } from "src/models/events/events-model.module";
+import { MembersModelModule } from "src/models/members/members-model.module";
 import { PublicController } from "./controllers/public.controller";
+import { PublicService } from "./services/public.service";
 
 @Module({
 	controllers: [PublicController],
-	imports: [EventsModelModule],
+	imports: [EventsModelModule, AlbumsModelModule, MembersModelModule],
+	providers: [PublicService],
 })
 export class PublicModule {}

--- a/backend/src/api/public/services/public.service.ts
+++ b/backend/src/api/public/services/public.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { Config } from "src/config";
+import { AlbumStatus } from "src/models/albums/entities/album.entity";
+import { Photo } from "src/models/albums/entities/photo.entity";
+import { AlbumsRepository } from "src/models/albums/repositories/albums.repository";
+import { PhotosRepository } from "src/models/albums/repositories/photos.repository";
+import { Event } from "src/models/events/entities/event.entity";
+import { EventsRepository } from "src/models/events/repositories/events.repository";
+import { GroupsRepository } from "src/models/members/repositories/groups.repository";
+
+/**
+ * Builds the legacy (routesjs-era) response shapes the bosan.cz website expects:
+ * string `_id`s, photo `sizes` objects with URLs, and `_links` with `{id}`-style hrefs.
+ * This is deliberately decoupled from the internal AC-lib response format.
+ */
+@Injectable()
+export class PublicService {
+	constructor(
+		private readonly config: Config,
+		private readonly events: EventsRepository,
+		private readonly albums: AlbumsRepository,
+		private readonly photos: PhotosRepository,
+		private readonly groups: GroupsRepository,
+	) {}
+
+	private get apiBase() {
+		return `${this.config.app.baseUrl}/api`;
+	}
+
+	// ---- Program (events) ----
+
+	async getProgram(options: { limit?: number; dateFrom?: string; dateTill?: string }) {
+		const [events, groups] = await Promise.all([this.events.getPublicProgram(options), this.groups.getGroups()]);
+
+		const groupNameById = new Map(groups.map((g) => [g.id, g.shortName]));
+
+		return events.map((event) => this.serializeEvent(event, groupNameById));
+	}
+
+	private serializeEvent(event: Event, groupNameById: Map<number, string>) {
+		const groups = (event.groupsIds ?? [])
+			.map((id) => groupNameById.get(id))
+			.filter((name): name is string => !!name);
+
+		return {
+			_id: String(event.id),
+			status: event.status,
+			name: event.name,
+			type: event.type,
+			description: event.description,
+			dateFrom: event.dateFrom,
+			dateTill: event.dateTill,
+			timeFrom: event.timeFrom,
+			timeTill: event.timeTill,
+			groups,
+			leadersEvent: event.leadersEvent,
+			meeting: {
+				start: event.meetingPlaceStart,
+				end: event.meetingPlaceEnd,
+			},
+			leaders: (event.leaders ?? []).map((member) => ({
+				_id: String(member.id),
+				nickname: member.nickname,
+				contacts: { mobile: member.mobile ?? null },
+			})),
+			_links: {
+				registration: {
+					href: `${this.apiBase}/public/program/${event.id}/registration`,
+					method: "GET",
+					allowed: { GET: !!event.hasRegistration },
+				},
+			},
+		};
+	}
+
+	// ---- Gallery (albums / photos) ----
+
+	async getGallery() {
+		const albums = await this.albums.getAlbums({ status: AlbumStatus.public, limit: 1000 });
+		return albums.map((album) => this.serializeAlbum(album));
+	}
+
+	async getRecentGallery(limit = 5) {
+		const albums = await this.albums.getAlbums({
+			status: AlbumStatus.public,
+			limit: Math.min(limit, 10),
+		});
+
+		return Promise.all(
+			albums.map(async (album) => {
+				const photos = await this.photos.getPhotos({ album: album.id, limit: 3 });
+				return this.serializeAlbum(album, photos);
+			}),
+		);
+	}
+
+	async getAlbum(id: number, options: { preview?: boolean } = {}) {
+		const album = await this.albums.getAlbum(id);
+		if (!album || album.status !== AlbumStatus.public) throw new NotFoundException();
+
+		const photos = await this.photos.getPhotos({
+			album: album.id,
+			limit: options.preview ? 3 : undefined,
+		});
+
+		return this.serializeAlbum(album, photos);
+	}
+
+	private serializeAlbum(album: { id: number; [k: string]: any }, photos?: Photo[]) {
+		const serializedPhotos = photos?.map((photo) => this.serializePhoto(photo));
+		const titlePhotos = serializedPhotos?.slice(0, 3) ?? [];
+
+		return {
+			_id: String(album.id),
+			year: album.dateFrom ? new Date(album.dateFrom).getFullYear() : undefined,
+			status: album.status,
+			name: album.name,
+			description: album.description ?? null,
+			datePublished: album.datePublished ?? null,
+			dateFrom: album.dateFrom ?? null,
+			dateTill: album.dateTill ?? null,
+			titlePhotos,
+			photos: serializedPhotos,
+			_links: {
+				self: { href: `${this.apiBase}/public/gallery/${album.id}`, method: "GET", allowed: { GET: true } },
+				// bosan.cz always renders the album download link, so the href must exist even
+				// though the ZIP endpoint is not implemented yet (see PublicController.downloadAlbum).
+				download: {
+					href: `${this.apiBase}/public/gallery/${album.id}/download`,
+					method: "GET",
+					allowed: { GET: true },
+				},
+			},
+		};
+	}
+
+	private serializePhoto(photo: Photo) {
+		const base = `${this.apiBase}/public/photos/${photo.id}/image`;
+
+		return {
+			_id: String(photo.id),
+			album: String(photo.albumId),
+			name: photo.name,
+			caption: photo.caption ?? null,
+			width: photo.width,
+			height: photo.height,
+			bg: photo.bg ?? null,
+			tags: photo.tags ?? [],
+			date: photo.timestamp,
+			sizes: {
+				original: { url: `${base}/original`, ...this.scaledSize(photo, null) },
+				big: { url: `${base}/big`, ...this.scaledSize(photo, this.config.photos.sizes.big) },
+				small: { url: `${base}/small`, ...this.scaledSize(photo, this.config.photos.sizes.small) },
+			},
+		};
+	}
+
+	/** Compute the on-screen dimensions of a resized variant (fit: inside, never upscales). */
+	private scaledSize(photo: Photo, max: { width: number; height: number } | null) {
+		if (!photo.width || !photo.height) {
+			return { width: max?.width ?? null, height: max?.height ?? null };
+		}
+		if (!max) return { width: photo.width, height: photo.height };
+
+		const scale = Math.min(max.width / photo.width, max.height / photo.height, 1);
+		return { width: Math.round(photo.width * scale), height: Math.round(photo.height * scale) };
+	}
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { MulterModule } from "@nestjs/platform-express";
 import { ServeStaticModule } from "@nestjs/serve-static";
+import { memoryStorage } from "multer";
 import { AccessControlModule } from "./access-control/access-control.module";
 import { AccountModule } from "./api/account/account.module";
 import { AlbumsModule } from "./api/albums/albums.module";
@@ -32,7 +33,9 @@ import { UsersModelModule } from "./models/users/users-model.module";
 			useFactory: (config: Config) => [{ rootPath: config.server.staticRoot }],
 		}),
 		MulterModule.register({
-			dest: "/tmp/uploads",
+			// in-memory storage so handlers that read file.buffer (photos, insurance cards) work;
+			// handlers that need a file on disk (event registration) set their own dest per-route
+			storage: memoryStorage(),
 			limits: {
 				fileSize: 1024 * 1024 * 100, // 100 MB
 			},

--- a/backend/src/auth/services/hash.service.ts
+++ b/backend/src/auth/services/hash.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 import { compare, hash } from "bcryptjs";
+import { randomBytes } from "crypto";
 
 @Injectable()
 export class HashService {
@@ -11,7 +12,8 @@ export class HashService {
 		return compare(s, hash);
 	}
 
-	generateRandomString() {
-		return Math.random().toString(36).slice(2);
+	/** Cryptographically secure random token (URL-safe). Used for e.g. e-mailed login codes. */
+	generateRandomString(bytes = 32) {
+		return randomBytes(bytes).toString("base64url");
 	}
 }

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -28,6 +28,12 @@ const server = {
 	staticRoot: process.env.STATIC_ROOT || path.join(__dirname, "../../frontend/dist/browser"),
 	globalPrefix: process.env.GLOBAL_PREFIX ?? "api",
 	cors: environment === "development",
+	// Cross-origin allow-list for first-party sites that consume the public API from a
+	// different origin (the bosan.cz website). In development any origin is reflected.
+	corsOrigins: (process.env["CORS_ORIGINS"] ?? "https://bosan.cz,https://www.bosan.cz")
+		.split(",")
+		.map((origin) => origin.trim())
+		.filter(Boolean),
 };
 
 const logging: { level: LogLevel[]; query: boolean } = {
@@ -51,14 +57,22 @@ const app = {
 	environmentTitle: process.env["ENV_TITLE"] ?? (environment === "production" ? "" : environment.toUpperCase()),
 };
 
+const jwtSecret = process.env["JWT_SECRET"];
+
+// A predictable secret lets anyone forge admin session cookies, so never allow the
+// insecure development fallback outside of local development.
+if (production && (!jwtSecret || jwtSecret.length < 32)) {
+	throw new Error("JWT_SECRET environment variable must be set to a strong (>=32 char) value in production.");
+}
+
 const jwt = {
-	secret: process.env["JWT_SECRET"] ?? "secret",
+	secret: jwtSecret ?? "secret",
 };
 
 const db: PostgresConnectionOptions = {
 	type: "postgres",
 	host: process.env["DB_HOST"] ?? "localhost",
-	port: process.env["DB_HOST"] ? parseInt(process.env["DB_HOST"]) : 5432,
+	port: process.env["DB_PORT"] ? parseInt(process.env["DB_PORT"]) : 5432,
 	username: process.env["DB_USER"] ?? "postgres",
 	password: process.env["DB_PASSWORD"],
 	database: process.env.DB_DATABASE_NAME ?? "postgres",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -34,8 +34,15 @@ async function bootstrap() {
 	}
 
 	if (config.server.cors) {
+		// development: reflect any origin for convenience
 		app.enableCors({
 			origin: true,
+			credentials: true,
+		});
+	} else if (config.server.corsOrigins.length) {
+		// production: only the explicitly allow-listed first-party origins (e.g. the bosan.cz website)
+		app.enableCors({
+			origin: config.server.corsOrigins,
 			credentials: true,
 		});
 	}

--- a/backend/src/models/albums/services/photos-files.service.ts
+++ b/backend/src/models/albums/services/photos-files.service.ts
@@ -6,6 +6,9 @@ import sharp = require("sharp");
 import { FilesService } from "src/models/files/services/files.service";
 import { PhotoSizes } from "src/api/albums/dto/photo.dto";
 
+// Cap decoded image size to guard against decompression-bomb uploads (roughly 24k x 24k).
+const MAX_INPUT_PIXELS = 24000 * 24000;
+
 export interface PhotoMetadata {
 	width: number | null;
 	height: number | null;
@@ -42,7 +45,7 @@ export class PhotosFilesService {
 
 	/** Read image dimensions, dominant background color and capture date from the buffer. */
 	async extractMetadata(buffer: Buffer): Promise<PhotoMetadata> {
-		const image = sharp(buffer);
+		const image = sharp(buffer, { limitInputPixels: MAX_INPUT_PIXELS });
 		const [metadata, stats] = await Promise.all([image.metadata(), image.stats()]);
 
 		const bg =
@@ -66,10 +69,10 @@ export class PhotosFilesService {
 		await this.files.saveFile(this.getImagePath(albumId, photoId, PhotoSizes.original, ext), buffer);
 
 		for (const [name, size] of Object.entries(this.config.photos.sizes)) {
-			const resized = await sharp(buffer)
+			const resized = await sharp(buffer, { limitInputPixels: MAX_INPUT_PIXELS })
 				.rotate()
 				.resize(size.width, size.height, { fit: "inside" })
-				.withMetadata()
+				// intentionally drop EXIF (incl. GPS) from the derived variants that are served to clients
 				.toBuffer();
 
 			await this.files.saveFile(this.getImagePath(albumId, photoId, name as PhotoSizes, ext), resized);

--- a/backend/src/models/events/repositories/events.repository.ts
+++ b/backend/src/models/events/repositories/events.repository.ts
@@ -5,7 +5,7 @@ import { Group } from "src/models/members/entities/group.entity";
 import { Brackets, FindOptionsSelect, Repository } from "typeorm";
 import { EventAttendee, EventAttendeeType } from "../entities/event-attendee.entity";
 import { EventExpense } from "../entities/event-expense.entity";
-import { Event } from "../entities/event.entity";
+import { Event, EventStates } from "../entities/event.entity";
 
 export interface GetEventsOptions extends PaginationOptions {
 	year?: number[];
@@ -29,7 +29,19 @@ export class EventsRepository {
 	async getEvents(options: GetEventsOptions = {}) {
 		const q = this.eventsRepository
 			.createQueryBuilder("events")
-			.select(["events.id", "events.name", "events.status", "events.dateFrom", "events.dateTill", "events.type"])
+			.select([
+				"events.id",
+				"events.name",
+				"events.status",
+				"events.statusNote",
+				"events.dateFrom",
+				"events.dateTill",
+				"events.type",
+				"events.place",
+				"events.description",
+				"events.meetingPlaceStart",
+				"events.meetingPlaceEnd",
+			])
 			.leftJoinAndSelect("events.attendees", "attendees", "attendees.type = :type", { type: "leader" })
 			.leftJoinAndSelect("attendees.member", "leaders")
 			.orderBy("events.dateFrom", "DESC");
@@ -68,7 +80,70 @@ export class EventsRepository {
 
 		if (options.deleted) q.withDeleted().andWhere("events.deleted_at IS NOT NULL");
 
-		return q.getMany();
+		const events = await q.getMany();
+
+		// populate `leaders` from the joined leader attendees so list consumers (cards, exports)
+		// get the same shape as getEvent() — the @AfterLoad hook only covers already-loaded attendees
+		for (const event of events) {
+			event.leaders = (event.attendees ?? [])
+				.filter((a) => a.member && a.type === EventAttendeeType.leader)
+				.map((a) => a.member!);
+		}
+
+		return events;
+	}
+
+	/**
+	 * Public program for the bosan.cz website: only published/cancelled events, with
+	 * leader members and groups loaded. `dateFrom` defaults to a few days back so the
+	 * currently-running events stay visible.
+	 */
+	async getPublicProgram(options: { dateFrom?: string; dateTill?: string; limit?: number } = {}) {
+		const q = this.eventsRepository
+			.createQueryBuilder("events")
+			.select([
+				"events.id",
+				"events.name",
+				"events.status",
+				"events.dateFrom",
+				"events.dateTill",
+				"events.timeFrom",
+				"events.timeTill",
+				"events.type",
+				"events.place",
+				"events.description",
+				"events.meetingPlaceStart",
+				"events.meetingPlaceEnd",
+				"events.leadersEvent",
+				"events.hasRegistration",
+			])
+			.leftJoinAndSelect("events.groups", "groups")
+			.leftJoinAndSelect("events.attendees", "attendees", "attendees.type = :type", { type: "leader" })
+			.leftJoinAndSelect("attendees.member", "leaders")
+			.where("events.status IN (:...statuses)", { statuses: [EventStates.public, EventStates.cancelled] })
+			.andWhere("events.dateTill >= :dateFrom", { dateFrom: options.dateFrom ?? this.defaultProgramFrom() })
+			.orderBy("events.dateFrom", "ASC")
+			.addOrderBy("events.timeFrom", "ASC", "NULLS FIRST")
+			.take(Math.min(options.limit ?? 100, 100));
+
+		if (options.dateTill) q.andWhere("events.dateFrom <= :dateTill", { dateTill: options.dateTill });
+
+		const events = await q.getMany();
+
+		for (const event of events) {
+			event.leaders = (event.attendees ?? [])
+				.filter((a) => a.member && a.type === EventAttendeeType.leader)
+				.map((a) => a.member!);
+		}
+
+		return events;
+	}
+
+	/** Three days back, so events that are currently under way are still shown. */
+	private defaultProgramFrom() {
+		const from = new Date();
+		from.setDate(from.getDate() - 3);
+		return from.toISOString().slice(0, 10);
 	}
 
 	async getEvent(id: number, options: { select?: FindOptionsSelect<Event>; leaders?: boolean } = {}) {
@@ -145,7 +220,8 @@ export class EventsRepository {
 	async getEventAttendee(eventId: number, memberId: number) {
 		return this.eventAttendeesRepository.findOne({
 			where: { eventId, memberId },
-			relations: { member: true, event: true },
+			// event.attendees is needed so isMyEvent(doc.event) works in the edit/delete permission checks
+			relations: { member: true, event: { attendees: true } },
 			withDeleted: true,
 		});
 	}

--- a/backend/src/models/users/commands/create-admin.command.ts
+++ b/backend/src/models/users/commands/create-admin.command.ts
@@ -1,9 +1,18 @@
 import { Logger } from "@nestjs/common";
 import { Command, CommandRunner } from "nest-commander";
 import { HashService } from "src/auth/services/hash.service";
+import { StaticConfig } from "src/config";
 import { UserRoles } from "../entities/user.entity";
 import { UsersRepository } from "../repositories/users.repository";
 
+/**
+ * Creates (or resets the password of) an admin user.
+ *
+ * Credentials come from the ADMIN_LOGIN / ADMIN_EMAIL / ADMIN_PASSWORD environment
+ * variables. If no password is provided a strong random one is generated and printed
+ * once. There is intentionally no hardcoded default so this command can never seed a
+ * well-known admin account.
+ */
 @Command({
 	name: "create-admin",
 	arguments: "",
@@ -19,25 +28,40 @@ export class CreateAdminCommand extends CommandRunner {
 		super();
 	}
 
-	async run(inputs: string[], options: Record<string, any>): Promise<void> {
-		const userData = {
-			login: "bilbo",
-			email: "bilbo@bosan.cz",
-			password: "gandalf",
-		};
+	async run(): Promise<void> {
+		const login = process.env["ADMIN_LOGIN"];
+		const email = process.env["ADMIN_EMAIL"];
 
-		const user = await this.usersService.findUser({ login: userData.login });
-
-		if (user) {
-			await this.usersService.deleteUser(user.id);
+		if (!login || !email) {
+			throw new Error("Set ADMIN_LOGIN and ADMIN_EMAIL environment variables to create an admin user.");
 		}
-		const passwordHash = await this.hashService.generateHash(userData.password);
-		await this.usersService.createUser({
-			login: userData.login,
-			password: passwordHash,
-			email: userData.email,
-			roles: [UserRoles.admin],
-		});
-		this.logger.warn(`Admin user created with login 'bilbo' and password 'gandalf'`);
+
+		let password = process.env["ADMIN_PASSWORD"];
+		let generated = false;
+		if (!password) {
+			if (StaticConfig.production) {
+				throw new Error("Set ADMIN_PASSWORD when creating an admin user in production.");
+			}
+			password = this.hashService.generateRandomString(18);
+			generated = true;
+		}
+
+		const passwordHash = await this.hashService.generateHash(password);
+
+		const existing = await this.usersService.findUser({ login: login.toLocaleLowerCase() });
+		if (existing) {
+			await this.usersService.updateUser(existing.id, { password: passwordHash });
+			this.logger.log(`Updated password for existing admin user '${login}'.`);
+		} else {
+			await this.usersService.createUser({
+				login,
+				email,
+				password: passwordHash,
+				roles: [UserRoles.admin],
+			});
+			this.logger.log(`Admin user '${login}' created.`);
+		}
+
+		if (generated) this.logger.warn(`Generated password for '${login}': ${password}`);
 	}
 }


### PR DESCRIPTION


Security / access control:
- Enforce authorization on previously unauthenticated list endpoints: GET /events, /albums, /photos and /albums/:id/photos now require the relevant permission (were returning all data, incl. drafts, to anyone).
- Load event.attendees in getEventAttendee so leader-ownership checks (isMyEvent) actually work for attendee edit/delete instead of always denying.
- members-export: authorize before querying; use the export permission.
- groups: enforce list permission; persist the validated DTO, not raw req.body.
- Insurance-card upload: restrict to pdf/jpg/jpeg/png and send X-Content-Type-Options: nosniff to prevent stored-XSS via svg/html.

Auth:
- Require a strong JWT_SECRET in production (no insecure "secret" fallback).
- Login-by-link: generate the code with a CSPRNG, set a real 30-minute expiry (was set to "now", so links were always expired), invalidate the code single-use, and stop logging it.
- create-admin CLI: take credentials from env, no hardcoded bilbo/gandalf.

Correctness / compatibility:
- Multer now uses in-memory storage so photo and insurance-card handlers (which read file.buffer) work; disk-based handlers set their own dest.
- getEvents populates event.leaders and returns the columns the event cards/exports render (were blank in list views).
- Fix DB port config (read DB_PORT, not parseInt(DB_HOST)).
- sharp: cap input pixels (decompression-bomb guard) and drop EXIF/GPS from generated image variants.

Public API for the bosan.cz website:
- Implement the unauthenticated public API (program, gallery, recent, album, album preview, public photo images) returning the legacy response shape the website expects, advertised on the API root _links. Only published events/albums are exposed. Registration PDF and album ZIP download are stubbed (501) pending follow-up decisions.
- Add an explicit CORS allow-list for the public site origins.


Claude-Session: https://claude.ai/code/session_01SQqv3uYuHMETpBaaZYvhGD

# Změny

 - 

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že …

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)