### PR TITLE
Add empty state messages to global search results

### DIFF
--- a/frontend/src/app/core/components/global-search/global-search.component.html
+++ b/frontend/src/app/core/components/global-search/global-search.component.html
@@ -33,6 +33,10 @@
 								</p>
 							</ion-label>
 						</ion-item>
+					} @empty {
+						<ion-item lines="none">
+							<ion-label class="search-empty">Žádné výsledky</ion-label>
+						</ion-item>
 					}
 				}
 			</ion-list>
@@ -59,6 +63,10 @@
 								</p>
 							</ion-label>
 						</ion-item>
+					} @empty {
+						<ion-item lines="none">
+							<ion-label class="search-empty">Žádné výsledky</ion-label>
+						</ion-item>
 					}
 				}
 			</ion-list>
@@ -81,6 +89,10 @@
 									<p>{{ album.dateFrom | date: "d. M. yyyy" }}</p>
 								}
 							</ion-label>
+						</ion-item>
+					} @empty {
+						<ion-item lines="none">
+							<ion-label class="search-empty">Žádné výsledky</ion-label>
 						</ion-item>
 					}
 				}


### PR DESCRIPTION
# Změny

- Přidány zprávy "Žádné výsledky" pro prázdné výsledky vyhledávání v globálním vyhledávání
- Implementováno pro tři sekce: členy, akce a alba
- Použita Angular `@empty` direktiva pro zobrazení fallback UI když nejsou dostupné výsledky

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
   - Otevři globální vyhledávání
   - Vyhledej text, který nevrátí žádné výsledky (např. "xyzabc123")
   - Ověř, že se zobrazí zpráva "Žádné výsledky" v sekcích Členů, Akcí a Alb
   - Vyhledej existující položku a ověř, že se zpráva "Žádné výsledky" nezobrazuje

Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

https://claude.ai/code/session_017u5H62pFFMd6gGgMLhirY8