### PR TITLE
Support legacy photo file paths for imported Mongo photos

### DIFF
--- a/backend/src/api/albums/controllers/photos.controller.ts
+++ b/backend/src/api/albums/controllers/photos.controller.ts
@@ -123,7 +123,7 @@ export class PhotosController {
 		PhotoReadFilePermission.canOrThrow(req, photo);
 
 		const ext = extname(photo.name);
-		const path = this.photosFiles.getImagePath(photo.albumId, photo.id, size, ext);
+		const path = this.photosFiles.getPhotoImagePath(photo, size);
 
 		try {
 			await this.photosFiles.fileExists(path);

--- a/backend/src/api/public/controllers/public.controller.ts
+++ b/backend/src/api/public/controllers/public.controller.ts
@@ -131,7 +131,7 @@ export class PublicController {
 		if (!album || album.status !== AlbumStatus.public) throw new NotFoundException();
 
 		const ext = extname(photo.name);
-		const path = this.photosFiles.getImagePath(photo.albumId, photo.id, size, ext);
+		const path = this.photosFiles.getPhotoImagePath(photo, size);
 
 		try {
 			await this.photosFiles.fileExists(path);

--- a/backend/src/api/public/services/public.service.ts
+++ b/backend/src/api/public/services/public.service.ts
@@ -75,7 +75,7 @@ export class PublicService {
 
 		for (const photo of photos) {
 			const ext = extname(photo.name);
-			const path = this.photosFiles.getImagePath(photo.albumId, photo.id, PhotoSizes.original, ext);
+			const path = this.photosFiles.getPhotoImagePath(photo, PhotoSizes.original);
 
 			try {
 				await this.photosFiles.fileExists(path);

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -94,16 +94,12 @@ const fs = {
 	dataDir,
 	keysDir: path.resolve(process.env["KEYS_DIR"] ?? "../keys"),
 	photosDir: path.resolve(process.env["PHOTOS_DIR"] ?? path.join(dataDir, "photos")),
-	thumbnailsDir: path.resolve(process.env["THUMBNAILS_DIR"] ?? path.join(dataDir, "thumbnails")),
+	// Same directories the old server used ("photos" / "thumbs"). Photos imported from the
+	// old server keep their existing files there, keyed by Mongo ObjectId; new uploads are
+	// written alongside them keyed by numeric id (see PhotosFilesService).
+	thumbnailsDir: path.resolve(process.env["THUMBNAILS_DIR"] ?? path.join(dataDir, "thumbs")),
 	eventsDir: path.resolve(process.env["EVENTS_DIR"] ?? path.join(dataDir, "events")),
 	membersDir: path.resolve(process.env["MEMBERS_DIR"] ?? path.join(dataDir, "members")),
-	// Legacy on-disk photo storage from the old (Mongo) server. Those files (gigabytes of
-	// them) are left in place — `mongo-import` records each photo's original Mongo ObjectIds
-	// and the backend serves the files straight from here, keyed by ObjectId, instead of the
-	// numeric-id layout in photosDir / thumbnailsDir. Defaults mirror the old server's
-	// `data/photos` and `data/thumbs` directories.
-	legacyPhotosDir: path.resolve(process.env["LEGACY_PHOTOS_DIR"] ?? path.join(dataDir, "photos")),
-	legacyThumbsDir: path.resolve(process.env["LEGACY_THUMBS_DIR"] ?? path.join(dataDir, "thumbs")),
 };
 
 const photos = {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -97,6 +97,13 @@ const fs = {
 	thumbnailsDir: path.resolve(process.env["THUMBNAILS_DIR"] ?? path.join(dataDir, "thumbnails")),
 	eventsDir: path.resolve(process.env["EVENTS_DIR"] ?? path.join(dataDir, "events")),
 	membersDir: path.resolve(process.env["MEMBERS_DIR"] ?? path.join(dataDir, "members")),
+	// Legacy on-disk photo storage from the old (Mongo) server. Those files (gigabytes of
+	// them) are left in place — `mongo-import` records each photo's original Mongo ObjectIds
+	// and the backend serves the files straight from here, keyed by ObjectId, instead of the
+	// numeric-id layout in photosDir / thumbnailsDir. Defaults mirror the old server's
+	// `data/photos` and `data/thumbs` directories.
+	legacyPhotosDir: path.resolve(process.env["LEGACY_PHOTOS_DIR"] ?? path.join(dataDir, "photos")),
+	legacyThumbsDir: path.resolve(process.env["LEGACY_THUMBS_DIR"] ?? path.join(dataDir, "thumbs")),
 };
 
 const photos = {

--- a/backend/src/database/migrations/1784556523404-photos-legacy-src-ids.ts
+++ b/backend/src/database/migrations/1784556523404-photos-legacy-src-ids.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class photosLegacySrcIds1784556523404 implements MigrationInterface {
+	name = "photosLegacySrcIds1784556523404";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "photos" ADD "src_album_id" character varying`);
+		await queryRunner.query(`ALTER TABLE "photos" ADD "src_id" character varying`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "photos" DROP COLUMN "src_id"`);
+		await queryRunner.query(`ALTER TABLE "photos" DROP COLUMN "src_album_id"`);
+	}
+}

--- a/backend/src/models/albums/entities/photo.entity.ts
+++ b/backend/src/models/albums/entities/photo.entity.ts
@@ -34,4 +34,11 @@ export class Photo {
 	@Column({ type: "text", nullable: true }) caption!: string | null;
 	@Column({ type: "varchar", array: true, nullable: true }) tags!: string[] | null;
 	@Column({ type: "varchar", nullable: true }) bg!: string | null;
+
+	// Legacy Mongo ObjectIds of the album and photo, set only for photos imported from the
+	// old server (mongo-import). When present, the image files live in the legacy on-disk
+	// layout (keyed by these ObjectIds) rather than the numeric-id layout; see
+	// PhotosFilesService.getPhotoImagePath.
+	@Column({ type: "varchar", nullable: true }) srcAlbumId!: string | null;
+	@Column({ type: "varchar", nullable: true }) srcId!: string | null;
 }

--- a/backend/src/models/albums/repositories/photos.repository.ts
+++ b/backend/src/models/albums/repositories/photos.repository.ts
@@ -80,7 +80,7 @@ export class PhotosRepository {
 			await this.photosFiles.savePhotoFiles(albumId, photo.id, ext, file.buffer);
 		} catch (err) {
 			await this.repository.delete(photo.id);
-			await this.photosFiles.deletePhotoFiles(albumId, photo.id, ext);
+			await this.photosFiles.deletePhotoFiles(photo);
 			throw err;
 		}
 
@@ -106,7 +106,7 @@ export class PhotosRepository {
 		if (!photo) return;
 
 		await this.repository.delete(id);
-		await this.photosFiles.deletePhotoFiles(photo.albumId, photo.id, extname(photo.name));
+		await this.photosFiles.deletePhotoFiles(photo);
 	}
 
 	async deletePhotosByAlbum(albumId: Photo["albumId"]) {

--- a/backend/src/models/albums/services/photos-files.service.ts
+++ b/backend/src/models/albums/services/photos-files.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { join } from "path";
+import { extname, join } from "path";
 import { Config } from "src/config";
 import exifReader = require("exif-reader");
 import sharp = require("sharp");
 import { FilesService } from "src/models/files/services/files.service";
 import { PhotoSizes } from "src/api/albums/dto/photo.dto";
+import { Photo } from "../entities/photo.entity";
 
 // Cap decoded image size to guard against decompression-bomb uploads (roughly 24k x 24k).
 const MAX_INPUT_PIXELS = 24000 * 24000;
@@ -41,6 +42,26 @@ export class PhotosFilesService {
 			return join(this.config.fs.photosDir, String(albumId), `${photoId}${ext}`);
 		}
 		return join(this.config.fs.thumbnailsDir, String(albumId), `${photoId}_${size}${ext}`);
+	}
+
+	/**
+	 * Resolve the on-disk path for a photo entity, honoring the legacy layout for photos
+	 * imported from the old Mongo server. Those files were never moved (there are gigabytes
+	 * of them); they stay keyed by Mongo ObjectId in the legacy directories, whereas natively
+	 * uploaded photos use the numeric-id layout. The file extension is derived from the
+	 * photo's original name, exactly as the old server did.
+	 */
+	getPhotoImagePath(photo: Photo, size: PhotoSizes): string {
+		const ext = extname(photo.name);
+
+		if (photo.srcAlbumId && photo.srcId) {
+			if (size === PhotoSizes.original) {
+				return join(this.config.fs.legacyPhotosDir, photo.srcAlbumId, `${photo.srcId}${ext}`);
+			}
+			return join(this.config.fs.legacyThumbsDir, photo.srcAlbumId, `${photo.srcId}_${size}${ext}`);
+		}
+
+		return this.getImagePath(photo.albumId, photo.id, size, ext);
 	}
 
 	/** Read image dimensions, dominant background color and capture date from the buffer. */
@@ -80,13 +101,11 @@ export class PhotosFilesService {
 	}
 
 	/** Remove the original file and all resized variants from disk. Missing files are ignored. */
-	async deletePhotoFiles(albumId: number, photoId: number, ext: string): Promise<void> {
+	async deletePhotoFiles(photo: Photo): Promise<void> {
 		const sizes: PhotoSizes[] = [PhotoSizes.original, ...(Object.keys(this.config.photos.sizes) as PhotoSizes[])];
 
 		await Promise.all(
-			sizes.map((size) =>
-				this.files.deleteFile(this.getImagePath(albumId, photoId, size, ext)).catch(() => {}),
-			),
+			sizes.map((size) => this.files.deleteFile(this.getPhotoImagePath(photo, size)).catch(() => {})),
 		);
 	}
 

--- a/backend/src/models/albums/services/photos-files.service.ts
+++ b/backend/src/models/albums/services/photos-files.service.ts
@@ -45,23 +45,21 @@ export class PhotosFilesService {
 	}
 
 	/**
-	 * Resolve the on-disk path for a photo entity, honoring the legacy layout for photos
-	 * imported from the old Mongo server. Those files were never moved (there are gigabytes
-	 * of them); they stay keyed by Mongo ObjectId in the legacy directories, whereas natively
-	 * uploaded photos use the numeric-id layout. The file extension is derived from the
-	 * photo's original name, exactly as the old server did.
+	 * Resolve the on-disk path for a photo entity. Files live in the same directories the old
+	 * server used; photos imported from the old Mongo server keep their existing files, keyed
+	 * by the original Mongo ObjectIds (album folder + file name), while natively uploaded
+	 * photos are keyed by their numeric ids. The extension is derived from the photo's
+	 * original name, exactly as the old server did.
 	 */
 	getPhotoImagePath(photo: Photo, size: PhotoSizes): string {
 		const ext = extname(photo.name);
+		const albumDir = photo.srcAlbumId ?? String(photo.albumId);
+		const fileId = photo.srcId ?? String(photo.id);
 
-		if (photo.srcAlbumId && photo.srcId) {
-			if (size === PhotoSizes.original) {
-				return join(this.config.fs.legacyPhotosDir, photo.srcAlbumId, `${photo.srcId}${ext}`);
-			}
-			return join(this.config.fs.legacyThumbsDir, photo.srcAlbumId, `${photo.srcId}_${size}${ext}`);
+		if (size === PhotoSizes.original) {
+			return join(this.config.fs.photosDir, albumDir, `${fileId}${ext}`);
 		}
-
-		return this.getImagePath(photo.albumId, photo.id, size, ext);
+		return join(this.config.fs.thumbnailsDir, albumDir, `${fileId}_${size}${ext}`);
 	}
 
 	/** Read image dimensions, dominant background color and capture date from the buffer. */

--- a/backend/src/mongo-import/services/mongo-import.service.ts
+++ b/backend/src/mongo-import/services/mongo-import.service.ts
@@ -367,6 +367,10 @@ export class MongoImportService {
 				uploadedById: mongoPhoto.uploadedBy ? userIds[mongoPhoto.uploadedBy.toString()] : null,
 				width: mongoPhoto.sizes?.original.width ?? null,
 				height: mongoPhoto.sizes?.original.height ?? null,
+				// Keep the original Mongo ObjectIds so the backend can serve the existing image
+				// files straight from the legacy on-disk layout (they are not moved or copied).
+				srcAlbumId: mongoPhoto.album.toString(),
+				srcId: mongoPhoto._id.toString(),
 			};
 
 			await t.save(Photo, photoData);


### PR DESCRIPTION
# Změny

- Added `srcAlbumId` and `srcId` columns to the `Photo` entity to store original Mongo ObjectIds for imported photos
- Created migration to add these columns to the database
- Implemented `getPhotoImagePath()` method that resolves photo file paths based on whether they're imported (using legacy Mongo ObjectIds) or natively uploaded (using numeric IDs)
- Updated `deletePhotoFiles()` to accept a `Photo` entity instead of individual parameters, simplifying the API
- Updated all callers of photo file operations to use the new `getPhotoImagePath()` method
- Updated `mongo-import` service to populate `srcAlbumId` and `srcId` when importing photos, preserving the legacy on-disk file layout
- Fixed default thumbnails directory path from "thumbnails" to "thumbs" to match the old server's layout
- Added documentation explaining the dual file path layout for legacy vs. new photos

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
   - Fotografie z importu z MongoDB se stále zobrazují správně (ověř, že se načítají z legacy cesty)
   - Nově nahrané fotografie se zobrazují správně (ověř, že se načítají z nové cesty s numerickým ID)
   - Náhledy fotek se zobrazují správně
   - Mazání fotek funguje bez chyb

Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

https://claude.ai/code/session_016VKSkwVZY85Q8uXe3dWcPx