### PR TITLE
fix(events): show remove-attendee button for event leaders

### DIFF
--- a/backend/src/models/events/repositories/events.repository.ts
+++ b/backend/src/models/events/repositories/events.repository.ts
@@ -210,11 +210,17 @@ export class EventsRepository {
 	}
 
 	async getEventAttendees(id: number) {
-		return this.eventAttendeesRepository.find({
-			where: { eventId: id },
-			relations: { member: true, event: true },
-			withDeleted: true,
-		});
+		const q = this.eventAttendeesRepository
+			.createQueryBuilder("attendee")
+			.where("attendee.event_id = :id", { id })
+			.leftJoinAndSelect("attendee.member", "member")
+			.leftJoinAndSelect("attendee.event", "event")
+			// event.attendees is needed so isMyEvent(doc.event) works in the edit/delete permission checks and _links
+			.leftJoinAndSelect("event.attendees", "leaders", "leaders.type = :type", { type: "leader" })
+			.select(["attendee", "member", "event.id", "leaders"])
+			.withDeleted();
+
+		return q.getMany();
 	}
 
 	async getEventAttendee(eventId: number, memberId: number) {


### PR DESCRIPTION
# Změny

- Opraveno skrývání tlačítka pro odebrání účastníka akce (a změnu jeho typu) pro všechny ne-admin uživatele. Tlačítko i backendový DELETE endpoint už existovaly — chyba byla v tom, že endpoint `GET /api/events/:id/attendees` počítá per-item oprávnění v `_links` přes `isMyEvent(doc.event)`, které kontroluje `event.attendees`, ale dotaz `getEventAttendees()` načítal relaci `event` bez jejích attendees. Kontrola tak vždy selhala a `deleteEventAttendee`/`updateEventAttendee` linky se vracely s `allowed: false`, takže frontend tlačítko nevykreslil (admini mají výjimku, proto jim tlačítko fungovalo).
- Dotaz nyní načítá vedoucí akce stejným způsobem jako `getEventExpenses()` (kde mazání účtenek už funguje) — jen `event.id` + řádky vedoucích, aby odpověď zůstala malá.
- Ověřeno end-to-end proti lokální DB: před opravou vracel endpoint vedoucímu vlastní akce `allowed: false`, po opravě `true` pro jeho akce a `false` pro cizí; DELETE účastníka poté proběhl úspěšně.

Fixes #236

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Přihlas se jako **ne-admin** uživatel, který je vedoucím nějaké akce.
3. Otevři detail této akce → záložka s účastníky.
4. Zkontroluj, že u každého vedoucího i účastníka je ikona koše (stejný styl jako u mazání účtenky v hospodaření) a že odebrání účastníka funguje.
5. Zkontroluj, že u akce, kde uživatel **není** vedoucím, se tlačítko nezobrazuje.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbz1TjbcAcRWzcEMM5ERBo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbz1TjbcAcRWzcEMM5ERBo)_