### PR TITLE
feat(members): dodělání designu přepínače aktivní/neaktivní členové

### DIFF
--- a/frontend/src/app/features/members/pages/members-list/members-list.component.html
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.html
@@ -108,6 +108,7 @@
 			<ion-popover trigger="checkbox-popover-trigger" triggerAction="click">
 			<ng-template>
 				<ion-content>
+					<ion-item-divider>SLOUPCE</ion-item-divider>
 					@for (selection of viewSelections()| keyvalue: originalViewOrder; track selection.key) {
 						<ion-item>
 							<ion-checkbox
@@ -119,6 +120,7 @@
 							</ion-checkbox>
 						</ion-item>
 					}
+					<ion-item-divider>FILTR</ion-item-divider>
 					<ion-item lines="none">
 						<ion-checkbox
 							justify="space-between"
@@ -234,9 +236,11 @@
 						@if (viewSelections().firstTelephone){
 							<th class="align-middle events-name-column" >Telefon</th>					
 						}
-						@if (viewSelections().firstEmail){	
-							<th class="align-middle events-name-column" >E-mail</th>					
+						@if (viewSelections().firstEmail){
+							<th class="align-middle events-name-column" >E-mail</th>
 						}
+
+						<th class="align-middle members-status-column">Stav</th>
 
 					</tr>
 				</thead>
@@ -293,6 +297,17 @@
 								@if (viewSelections().firstEmail) {
 								<td> <strong> {{ member.contacts?.[0]?.relationship || "" }} </strong> {{ member.contacts?.[0]?.email || "" }} </td>
 								}
+
+								<td class="members-status-cell">
+									<ion-badge
+										mode="ios"
+										class="status-badge"
+										[class.status-active]="member.active"
+										[class.status-inactive]="!member.active"
+									>
+										{{ member.active ? "Aktivní" : "Neaktivní" }}
+									</ion-badge>
+								</td>
 
 							</tr>
 						}

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.scss
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.scss
@@ -19,6 +19,31 @@ td ion-badge {
 	vertical-align: text-top;
 }
 
+.members-status-column {
+	width: 8rem;
+}
+
+// status chip — active/inactive is a quiet, low-prominence signal, so use the
+// soft tint pills (not the loud solid team badge). Colours are set explicitly
+// so the muted/line-through styling on inactive rows never bleeds into the chip.
+ion-badge.status-badge {
+	border-radius: var(--bo-radius-pill);
+	font-weight: 700;
+	font-size: 0.7rem;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	padding: 0.45em 0.7em;
+	text-decoration: none;
+}
+ion-badge.status-active {
+	background-color: var(--bo-green-tint);
+	color: var(--bo-green);
+}
+ion-badge.status-inactive {
+	background-color: var(--bo-neutral-pill);
+	color: var(--bo-neutral-pill-text);
+}
+
 .column-filter {
 	display: flex;
 	align-items: center;

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.ts
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from "@angular/forms";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import {
 	InfiniteScrollCustomEvent,
+	IonBadge,
 	IonButton,
 	IonCheckbox,
 	IonContent,
@@ -11,6 +12,7 @@ import {
 	IonInfiniteScroll,
 	IonInfiniteScrollContent,
 	IonItem,
+	IonItemDivider,
 	IonLabel,
 	IonList,
 	IonPopover,
@@ -50,6 +52,8 @@ import { MemberCreateModalComponent } from "../../components/member-create-modal
 		IonContent,
 		IonList,
 		IonItem,
+		IonItemDivider,
+		IonBadge,
 		IonLabel,
 		IonSkeletonText,
 		IonSelect,


### PR DESCRIPTION
# Změny

Dodělání vizuální/layoutové části z design handoff balíčku, která v předchozí implementaci přepínače aktivní/neaktivní chyběla (funkční část — backend filtr, URL parametr `active`, oprava CSS překlepu — už byla hotová).

 - Přidán stále viditelný sloupec **„Stav"** do tabulky členů s jemným pill chipem: zelené **„Aktivní"** (`--bo-green-tint`) vs. šedé **„Neaktivní"** (`--bo-neutral-pill`) — odpovídá `screens/01` a `screens/03`. Barvy chipu jsou nastaveny explicitně, aby se ztlumené/přeškrtnuté řádky neaktivních členů nepropisovaly do chipu.
 - Přidány sekční nadpisy **„SLOUPCE"** a **„FILTR"** (`ion-item-divider`) do „oka" (popover nastavení zobrazení), takže filtr „Zobrazit i neaktivní" tvoří vlastní sekci pod přepínači sloupců — odpovídá `screens/02`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři **Členská databáze** v desktop (table) zobrazení. Zkontroluj, že tabulka má poslední sloupec **„Stav"** a aktivní členové mají zelený chip **„Aktivní"** (`screens/01`).
3. Klikni na ikonu **oka** (nastavení zobrazení). Zkontroluj, že popover má sekci **„SLOUPCE"** s přepínači sloupců a pod ní sekci **„FILTR"** s přepínačem **„Zobrazit i neaktivní"** (`screens/02`).
4. Zapni **„Zobrazit i neaktivní"**. Zkontroluj, že se objeví i neaktivní členové — jejich řádky jsou **přeškrtnuté a ztlumené šedě** a mají šedý chip **„Neaktivní"** (`screens/03`); v URL přibude `active=all`.
5. Vypni přepínač (nebo použij tichý odkaz **„Skrýt neaktivní"** pod tabulkou) — vrátí se pouze aktivní členové a parametr z URL zmizí.
6. Obnov stránku / otevři sdílený odkaz s `active=all` — stav zůstane zachovaný.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSXLgAPgW6LhbmnTQQ22e8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSXLgAPgW6LhbmnTQQ22e8)_