### PR TITLE
Fix attendee removal to handle both leaders and attendees

### DIFF
--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
@@ -141,9 +141,13 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 			if (!confirmation) return;
 		}
 
+		// leaders and attendees are held in separate signals; update the one that actually holds this item
+		const list = attendee.type === "leader" ? this.leaders : this.attendees;
+		const previous = list();
+
 		try {
 			// optimistic update
-			this.attendees.set(this.attendees()?.filter((item) => item.memberId !== attendee.memberId));
+			list.set(previous?.filter((item) => item.memberId !== attendee.memberId));
 
 			await this.api.EventsApi.deleteEventAttendee(event.id, attendee.memberId);
 
@@ -153,7 +157,7 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 			this.change.emit();
 		} catch (e) {
 			this.toastService.toast("Nepodařilo se odebrat účastníka.");
-			this.attendees.set([...(this.attendees() ?? []), attendee]); // rollback
+			list.set(previous); // rollback
 		}
 	}
 


### PR DESCRIPTION
# Změny

- Opravena funkce pro odebrání účastníka tak, aby správně pracovala s oběma typy: vedoucími a účastníky
- Vedoucí a účastníci jsou uloženi v oddělených signálech, nyní se aktualizuje správný seznam na základě typu
- Zjednodušen rollback při chybě - místo rekonstrukce seznamu se obnoví původní stav

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
   - Odebrání vedoucího z akce funguje správně
   - Odebrání účastníka z akce funguje správně
   - Při chybě API se seznam správně obnoví do původního stavu

Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

https://claude.ai/code/session_01UH1gxNtAn2c98HAWMAsZ2p