### PR TITLE
Fix "Moje akce" and "Volné akce" home card filters and sorting

### DIFF
--- a/frontend/src/app/features/home/components/home-card-my-events/home-card-my-events.component.html
+++ b/frontend/src/app/features/home/components/home-card-my-events/home-card-my-events.component.html
@@ -2,7 +2,7 @@
 	<bo-card>
 		<bo-card-header>
 			<bo-card-title> Moje akce </bo-card-title>
-			<bo-card-open-button routerLink="/akce" [queryParams]="{ my: true }"></bo-card-open-button>
+			<bo-card-open-button routerLink="/akce" [queryParams]="{ leaders: 'my' }"></bo-card-open-button>
 		</bo-card-header>
 
 		<bo-card-content>

--- a/frontend/src/app/features/home/components/home-card-noleader-events/home-card-noleader-events.component.html
+++ b/frontend/src/app/features/home/components/home-card-noleader-events/home-card-noleader-events.component.html
@@ -1,7 +1,7 @@
 <bo-card>
 	<bo-card-header>
 		<bo-card-title> Volné akce </bo-card-title>
-		<bo-card-open-button routerLink="/akce" [queryParams]="{ noleader: true }"></bo-card-open-button>
+		<bo-card-open-button routerLink="/akce" [queryParams]="{ leaders: 'noleader' }"></bo-card-open-button>
 	</bo-card-header>
 	<bo-card-content>
 		@if (events().length) {
@@ -24,7 +24,7 @@
 				<bo-button
 					color="light"
 					routerLink="/akce"
-					[queryParams]="{ noleader: true }"
+					[queryParams]="{ leaders: 'noleader' }"
 					class="m-0 mt-2 mb-3 text-center"
 					>Zobrazit vše</bo-button
 				>

--- a/frontend/src/app/features/home/components/home-card-noleader-events/home-card-noleader-events.component.ts
+++ b/frontend/src/app/features/home/components/home-card-noleader-events/home-card-noleader-events.component.ts
@@ -2,6 +2,7 @@ import { DatePipe } from "@angular/common";
 import { Component, OnInit, signal } from "@angular/core";
 import { RouterLink } from "@angular/router";
 import { IonItem, IonLabel, IonList } from "@ionic/angular/standalone";
+import { DateTime } from "luxon";
 import { ApiService } from "src/app/core/services/api.service";
 import { ButtonComponent } from "src/app/shared/components/button/button.component";
 import { CardContentComponent } from "src/app/shared/components/card-content/card-content.component";
@@ -41,8 +42,12 @@ export class HomeCardNoleaderEventsComponent implements OnInit {
 	}
 
 	async loadNoLeaderEvents() {
-		// TODO: list only noleader events
-		const events = await this.api.EventsApi.listEvents({ limit: 6, noleader: true }).then((res) => res.data);
+		// the API returns events ordered by dateFrom descending, so ask for all upcoming
+		// noleader events and sort them nearest-first here
+		const events = await this.api.EventsApi.listEvents({ noleader: true, dateFrom: DateTime.now().toISODate() }).then(
+			(res) => res.data,
+		);
+		events.sort((a, b) => a.dateFrom.localeCompare(b.dateFrom));
 		this.hasMore.set(events.length > 5);
 		this.events.set(events.slice(0, 5));
 	}


### PR DESCRIPTION
# Změny

 - Tlačítko „→" na kartě **Moje akce** na hlavní stránce nyní otevírá přehled akcí s rovnou aplikovaným filtrem „Moje akce" (odkaz nově používá `?leaders=my` místo ignorovaného `?my=true`).
 - Karta **Volné akce** nyní zobrazuje nadcházející akce bez vedoucího seřazené od nejbližší (dříve zobrazovala akce nejdále v budoucnosti jako první).
 - Tlačítka „→" a „Zobrazit vše" na kartě **Volné akce** otevírají přehled akcí s aplikovaným filtrem „Akce bez vedoucího" (`?leaders=noleader` místo ignorovaného `?noleader=true`).

Fixes #237
Fixes #235

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že po kliknutí na „→" na kartě „Moje akce" se otevře přehled akcí s URL `?leaders=my`, ve filtru „Vedoucí" je vybráno „Moje akce" a seznam obsahuje jen tvoje akce.
3. Zkontroluj, že karta „Volné akce" zobrazuje nadcházející akce bez vedoucího od nejbližší po nejvzdálenější.
4. Zkontroluj, že po kliknutí na „→" nebo „Zobrazit vše" na kartě „Volné akce" se otevře přehled akcí s URL `?leaders=noleader`, ve filtru „Vedoucí" je vybráno „Akce bez vedoucího" a seznam obsahuje jen akce bez vedoucího.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zN6FZCUZZ4YTteGVq7U86