### PR TITLE
Add active member filter to members list

### DIFF
--- a/backend/src/api/members/dto/member.dto.ts
+++ b/backend/src/api/members/dto/member.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiPropertyOptional, OmitType, PartialType } from "@nestjs
 import { Type } from "class-transformer";
 import { IsArray, IsEnum, IsNumber, IsOptional, IsString, ValidateNested } from "class-validator";
 import { PaginationQuery } from "src/api/helpers/dto";
-import { EnsureArray } from "src/helpers/validation";
+import { EnsureArray, EnsureBoolean } from "src/helpers/validation";
 import { MemberAchievement } from "src/models/members/entities/member-achievements.entity";
 import { MemberContact } from "src/models/members/entities/member-contact.entity";
 import {
@@ -104,4 +104,6 @@ export class MembersListQuery extends PaginationQuery {
 	@IsNumber({}, { each: true })
 	@IsOptional()
 	age?: number[];
+
+	@EnsureBoolean() @IsOptional() active?: boolean;
 }

--- a/backend/src/models/members/repositories/members.repository.ts
+++ b/backend/src/models/members/repositories/members.repository.ts
@@ -11,6 +11,7 @@ export interface GetMembersOptions extends PaginationOptions {
 	roles?: string[];
 	membership?: string[];
 	age?: number[];
+	active?: boolean;
 }
 
 @Injectable()
@@ -48,6 +49,8 @@ export class MembersRepository {
 				"members.birthday IS NOT NULL AND DATE_PART('year', AGE(CURRENT_DATE, members.birthday))::int IN (:...ages)",
 				{ ages: options.age },
 			);
+
+		if (options.active !== undefined) q.andWhere("members.active = :active", { active: options.active });
 
 		return q.getMany();
 	}

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.html
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.html
@@ -119,6 +119,15 @@
 							</ion-checkbox>
 						</ion-item>
 					}
+					<ion-item lines="none">
+						<ion-checkbox
+							justify="space-between"
+							[ngModel]="(filter['active'] || 'active') === 'all'"
+							(ngModelChange)="setFilterParam('active', $event ? 'all' : null)"
+						>
+							Zobrazit i neaktivní
+						</ion-checkbox>
+					</ion-item>
 				</ion-content>
 			</ng-template>
 			</ion-popover>
@@ -237,9 +246,9 @@
 							<tr
 								class="clickable"
 								[routerLink]="'' + member.id"
-								[class.member-inactive]="member.membership === 'neclen'"
+								[class.member-inactive]="!member.active || member.membership === 'neclen'"
 								[class.member-paused]="member.membership === 'pozastaveno'"
-							>	
+							>
 								@if (viewSelections().nickname){
 									<td>{{ member.nickname }}</td>
 								}
@@ -291,6 +300,18 @@
 				</tbody>
 			</admin-table>
 		}
+	}
+
+	@if (members()?.length) {
+		<p class="ion-padding members-active-toggle">
+			@if ((filter['active'] || 'active') !== 'all') {
+				Zobrazeni pouze aktivní členové.
+				<a class="clickable" (click)="setFilterParam('active', 'all')">Zobrazit i neaktivní</a>
+			} @else {
+				Zobrazeni všichni členové.
+				<a class="clickable" (click)="setFilterParam('active', null)">Skrýt neaktivní</a>
+			}
+		</p>
 	}
 
 	@if (!members()) {

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.scss
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.scss
@@ -2,11 +2,17 @@
 	cursor: pointer;
 }
 
-tr.mmber-inactive {
+tr.member-inactive {
 	text-decoration: line-through;
-}
-tr.mmber-paused {
 	color: var(--bo-muted);
+}
+tr.member-paused {
+	color: var(--bo-muted);
+}
+
+.members-active-toggle {
+	color: var(--bo-muted);
+	font-size: 0.875rem;
 }
 
 td ion-badge {

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.ts
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.ts
@@ -133,6 +133,7 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 				parseInt(group, 10),
 			),
 			age: this.normalizeFilterValueToArray((this.filter as any)["age"]).map((age) => parseInt(age, 10)),
+			active: (((this.filter as any)["active"] as string) || "active") === "all" ? undefined : true,
 		};
 
 		this.api.MembersApi.exportMembersXlsx(params, { responseType: "blob" }).then((res) => {
@@ -209,6 +210,8 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 			age: this.normalizeFilterValueToArray(filter["age"]).map((age) => parseInt(age, 10)),
 			limit: this.pageSize,
 			groups: this.normalizeFilterValueToArray(filter["groups"]).map((group) => parseInt(group, 10)),
+			// default: active only; "all" reveals inactive members too
+			active: ((filter["active"] as string) || "active") === "all" ? undefined : true,
 		};
 
 		var members = await this.api.MembersApi.listMembers(params).then((res) => res.data);

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -6783,11 +6783,19 @@ export namespace SDK {
     
         //age
         /**
-         * 
+         *
          * @type {Array<number>}
          * @memberof MembersApiExportMembersXlsx
          */
         age?: Array<number>
+
+        //active
+        /**
+         *
+         * @type {boolean}
+         * @memberof MembersApiExportMembersXlsx
+         */
+        active?: boolean
     }
     
     
@@ -6911,11 +6919,19 @@ export namespace SDK {
     
         //age
         /**
-         * 
+         *
          * @type {Array<number>}
          * @memberof MembersApiListMembers
          */
         age?: Array<number>
+
+        //active
+        /**
+         *
+         * @type {boolean}
+         * @memberof MembersApiListMembers
+         */
+        active?: boolean
     }
     
     
@@ -7316,6 +7332,10 @@ export namespace SDK {
                 requestQueryParameter['age'] = queryParams.age;
             }
     
+            if (queryParams.active !== undefined) {
+                requestQueryParameter['active'] = queryParams.active;
+            }
+    
     
     
             setSearchParams(requestUrlObj, requestQueryParameter);
@@ -7594,6 +7614,10 @@ export namespace SDK {
     
             if (queryParams.age) {
                 requestQueryParameter['age'] = queryParams.age;
+            }
+    
+            if (queryParams.active !== undefined) {
+                requestQueryParameter['active'] = queryParams.active;
             }
     
     


### PR DESCRIPTION
# Změny

- Přidán filtr `active` do API endpointů `listMembers` a `exportMembersXlsx`
- Implementován backend filtr v `MembersRepository` pro filtrování podle stavu aktivnosti
- Přidán UI prvek pro přepínání zobrazení neaktivních členů v seznamu
- Přidán informativní text zobrazující aktuální stav filtru
- Opraveny CSS třídy a styly pro neaktivní a pozastavené členy
- Výchozí chování: zobrazují se pouze aktivní členové, lze přepnout na zobrazení všech

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že …
   - V seznamu členů se zobrazují pouze aktivní členové
   - V popover filtru se zobrazuje nová checkbox "Zobrazit i neaktivní"
   - Pod seznamem se zobrazuje text "Zobrazeni pouze aktivní členové" s odkazem na zobrazení neaktivních
   - Po kliknutí na checkbox/odkaz se zobrazí i neaktivní členové a text se změní
   - Neaktivní členové jsou zobrazeni se škrtnutým textem a ztlumenou barvou
   - Export do Excelu respektuje aktuální filtr aktivnosti

https://claude.ai/code/session_01NZq6X9yACYw4BwqE7doF3C