### PR TITLE
Add camera capture for insurance card photos

### DIFF
--- a/frontend/src/app/features/members/components/card-insurance-card/card-insurance-card.component.html
+++ b/frontend/src/app/features/members/components/card-insurance-card/card-insurance-card.component.html
@@ -26,9 +26,11 @@
 			class="upload"
 			#dropzone
 			>
-				<ion-button fill="clear" color="primary" (click)="fileInput.click()">Nahrát ze souboru </ion-button>
-				
+				<ion-button fill="clear" color="primary" (click)="fileInput.click()">Nahrát ze souboru</ion-button>
 
+				@if (isCameraCapable) {
+					<ion-button fill="clear" color="primary" (click)="captureFromCamera()">Vyfotit kartičku</ion-button>
+				}
 			</div>
 		}
 

--- a/frontend/src/app/features/members/components/card-insurance-card/card-insurance-card.component.ts
+++ b/frontend/src/app/features/members/components/card-insurance-card/card-insurance-card.component.ts
@@ -9,6 +9,7 @@ import { SDK } from "src/sdk";
 import { CardContentComponent } from "../../../../shared/components/card-content/card-content.component";
 import { CardFooterComponent } from "../../../../shared/components/card-footer/card-footer.component";
 import { CardComponent } from "../../../../shared/components/card/card.component";
+import { InsuranceCardCameraModalComponent } from "../insurance-card-camera-modal/insurance-card-camera-modal.component";
 
 @Component({
 	selector: "bo-card-insurance-card",
@@ -121,6 +122,17 @@ export class CardInsuranceCardComponent implements OnDestroy {
 		const file = fileInput.files?.[0];
 		if (file) await this.uploadCard(file);
 		fileInput.value = "";
+	}
+
+	/**
+	 * Opens the camera modal, lets the user frame and photograph the card, then
+	 * uploads the cropped image through the same path as a file upload.
+	 */
+	async captureFromCamera() {
+		const file = await this.modalService.componentModal(InsuranceCardCameraModalComponent, undefined, {
+			cssClass: "insurance-card-camera",
+		});
+		if (file) await this.uploadCard(file);
 	}
 
 	private async uploadCard(file: File) {

--- a/frontend/src/app/features/members/components/insurance-card-camera-modal/insurance-card-camera-modal.component.html
+++ b/frontend/src/app/features/members/components/insurance-card-camera-modal/insurance-card-camera-modal.component.html
@@ -1,0 +1,81 @@
+<bo-modal-layout>
+	<h4 slot="title">Vyfotit kartičku pojištěnce</h4>
+
+	<div class="camera-stage" [style.aspect-ratio]="cardAspectRatio">
+		<!-- Live camera preview. Kept in the DOM (hidden) during preview so the -->
+		<!-- video element and its ref stay available for a quick retake. -->
+		<video #video class="feed" [class.hidden]="state() !== 'live'" playsinline muted></video>
+
+		@if (state() === "live") {
+			<!-- Card-shaped guide with corner brackets to line the card up against. -->
+			<div class="overlay">
+				<div #frame class="guide" [style.aspect-ratio]="cardAspectRatio">
+					<span class="corner top-left"></span>
+					<span class="corner top-right"></span>
+					<span class="corner bottom-left"></span>
+					<span class="corner bottom-right"></span>
+				</div>
+				<p class="hint">Umístěte kartičku do rámečku a vyplňte co největší plochu</p>
+			</div>
+		}
+
+		@if (state() === "initializing") {
+			<div class="status">
+				<ion-spinner></ion-spinner>
+				<p>Spouštím kameru…</p>
+			</div>
+		}
+
+		@if (state() === "error") {
+			<div class="status error">
+				<p>{{ errorMessage() }}</p>
+			</div>
+		}
+
+		@if (state() === "preview" && previewUrl()) {
+			<img class="feed" [src]="previewUrl()!" alt="Náhled vyfocené kartičky" />
+		}
+
+		@if (state() === "live" && torchAvailable()) {
+			<ion-button
+				class="torch"
+				fill="clear"
+				shape="round"
+				(click)="toggleTorch()"
+				[attr.aria-label]="torchOn() ? 'Vypnout svítilnu' : 'Zapnout svítilnu'"
+			>
+				<ion-icon slot="icon-only" [name]="torchOn() ? 'flash-outline' : 'flash-off-outline'"></ion-icon>
+			</ion-button>
+		}
+	</div>
+
+	<p class="tips">
+		Tipy pro čitelnou fotku: dobré osvětlení bez odlesků, kartička na kontrastním podkladu a rovná, nerozmazaná
+		fotka.
+	</p>
+
+	<ion-buttons slot="buttons">
+		@switch (state()) {
+			@case ("preview") {
+				<ion-button (click)="retake()" color="secondary">
+					<ion-icon slot="start" name="refresh-outline"></ion-icon>
+					Znovu
+				</ion-button>
+				<ion-button (click)="confirm()" color="primary">
+					<ion-icon slot="start" name="checkmark-outline"></ion-icon>
+					Použít
+				</ion-button>
+			}
+			@case ("error") {
+				<ion-button (click)="close.emit()" color="secondary">Zavřít</ion-button>
+			}
+			@default {
+				<ion-button (click)="close.emit()" color="secondary">Zrušit</ion-button>
+				<ion-button (click)="capture()" color="primary" [disabled]="state() !== 'live'">
+					<ion-icon slot="start" name="camera-outline"></ion-icon>
+					Vyfotit
+				</ion-button>
+			}
+		}
+	</ion-buttons>
+</bo-modal-layout>

--- a/frontend/src/app/features/members/components/insurance-card-camera-modal/insurance-card-camera-modal.component.scss
+++ b/frontend/src/app/features/members/components/insurance-card-camera-modal/insurance-card-camera-modal.component.scss
@@ -1,0 +1,132 @@
+:host {
+	display: block;
+}
+
+.camera-stage {
+	position: relative;
+	width: min(80vw, 640px);
+	max-height: 70vh;
+	margin: 0 auto;
+	background: #000;
+	border-radius: var(--bo-radius-card);
+	overflow: hidden;
+}
+
+.feed {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.hidden {
+	visibility: hidden;
+}
+
+.overlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	pointer-events: none;
+}
+
+.guide {
+	position: relative;
+	width: 82%;
+	max-height: 78%;
+	// Darken everything outside the card frame to draw the eye to it.
+	box-shadow: 0 0 0 1000px rgba(0, 0, 0, 0.45);
+	border-radius: 10px;
+	outline: 2px dashed rgba(255, 255, 255, 0.85);
+	outline-offset: -2px;
+}
+
+.corner {
+	position: absolute;
+	width: 22px;
+	height: 22px;
+	border: 3px solid #fff;
+}
+
+.corner.top-left {
+	top: -2px;
+	left: -2px;
+	border-right: none;
+	border-bottom: none;
+	border-top-left-radius: 10px;
+}
+
+.corner.top-right {
+	top: -2px;
+	right: -2px;
+	border-left: none;
+	border-bottom: none;
+	border-top-right-radius: 10px;
+}
+
+.corner.bottom-left {
+	bottom: -2px;
+	left: -2px;
+	border-right: none;
+	border-top: none;
+	border-bottom-left-radius: 10px;
+}
+
+.corner.bottom-right {
+	bottom: -2px;
+	right: -2px;
+	border-left: none;
+	border-top: none;
+	border-bottom-right-radius: 10px;
+}
+
+.hint {
+	position: absolute;
+	bottom: 12px;
+	left: 12px;
+	right: 12px;
+	margin: 0;
+	text-align: center;
+	color: #fff;
+	font-size: 0.85em;
+	text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+
+.status {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 0.75em;
+	color: #fff;
+	text-align: center;
+	padding: 1em;
+}
+
+.status.error p {
+	max-width: 32ch;
+}
+
+.torch {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	--color: #fff;
+	--background: rgba(0, 0, 0, 0.4);
+	font-size: 1.3em;
+}
+
+.tips {
+	max-width: min(80vw, 640px);
+	margin: 1em auto 0;
+	color: var(--bo-muted, #666);
+	font-size: 0.8em;
+	text-align: center;
+}

--- a/frontend/src/app/features/members/components/insurance-card-camera-modal/insurance-card-camera-modal.component.ts
+++ b/frontend/src/app/features/members/components/insurance-card-camera-modal/insurance-card-camera-modal.component.ts
@@ -1,0 +1,192 @@
+import { AfterViewInit, Component, ElementRef, OnDestroy, signal, viewChild } from "@angular/core";
+import { IonButton, IonButtons, IonIcon, IonSpinner, ModalController } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import { cameraOutline, checkmarkOutline, flashOffOutline, flashOutline, refreshOutline } from "ionicons/icons";
+import { InputModalComponent } from "src/app/core/services/modal.service";
+import { ModalLayoutComponent } from "src/app/shared/components/modal-layout/modal-layout.component";
+
+/**
+ * Aspect ratio of an ID-1 card (bank / insurance card): 85.6mm × 53.98mm ≈ 1.586.
+ * The on-screen guide frame and the captured crop both use this ratio so that the
+ * photo matches exactly what the user framed.
+ */
+const CARD_ASPECT_RATIO = 85.6 / 53.98;
+
+/** Longest edge of the produced image, keeps the upload small while staying sharp. */
+const OUTPUT_MAX_WIDTH = 1600;
+
+type CaptureState = "initializing" | "live" | "preview" | "error";
+
+@Component({
+	selector: "bo-insurance-card-camera-modal",
+	templateUrl: "./insurance-card-camera-modal.component.html",
+	styleUrls: ["./insurance-card-camera-modal.component.scss"],
+
+	imports: [ModalLayoutComponent, IonButton, IonButtons, IonIcon, IonSpinner],
+})
+export class InsuranceCardCameraModalComponent extends InputModalComponent<File> implements AfterViewInit, OnDestroy {
+	private video = viewChild<ElementRef<HTMLVideoElement>>("video");
+	private frame = viewChild<ElementRef<HTMLDivElement>>("frame");
+
+	readonly cardAspectRatio = CARD_ASPECT_RATIO;
+
+	state = signal<CaptureState>("initializing");
+	errorMessage = signal<string>("");
+
+	torchAvailable = signal(false);
+	torchOn = signal(false);
+
+	/** Data URL of the freshly cropped photo, shown in the preview step. */
+	previewUrl = signal<string | null>(null);
+
+	private stream: MediaStream | null = null;
+	/** The cropped photo, produced on capture and uploaded when confirmed. */
+	private capturedFile: File | null = null;
+
+	constructor(modalController: ModalController) {
+		super(modalController);
+		addIcons({ cameraOutline, checkmarkOutline, refreshOutline, flashOutline, flashOffOutline });
+	}
+
+	async ngAfterViewInit() {
+		await this.startCamera();
+	}
+
+	ngOnDestroy() {
+		this.stopCamera();
+	}
+
+	private async startCamera() {
+		this.state.set("initializing");
+
+		if (!navigator.mediaDevices?.getUserMedia) {
+			this.fail("Tento prohlížeč nepodporuje přístup ke kameře.");
+			return;
+		}
+
+		try {
+			// Prefer the rear camera at a high resolution – best for reading small print off a card.
+			this.stream = await navigator.mediaDevices.getUserMedia({
+				video: {
+					facingMode: { ideal: "environment" },
+					width: { ideal: 1920 },
+					height: { ideal: 1080 },
+				},
+				audio: false,
+			});
+
+			const videoEl = this.video()?.nativeElement;
+			if (!videoEl) {
+				this.fail("Nepodařilo se zobrazit náhled kamery.");
+				return;
+			}
+
+			videoEl.srcObject = this.stream;
+			await videoEl.play();
+
+			this.detectTorch();
+			this.state.set("live");
+		} catch (e) {
+			this.fail("Nepodařilo se získat přístup ke kameře. Zkontrolujte oprávnění a zkuste to znovu.");
+		}
+	}
+
+	private detectTorch() {
+		const track = this.stream?.getVideoTracks()[0];
+		const capabilities = track?.getCapabilities?.() as (MediaTrackCapabilities & { torch?: boolean }) | undefined;
+		this.torchAvailable.set(!!capabilities?.torch);
+	}
+
+	async toggleTorch() {
+		const track = this.stream?.getVideoTracks()[0];
+		if (!track) return;
+
+		const next = !this.torchOn();
+		try {
+			await track.applyConstraints({ advanced: [{ torch: next } as MediaTrackConstraintSet] });
+			this.torchOn.set(next);
+		} catch {
+			// Some devices report torch support but reject the constraint – just hide the option.
+			this.torchAvailable.set(false);
+		}
+	}
+
+	private stopCamera() {
+		this.stream?.getTracks().forEach((track) => track.stop());
+		this.stream = null;
+		this.torchOn.set(false);
+	}
+
+	private fail(message: string) {
+		this.errorMessage.set(message);
+		this.state.set("error");
+	}
+
+	/**
+	 * Grabs the current video frame and crops it to the region covered by the guide
+	 * frame. The video is rendered with `object-fit: cover`, so the mapping between
+	 * the displayed frame and the intrinsic camera pixels has to account for the
+	 * scaling and centering the browser applies.
+	 */
+	capture() {
+		const videoEl = this.video()?.nativeElement;
+		const frameEl = this.frame()?.nativeElement;
+		if (!videoEl || !frameEl) return;
+
+		const intrinsicW = videoEl.videoWidth;
+		const intrinsicH = videoEl.videoHeight;
+		if (!intrinsicW || !intrinsicH) return;
+
+		const videoRect = videoEl.getBoundingClientRect();
+		const frameRect = frameEl.getBoundingClientRect();
+
+		// object-fit: cover scales the video up until it fills the box, cropping the overflow.
+		const scale = Math.max(videoRect.width / intrinsicW, videoRect.height / intrinsicH);
+		const visibleW = videoRect.width / scale;
+		const visibleH = videoRect.height / scale;
+		const offsetX = (intrinsicW - visibleW) / 2;
+		const offsetY = (intrinsicH - visibleH) / 2;
+
+		// Guide frame position relative to the video element, mapped into intrinsic pixels.
+		const cropX = offsetX + (frameRect.left - videoRect.left) / scale;
+		const cropY = offsetY + (frameRect.top - videoRect.top) / scale;
+		const cropW = frameRect.width / scale;
+		const cropH = frameRect.height / scale;
+
+		const outputW = Math.min(OUTPUT_MAX_WIDTH, Math.round(cropW));
+		const outputH = Math.round(outputW / (cropW / cropH));
+
+		const canvas = document.createElement("canvas");
+		canvas.width = outputW;
+		canvas.height = outputH;
+
+		const ctx = canvas.getContext("2d");
+		if (!ctx) return;
+
+		ctx.drawImage(videoEl, cropX, cropY, cropW, cropH, 0, 0, outputW, outputH);
+
+		canvas.toBlob(
+			(blob) => {
+				if (!blob) return;
+				this.capturedFile = new File([blob], "insurance-card.jpg", { type: "image/jpeg" });
+				this.previewUrl.set(canvas.toDataURL("image/jpeg"));
+				this.state.set("preview");
+				this.stopCamera();
+			},
+			"image/jpeg",
+			0.92,
+		);
+	}
+
+	/** Discard the captured photo and go back to the live camera. */
+	async retake() {
+		this.capturedFile = null;
+		this.previewUrl.set(null);
+		await this.startCamera();
+	}
+
+	/** Confirm the captured photo – hands the file back to the caller for upload. */
+	confirm() {
+		if (this.capturedFile) this.submit.emit(this.capturedFile);
+	}
+}


### PR DESCRIPTION
# Změny

- Nová komponenta `InsuranceCardCameraModalComponent` pro fotografování pojistné kartičky přímo z aplikace
- Modální dialog s živým náhledem z kamery, průvodcem zarovnání kartičky a možností zapnout svítilnu
- Automatické oříznutí fotografie podle poměru stran ID-1 kartičky (1.586) a optimalizace velikosti výstupu
- Tlačítko "Vyfotit kartičku" v komponentě `CardInsuranceCardComponent` (viditelné pouze na zařízeních s kamerou)
- Fotografovaná kartička se nahraje stejným způsobem jako soubor vybraný z disku

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `�Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
   - Na stránce s pojistnou kartičkou se zobrazuje tlačítko "Vyfotit kartičku" (na mobilních zařízeních s kamerou)
   - Po kliknutí se otevře modální dialog s náhledem z kamery
   - Kartička se zobrazuje v průvodci zarovnání (dashed outline s rohovými závorkami)
   - Tlačítko svítilny se zobrazuje pouze pokud zařízení svítilnu podporuje
   - Po kliknutí "Vyfotit" se zobrazí náhled fotografované kartičky
   - Tlačítka "Znovu" a "Použít" fungují správně
   - Fotografovaná kartička se nahraje a zobrazí se v aplikaci

https://claude.ai/code/session_01QANPmR3M7Nu6oHbpwKZfhu