### PR TITLE
Redesign account page with card-based layout

### DIFF
--- a/frontend/src/app/core/services/modal.service.ts
+++ b/frontend/src/app/core/services/modal.service.ts
@@ -30,6 +30,11 @@ interface SelectModalOptions<D> extends BaseModalOptions {
 	value?: D;
 }
 
+interface MultiSelectModalOptions<D> extends BaseModalOptions {
+	values: { label: string; value: D }[];
+	value?: D[];
+}
+
 export class InputModalComponent<D = any> {
 	submit = new EventEmitter<D>();
 	close = new EventEmitter<void>();
@@ -133,6 +138,31 @@ export class ModalService {
 					},
 					{
 						text: options.buttonText ?? "Vybrat",
+						handler: (data) => resolve(data),
+					},
+				],
+			});
+
+			await alert.present();
+		});
+	}
+
+	async multiSelectModal<D>(options: MultiSelectModalOptions<D>) {
+		return new Promise<D[] | null>(async (resolve, reject) => {
+			const alert = await this.alertController.create({
+				header: options.header,
+				inputs: options.values.map((item) => ({
+					...item,
+					type: "checkbox",
+					checked: options.value?.includes(item.value),
+				})),
+				buttons: [
+					{
+						text: "Zrušit",
+						role: "cancel",
+					},
+					{
+						text: options.buttonText ?? "Uložit",
 						handler: (data) => resolve(data),
 					},
 				],

--- a/frontend/src/app/features/account/components/account-app/account-app.component.html
+++ b/frontend/src/app/features/account/components/account-app/account-app.component.html
@@ -1,16 +1,45 @@
-@if (!beforeinstallprompt()) {
-	<p class="mb-0">
-		<ion-text color="danger">Aplikaci nelze nainstalovat.</ion-text>
-	</p>
-	<p class="text-muted">Aplikace je buď již nainstalovaná, nebo to ji toto zařízení nepodporuje.</p>
-}
+<bo-card>
+	<bo-card-header>
+		<bo-card-title>
+			<span class="bo-card-section-title">
+				<ion-icon name="phone-portrait-outline" />
+				Aplikace
+			</span>
+		</bo-card-title>
+	</bo-card-header>
 
-@if (beforeinstallprompt()) {
-	<div>
-		<button class="btn btn-primary" (click)="install()">Nainstalovat aplikaci</button>
-	</div>
-}
-
-@if (installed()) {
-	<p>Instalace se zdařila!</p>
-}
+	<bo-card-content>
+		<div class="bo-info-list">
+			@if (installed()) {
+				<div class="bo-info-row app-row">
+					<ion-icon class="app-icon" color="success" name="checkmark-circle-outline" />
+					<div class="app-text">
+						<strong>Instalace se zdařila!</strong>
+					</div>
+				</div>
+			} @else if (beforeinstallprompt()) {
+				<div class="bo-info-row app-row">
+					<ion-icon class="app-icon" name="phone-portrait-outline" />
+					<div class="app-text">
+						<strong>Nainstalovat aplikaci</strong>
+						<span class="app-muted">Přidat aplikaci na plochu tohoto zařízení.</span>
+					</div>
+					<ion-button (click)="install()">
+						<ion-icon name="download-outline" slot="start" />
+						Nainstalovat
+					</ion-button>
+				</div>
+			} @else {
+				<div class="bo-info-row app-row">
+					<ion-icon class="app-icon" color="danger" name="information-circle-outline" />
+					<div class="app-text">
+						<strong>Aplikaci nelze nainstalovat.</strong>
+						<span class="app-muted">
+							Aplikace je buď již nainstalovaná, nebo to toto zařízení nepodporuje.
+						</span>
+					</div>
+				</div>
+			}
+		</div>
+	</bo-card-content>
+</bo-card>

--- a/frontend/src/app/features/account/components/account-app/account-app.component.scss
+++ b/frontend/src/app/features/account/components/account-app/account-app.component.scss
@@ -1,0 +1,57 @@
+:host {
+	display: block;
+}
+
+/* řádky mají vlastní odsazení – zrušíme výchozí p-3 z bo-card-content */
+::ng-deep bo-card-content {
+	padding: 0 !important;
+}
+
+.app-row {
+	align-items: flex-start;
+	gap: 12px;
+	justify-content: flex-start;
+}
+
+.app-icon {
+	font-size: 1.4rem;
+	color: var(--bo-muted);
+	flex: 0 0 auto;
+	margin-top: 1px;
+}
+
+.app-text {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1;
+	min-width: 0;
+
+	strong {
+		color: var(--bo-ink);
+	}
+}
+
+.app-muted {
+	color: var(--bo-muted);
+}
+
+ion-button {
+	--border-radius: var(--bo-radius-btn);
+	text-transform: none;
+	letter-spacing: 0;
+	font-weight: 700;
+	margin: 0;
+	flex: 0 0 auto;
+	align-self: center;
+}
+
+@media (max-width: 991.98px) {
+	.app-row {
+		flex-wrap: wrap;
+	}
+
+	ion-button {
+		flex: 0 0 100%;
+	}
+}

--- a/frontend/src/app/features/account/components/account-app/account-app.component.ts
+++ b/frontend/src/app/features/account/components/account-app/account-app.component.ts
@@ -1,5 +1,16 @@
 import { Component, OnInit, signal } from "@angular/core";
-import { IonText } from "@ionic/angular/standalone";
+import { IonButton, IonIcon } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import {
+	checkmarkCircleOutline,
+	downloadOutline,
+	informationCircleOutline,
+	phonePortraitOutline,
+} from "ionicons/icons";
+import { CardContentComponent } from "src/app/shared/components/card-content/card-content.component";
+import { CardHeaderComponent } from "src/app/shared/components/card-header/card-header.component";
+import { CardTitleComponent } from "src/app/shared/components/card-title/card-title.component";
+import { CardComponent } from "src/app/shared/components/card/card.component";
 
 // from https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent
 interface BeforeInstallPromptEvent {
@@ -12,7 +23,14 @@ interface BeforeInstallPromptEvent {
 	selector: "bo-account-app",
 	templateUrl: "./account-app.component.html",
 	styleUrls: ["./account-app.component.scss"],
-	imports: [IonText],
+	imports: [
+		IonButton,
+		IonIcon,
+		CardComponent,
+		CardHeaderComponent,
+		CardTitleComponent,
+		CardContentComponent,
+	],
 })
 export class AccountAppComponent implements OnInit {
 	beforeinstallprompt = signal<BeforeInstallPromptEvent | undefined>(undefined);
@@ -21,7 +39,14 @@ export class AccountAppComponent implements OnInit {
 
 	promptShown = signal(false);
 
-	constructor() {}
+	constructor() {
+		addIcons({
+			phonePortraitOutline,
+			informationCircleOutline,
+			checkmarkCircleOutline,
+			downloadOutline,
+		});
+	}
 
 	ngOnInit() {
 		window.addEventListener("beforeinstallprompt", (event: any) => {

--- a/frontend/src/app/features/account/components/account-credentials/account-credentials.component.html
+++ b/frontend/src/app/features/account/components/account-credentials/account-credentials.component.html
@@ -1,72 +1,79 @@
-<ion-list>
-	<ion-item>
-		<ion-label>Login:</ion-label>
-		@if (user()?.login) {
-			<ion-label>
-				<ion-text color="success">Zapnuto</ion-text><br />
-				{{ user()?.login }}
-			</ion-label>
-		} @else {
-			<ion-label>
-				<ion-text color="danger">Vypnuto</ion-text>
-			</ion-label>
-		}
-		<ion-label>
-			@if (user()?._links?.updateUser?.allowed) {
-				<a class="clickable" (click)="changeLogin()">Změnit login</a>
-			}
-		</ion-label>
-	</ion-item>
+<bo-card>
+	<bo-card-header>
+		<bo-card-title>
+			<span class="bo-card-section-title">
+				<ion-icon name="key-outline" />
+				Přihlašování
+			</span>
+		</bo-card-title>
+	</bo-card-header>
 
-	<ion-item>
-		<ion-label>Heslo:</ion-label>
-		@if (user()?.login) {
-			<ion-label>
-				<ion-text color="success">Nastaveno</ion-text>
-			</ion-label>
-		} @else {
-			<ion-label>
-				<ion-text color="danger">Nenastaveno</ion-text>
-			</ion-label>
-		}
-		<ion-label>
-			@if (user()?._links?.setUserPassword?.allowed) {
-				<a class="clickable" (click)="changePassword()">Změnit heslo</a>
-			}
-		</ion-label>
-	</ion-item>
+	<bo-card-content>
+		<div class="bo-info-list">
+			<!-- Login -->
+			<div class="bo-info-row cred-row">
+				<span class="bo-info-label">Login</span>
+				<span class="cred-status">
+					@if (user()?.login; as login) {
+						<span class="bo-pill bo-pill-green">Zapnuto</span>
+						<span class="cred-value">{{ login }}</span>
+					} @else {
+						<span class="bo-pill bo-pill-red">Vypnuto</span>
+					}
+				</span>
+				@if (user()?._links?.updateUser?.allowed) {
+					<ion-button fill="outline" size="default" (click)="changeLogin()">
+						<ion-icon name="create-outline" slot="start" />
+						Změnit login
+					</ion-button>
+				}
+			</div>
 
-	<ion-item>
-		<ion-label>Bošánovský mail:</ion-label>
-		@if (user()?.email) {
-			<ion-label>
-				<ion-text color="success">Zapnuto</ion-text><br />
-				{{ user()?.email }}
-			</ion-label>
-		}
-		@if (!user()?.email) {
-			<ion-label>
-				<ion-text color="danger">Vypnuto</ion-text><br />
-				U účtu není uveden email
-			</ion-label>
-		}
-		<ion-label></ion-label>
-	</ion-item>
+			<!-- Heslo -->
+			<div class="bo-info-row cred-row">
+				<span class="bo-info-label">Heslo</span>
+				<span class="cred-status">
+					@if (user()?.login) {
+						<span class="bo-pill bo-pill-green">Nastaveno</span>
+					} @else {
+						<span class="bo-pill bo-pill-red">Nenastaveno</span>
+					}
+				</span>
+				@if (user()?._links?.setUserPassword?.allowed) {
+					<ion-button fill="outline" size="default" (click)="changePassword()">
+						<ion-icon name="create-outline" slot="start" />
+						Změnit heslo
+					</ion-button>
+				}
+			</div>
 
-	<ion-item>
-		<ion-label>Odkazem na mail:</ion-label>
-		@if (user()?.email) {
-			<ion-label>
-				<ion-text color="success">Zapnuto</ion-text><br />
-				{{ user()?.email }}
-			</ion-label>
-		}
-		@if (!user()?.email) {
-			<ion-label>
-				<ion-text color="danger">Vypnuto</ion-text><br />
-				U účtu není uveden email
-			</ion-label>
-		}
-		<ion-label></ion-label>
-	</ion-item>
-</ion-list>
+			<!-- Bošánovský mail -->
+			<div class="bo-info-row">
+				<span class="bo-info-label">Bošánovský mail</span>
+				<span class="cred-mail-value">
+					@if (user()?.email; as email) {
+						<span class="bo-pill bo-pill-green">Zapnuto</span>
+						<span class="cred-value">{{ email }}</span>
+					} @else {
+						<span class="bo-pill bo-pill-red">Vypnuto</span>
+						<span class="cred-muted">U účtu není uveden email</span>
+					}
+				</span>
+			</div>
+
+			<!-- Odkazem na mail -->
+			<div class="bo-info-row">
+				<span class="bo-info-label">Odkazem na mail</span>
+				<span class="cred-mail-value">
+					@if (user()?.email; as email) {
+						<span class="bo-pill bo-pill-green">Zapnuto</span>
+						<span class="cred-value">{{ email }}</span>
+					} @else {
+						<span class="bo-pill bo-pill-red">Vypnuto</span>
+						<span class="cred-muted">U účtu není uveden email</span>
+					}
+				</span>
+			</div>
+		</div>
+	</bo-card-content>
+</bo-card>

--- a/frontend/src/app/features/account/components/account-credentials/account-credentials.component.scss
+++ b/frontend/src/app/features/account/components/account-credentials/account-credentials.component.scss
@@ -1,0 +1,78 @@
+:host {
+	display: block;
+}
+
+/* řádky mají vlastní odsazení – zrušíme výchozí p-3 z bo-card-content */
+::ng-deep bo-card-content {
+	padding: 0 !important;
+}
+
+.cred-row {
+	flex-wrap: wrap;
+	gap: 10px;
+}
+
+.cred-status {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.cred-value {
+	color: var(--bo-ink);
+}
+
+.cred-muted {
+	color: var(--bo-muted);
+	font-size: 0.85em;
+}
+
+.cred-mail-value {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 3px;
+	text-align: right;
+	min-width: 0;
+	word-break: break-word;
+}
+
+/* akční tlačítko „Změnit …" */
+ion-button {
+	--border-radius: var(--bo-radius-btn);
+	--border-color: var(--bo-line);
+	--color: var(--bo-heading);
+	--background: var(--bo-white);
+	--background-hover: var(--bo-paper);
+	--background-hover-opacity: 1;
+	--padding-top: 10px;
+	--padding-bottom: 10px;
+	font-weight: 700;
+	text-transform: none;
+	letter-spacing: 0;
+	margin: 0;
+	/* mobil: tlačítko na celou šířku pod řádkem */
+	flex: 0 0 100%;
+}
+
+@media (min-width: 992px) {
+	.cred-row {
+		flex-wrap: nowrap;
+		gap: 16px;
+		justify-content: flex-start;
+	}
+
+	.cred-row .bo-info-label {
+		width: 180px;
+		flex: 0 0 auto;
+	}
+
+	.cred-status {
+		flex: 1;
+	}
+
+	ion-button {
+		flex: 0 0 auto;
+	}
+}

--- a/frontend/src/app/features/account/components/account-credentials/account-credentials.component.ts
+++ b/frontend/src/app/features/account/components/account-credentials/account-credentials.component.ts
@@ -1,17 +1,30 @@
 import { Component } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { IonItem, IonLabel, IonList, IonText } from "@ionic/angular/standalone";
+import { IonButton, IonIcon } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import { createOutline, keyOutline } from "ionicons/icons";
 import { ApiService } from "src/app/core/services/api.service";
 import { ModalService } from "src/app/core/services/modal.service";
 import { ToastService } from "src/app/core/services/toast.service";
 import { UserService } from "src/app/core/services/user.service";
+import { CardContentComponent } from "src/app/shared/components/card-content/card-content.component";
+import { CardHeaderComponent } from "src/app/shared/components/card-header/card-header.component";
+import { CardTitleComponent } from "src/app/shared/components/card-title/card-title.component";
+import { CardComponent } from "src/app/shared/components/card/card.component";
 
 @Component({
 	selector: "bo-account-credentials",
 	templateUrl: "./account-credentials.component.html",
 	styleUrls: ["./account-credentials.component.scss"],
 
-	imports: [IonList, IonItem, IonLabel, IonText],
+	imports: [
+		IonButton,
+		IonIcon,
+		CardComponent,
+		CardHeaderComponent,
+		CardTitleComponent,
+		CardContentComponent,
+	],
 })
 export class AccountCredentialsComponent {
 	user = toSignal(this.userService.user);
@@ -21,7 +34,9 @@ export class AccountCredentialsComponent {
 		private userService: UserService,
 		private toastService: ToastService,
 		private modalService: ModalService,
-	) {}
+	) {
+		addIcons({ keyOutline, createOutline });
+	}
 
 	async changeLogin() {
 		const user = this.user();

--- a/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.html
+++ b/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.html
@@ -1,0 +1,37 @@
+<bo-modal-layout>
+	<h4 slot="title">Upravit účet</h4>
+
+	<form [formGroup]="form">
+		<ion-list>
+			<ion-item>
+				<ion-input
+					label="E-mail"
+					labelPlacement="stacked"
+					type="email"
+					formControlName="email"
+					placeholder="bilbo@bosan.cz"
+					autocomplete="email"
+				/>
+			</ion-item>
+
+			<ion-item>
+				<ion-select
+					label="Role"
+					labelPlacement="stacked"
+					multiple
+					formControlName="roles"
+					placeholder="žádné"
+				>
+					@for (role of roles | keyvalue; track role.key) {
+						<ion-select-option [value]="role.key">{{ role.value.title }}</ion-select-option>
+					}
+				</ion-select>
+			</ion-item>
+		</ion-list>
+	</form>
+
+	<ion-buttons slot="buttons">
+		<ion-button (click)="close.emit()" color="secondary">Zrušit</ion-button>
+		<ion-button (click)="save()" color="primary">Uložit</ion-button>
+	</ion-buttons>
+</bo-modal-layout>

--- a/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.scss
+++ b/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.scss
@@ -4,6 +4,4 @@ form ion-list {
 
 ion-item {
 	--background: transparent;
-	--padding-start: 0;
-	--inner-padding-end: 0;
 }

--- a/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.scss
+++ b/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.scss
@@ -1,0 +1,9 @@
+form ion-list {
+	background: transparent;
+}
+
+ion-item {
+	--background: transparent;
+	--padding-start: 0;
+	--inner-padding-end: 0;
+}

--- a/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.ts
+++ b/frontend/src/app/features/account/components/account-edit-modal/account-edit-modal.component.ts
@@ -1,0 +1,72 @@
+import { KeyValuePipe } from "@angular/common";
+import { Component } from "@angular/core";
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
+import {
+	IonButton,
+	IonButtons,
+	IonInput,
+	IonItem,
+	IonList,
+	IonSelect,
+	IonSelectOption,
+	ModalController,
+} from "@ionic/angular/standalone";
+import { UserRoles } from "src/app/core/config/user-roles";
+import { InputModalComponent } from "src/app/core/services/modal.service";
+import { ModalLayoutComponent } from "src/app/shared/components/modal-layout/modal-layout.component";
+import { SDK } from "src/sdk";
+
+@Component({
+	selector: "bo-account-edit-modal",
+	templateUrl: "./account-edit-modal.component.html",
+	styleUrls: ["./account-edit-modal.component.scss"],
+
+	imports: [
+		ReactiveFormsModule,
+		KeyValuePipe,
+		IonList,
+		IonItem,
+		IonInput,
+		IonSelect,
+		IonSelectOption,
+		IonButtons,
+		IonButton,
+		ModalLayoutComponent,
+	],
+})
+export class AccountEditModalComponent extends InputModalComponent<SDK.UserUpdateBody> {
+	roles = UserRoles;
+
+	form = new FormGroup({
+		email: new FormControl<string>("", { nonNullable: true, validators: [Validators.email] }),
+		roles: new FormControl<SDK.UserUpdateBodyRolesEnum[]>([], { nonNullable: true }),
+	});
+
+	constructor(modalController: ModalController) {
+		super(modalController);
+	}
+
+	/** Called by ModalService via componentProps to seed the form. */
+	set user(user: SDK.AccountResponseWithLinks | null | undefined) {
+		this.form.reset({
+			email: user?.email ?? "",
+			roles: (user?.roles ?? []) as SDK.UserUpdateBodyRolesEnum[],
+		});
+	}
+
+	save() {
+		this.form.markAllAsTouched();
+
+		if (!this.form.valid) return;
+
+		const value = this.form.getRawValue();
+
+		const data: SDK.UserUpdateBody = {
+			// omit email entirely when left blank, to avoid clearing an existing address
+			...(value.email ? { email: value.email } : {}),
+			roles: value.roles,
+		};
+
+		this.submit.emit(data);
+	}
+}

--- a/frontend/src/app/features/account/pages/account.component.html
+++ b/frontend/src/app/features/account/pages/account.component.html
@@ -1,60 +1,133 @@
 <bo-page-header title="Můj účet" />
 
-<bo-page-content>
-	<h3 class="m-3">Uživatelský účet</h3>
+<bo-page-content [padding]="true">
+	@if (user(); as user) {
+		<div class="account-layout">
+			<!-- profilová hlavička -->
+			<bo-card class="profile-card">
+				<bo-card-content>
+					<div class="profile">
+						<bo-avatar
+							class="profile-avatar"
+							[initials]="user.member! | member: 'initials'"
+							[style.background-color]="user.member?.groupId | group: 'color'"
+						/>
 
-	<ion-list>
-		<ion-item>
-			<ion-label>E-mail:</ion-label>
-			<ion-label>
-				@if (user()?.email) {
-					<a [href]="'mailto:' + user()?.email">{{ user()?.email }}</a>
-				}
-			</ion-label>
-		</ion-item>
+						<div class="profile-info">
+							<div class="profile-name san">
+								@if (user.member; as member) {
+									{{ member.firstName }} {{ member.lastName }}
+								} @else {
+									{{ user.login }}
+								}
+							</div>
 
-		<ion-item>
-			<ion-label>Role:</ion-label>
-			<ion-label>
-				@for (role of user()?.roles; track role) {
-					<ion-badge>{{ role }}</ion-badge>
-				}
-			</ion-label>
-		</ion-item>
-	</ion-list>
+							<div class="profile-sub">
+								@if (user.member?.nickname; as nickname) {
+									„{{ nickname }}"
+									@if (user.email) {
+										·
+									}
+								}
+								@if (user.email) {
+									<a [href]="'mailto:' + user.email">{{ user.email }}</a>
+								}
+							</div>
 
-	<h3 class="m-3">Člen skupiny</h3>
-	@if (!user()?.member) {
-		<p class="ms-3 text-warning">Nespárováno s členským účtem</p>
+							<div class="profile-pills">
+								@for (role of user.roles; track role) {
+									<span class="bo-pill bo-pill-blue">{{ role }}</span>
+								}
+								@if (user.member?.groupId; as groupId) {
+									<span class="bo-pill">{{ groupId | group: "name" }}</span>
+								}
+							</div>
+
+							@if (!user.member) {
+								<div class="profile-unpaired">Nespárováno s členským účtem</div>
+							}
+						</div>
+					</div>
+				</bo-card-content>
+			</bo-card>
+
+			<div class="account-grid">
+				<!-- Uživatelský účet -->
+				<bo-card>
+					<bo-card-header>
+						<bo-card-title>
+							<span class="bo-card-section-title">
+								<ion-icon name="mail-outline" />
+								Uživatelský účet
+							</span>
+						</bo-card-title>
+					</bo-card-header>
+					<bo-card-content>
+						<div class="bo-info-list">
+							<div class="bo-info-row">
+								<span class="bo-info-label">E-mail</span>
+								@if (user.email) {
+									<a class="bo-info-value" [href]="'mailto:' + user.email">{{ user.email }}</a>
+								} @else {
+									<span class="bo-info-value">—</span>
+								}
+							</div>
+							<div class="bo-info-row">
+								<span class="bo-info-label">Role</span>
+								<span class="profile-pills">
+									@for (role of user.roles; track role) {
+										<span class="bo-pill bo-pill-blue">{{ role }}</span>
+									} @empty {
+										<span class="bo-info-value">—</span>
+									}
+								</span>
+							</div>
+						</div>
+					</bo-card-content>
+				</bo-card>
+
+				<!-- Člen skupiny -->
+				<bo-card>
+					<bo-card-header>
+						<bo-card-title>
+							<span class="bo-card-section-title">
+								<ion-icon name="people-outline" />
+								Člen skupiny
+							</span>
+						</bo-card-title>
+					</bo-card-header>
+					<bo-card-content>
+						@if (user.member; as member) {
+							<div class="bo-info-list">
+								<div class="bo-info-row">
+									<span class="bo-info-label">Přezdívka</span>
+									<span class="bo-info-value">{{ member.nickname }}</span>
+								</div>
+								<div class="bo-info-row">
+									<span class="bo-info-label">Jméno</span>
+									<span class="bo-info-value">{{ member.firstName }} {{ member.lastName }}</span>
+								</div>
+								<div class="bo-info-row">
+									<span class="bo-info-label">Oddíl</span>
+									<span class="bo-info-value">{{ member.groupId | group: "name" }}</span>
+								</div>
+							</div>
+						} @else {
+							<div class="bo-info-list">
+								<div class="bo-info-row">
+									<span class="profile-unpaired">Nespárováno s členským účtem</span>
+								</div>
+							</div>
+						}
+					</bo-card-content>
+				</bo-card>
+
+				<!-- Přihlašování -->
+				<bo-account-credentials class="grid-full" />
+
+				<!-- Aplikace -->
+				<bo-account-app class="grid-full" />
+			</div>
+		</div>
 	}
-
-	@if (user()?.member; as member) {
-		<ion-list>
-			<ion-item>
-				<ion-label>Přezdívka:</ion-label>
-				<ion-label>{{ member.nickname }}</ion-label>
-			</ion-item>
-			<ion-item>
-				<ion-label>Jméno:</ion-label>
-				<ion-label>{{ member.firstName }} {{ member.lastName }}</ion-label>
-			</ion-item>
-			<ion-item>
-				<ion-label>Oddíl:</ion-label>
-				<ion-label>{{ member.groupId | group: "name" }}</ion-label>
-			</ion-item>
-		</ion-list>
-	}
-
-	<h3 class="m-3 mt-4">Přihlašování</h3>
-	<bo-account-credentials></bo-account-credentials>
-
-	<h3 class="m-3 mt-4">Aplikace</h3>
-	<div class="ms-3">
-		<bo-account-app></bo-account-app>
-	</div>
-
-	<!-- <h2 class="m-3 mt-4">Notifikace</h2>
-  <div class="ms-3 mb-5">
-    <bo-account-notifications></bo-account-notifications>
-  </div> -->
 </bo-page-content>

--- a/frontend/src/app/features/account/pages/account.component.html
+++ b/frontend/src/app/features/account/pages/account.component.html
@@ -47,6 +47,13 @@
 								<div class="profile-unpaired">Nespárováno s členským účtem</div>
 							}
 						</div>
+
+						@if (user._links.updateUser.allowed) {
+							<ion-button class="profile-edit-btn" fill="outline" size="default" (click)="editAccount()">
+								<ion-icon name="create-outline" slot="start" />
+								Upravit
+							</ion-button>
+						}
 					</div>
 				</bo-card-content>
 			</bo-card>

--- a/frontend/src/app/features/account/pages/account.component.html
+++ b/frontend/src/app/features/account/pages/account.component.html
@@ -48,12 +48,6 @@
 							}
 						</div>
 
-						@if (user._links.updateUser.allowed) {
-							<ion-button class="profile-edit-btn" fill="outline" size="default" (click)="editAccount()">
-								<ion-icon name="create-outline" slot="start" />
-								Upravit
-							</ion-button>
-						}
 					</div>
 				</bo-card-content>
 			</bo-card>
@@ -73,19 +67,35 @@
 						<div class="bo-info-list">
 							<div class="bo-info-row">
 								<span class="bo-info-label">E-mail</span>
-								@if (user.email) {
-									<a class="bo-info-value" [href]="'mailto:' + user.email">{{ user.email }}</a>
-								} @else {
-									<span class="bo-info-value">—</span>
-								}
+								<span class="bo-info-action">
+									@if (user.email) {
+										<a class="bo-info-value" [href]="'mailto:' + user.email">{{ user.email }}</a>
+									} @else {
+										<span class="bo-info-value">—</span>
+									}
+									@if (user._links.updateUser.allowed) {
+										<bo-edit-button-text
+											type="email"
+											label="E-mail"
+											placeholder="bilbo@bosan.cz"
+											[value]="user.email"
+											(update)="updateAccount({ email: $event ?? undefined })"
+										/>
+									}
+								</span>
 							</div>
 							<div class="bo-info-row">
 								<span class="bo-info-label">Role</span>
-								<span class="profile-pills">
-									@for (role of user.roles; track role) {
-										<span class="bo-pill bo-pill-blue">{{ role }}</span>
-									} @empty {
-										<span class="bo-info-value">—</span>
+								<span class="bo-info-action">
+									<span class="profile-pills">
+										@for (role of user.roles; track role) {
+											<span class="bo-pill bo-pill-blue">{{ role }}</span>
+										} @empty {
+											<span class="bo-info-value">—</span>
+										}
+									</span>
+									@if (user._links.updateUser.allowed) {
+										<bo-edit-button (click)="editRoles()" />
 									}
 								</span>
 							</div>

--- a/frontend/src/app/features/account/pages/account.component.scss
+++ b/frontend/src/app/features/account/pages/account.component.scss
@@ -1,10 +1,133 @@
-ion-content {
-	::ng-deep ion-item ion-label:first-child {
-		flex-grow: 0.5;
-		padding-right: 10px;
+:host {
+	display: block;
+}
+
+.account-layout {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+/* karty používají vlastní odsazení řádků – zrušíme výchozí p-3 z bo-card-content */
+.account-grid ::ng-deep bo-card-content {
+	padding: 0 !important;
+}
+
+/* ---- profilová hlavička ---- */
+.profile-card {
+	::ng-deep bo-card-content {
+		padding: 18px !important;
 	}
-	::ng-deep ion-label {
-		white-space: normal !important;
-		align-self: flex-start;
+}
+
+.profile {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	gap: 6px;
+}
+
+.profile-avatar {
+	width: 76px;
+	height: 76px;
+	flex: 0 0 auto;
+
+	::ng-deep h3 {
+		font-size: 34px;
+		color: #fff;
+	}
+}
+
+.profile-info {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+}
+
+.profile-name {
+	font-size: 23px;
+	line-height: 1.1;
+	color: var(--bo-ink);
+	margin-top: 4px;
+}
+
+.profile-sub {
+	color: var(--bo-muted);
+	font-size: 14px;
+}
+
+.profile-pills {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+	justify-content: center;
+}
+
+.profile-unpaired {
+	color: var(--bo-yellow-deep);
+	font-weight: 600;
+}
+
+/* ---- mřížka karet ---- */
+.account-grid {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 14px;
+}
+
+.grid-full {
+	display: block;
+}
+
+/* ---- desktop ≥ 992px ---- */
+@media (min-width: 992px) {
+	.account-layout {
+		gap: 20px;
+	}
+
+	.profile-card ::ng-deep bo-card-content {
+		padding: 24px 26px !important;
+	}
+
+	.profile {
+		flex-direction: row;
+		align-items: center;
+		text-align: left;
+		gap: 24px;
+	}
+
+	.profile-avatar {
+		width: 82px;
+		height: 82px;
+
+		::ng-deep h3 {
+			font-size: 36px;
+		}
+	}
+
+	.profile-info {
+		align-items: flex-start;
+		gap: 3px;
+	}
+
+	.profile-name {
+		font-size: 27px;
+		margin-top: 0;
+	}
+
+	.profile-pills {
+		justify-content: flex-start;
+		margin-top: 11px;
+	}
+
+	.account-grid {
+		grid-template-columns: 1fr 1fr;
+		gap: 20px;
+	}
+
+	.grid-full {
+		grid-column: 1 / -1;
 	}
 }

--- a/frontend/src/app/features/account/pages/account.component.scss
+++ b/frontend/src/app/features/account/pages/account.component.scss
@@ -70,22 +70,17 @@
 	font-weight: 600;
 }
 
-/* akční tlačítko „Upravit" v profilové hlavičce */
-.profile-edit-btn {
-	--border-radius: var(--bo-radius-btn);
-	--border-color: var(--bo-line);
-	--color: var(--bo-heading);
-	--background: var(--bo-white);
-	--background-hover: var(--bo-paper);
-	--background-hover-opacity: 1;
-	--padding-top: 10px;
-	--padding-bottom: 10px;
-	font-weight: 700;
-	text-transform: none;
-	letter-spacing: 0;
-	margin: 12px 0 0;
-	/* mobil: přes celou šířku pod štítky */
-	width: 100%;
+/* hodnota + inline editační tlačítko na pravé straně řádku */
+.bo-info-action {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	min-width: 0;
+
+	bo-edit-button,
+	bo-edit-button-text {
+		flex: 0 0 auto;
+	}
 }
 
 /* ---- mřížka karet ---- */
@@ -134,13 +129,6 @@
 	.profile-name {
 		font-size: 27px;
 		margin-top: 0;
-	}
-
-	.profile-edit-btn {
-		width: auto;
-		margin: 0;
-		align-self: center;
-		flex: 0 0 auto;
 	}
 
 	.profile-pills {

--- a/frontend/src/app/features/account/pages/account.component.scss
+++ b/frontend/src/app/features/account/pages/account.component.scss
@@ -70,6 +70,24 @@
 	font-weight: 600;
 }
 
+/* akční tlačítko „Upravit" v profilové hlavičce */
+.profile-edit-btn {
+	--border-radius: var(--bo-radius-btn);
+	--border-color: var(--bo-line);
+	--color: var(--bo-heading);
+	--background: var(--bo-white);
+	--background-hover: var(--bo-paper);
+	--background-hover-opacity: 1;
+	--padding-top: 10px;
+	--padding-bottom: 10px;
+	font-weight: 700;
+	text-transform: none;
+	letter-spacing: 0;
+	margin: 12px 0 0;
+	/* mobil: přes celou šířku pod štítky */
+	width: 100%;
+}
+
 /* ---- mřížka karet ---- */
 .account-grid {
 	display: grid;
@@ -110,11 +128,19 @@
 	.profile-info {
 		align-items: flex-start;
 		gap: 3px;
+		flex: 1;
 	}
 
 	.profile-name {
 		font-size: 27px;
 		margin-top: 0;
+	}
+
+	.profile-edit-btn {
+		width: auto;
+		margin: 0;
+		align-self: center;
+		flex: 0 0 auto;
 	}
 
 	.profile-pills {

--- a/frontend/src/app/features/account/pages/account.component.ts
+++ b/frontend/src/app/features/account/pages/account.component.ts
@@ -1,10 +1,18 @@
 import { Component } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { IonBadge, IonItem, IonLabel, IonList } from "@ionic/angular/standalone";
+import { IonIcon } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import { mailOutline, peopleOutline } from "ionicons/icons";
 import { UserService } from "src/app/core/services/user.service";
+import { AvatarComponent } from "src/app/shared/components/avatar/avatar.component";
+import { CardContentComponent } from "src/app/shared/components/card-content/card-content.component";
+import { CardHeaderComponent } from "src/app/shared/components/card-header/card-header.component";
+import { CardTitleComponent } from "src/app/shared/components/card-title/card-title.component";
+import { CardComponent } from "src/app/shared/components/card/card.component";
 import { PageContentComponent } from "src/app/shared/components/page-content/page-content.component";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { GroupPipe } from "src/app/shared/pipes/group.pipe";
+import { MemberPipe } from "src/app/shared/pipes/member.pipe";
 import { AccountAppComponent } from "../components/account-app/account-app.component";
 import { AccountCredentialsComponent } from "../components/account-credentials/account-credentials.component";
 
@@ -15,17 +23,22 @@ import { AccountCredentialsComponent } from "../components/account-credentials/a
 	imports: [
 		PageHeaderComponent,
 		PageContentComponent,
-		IonList,
-		IonItem,
-		IonLabel,
-		IonBadge,
+		IonIcon,
+		AvatarComponent,
+		CardComponent,
+		CardHeaderComponent,
+		CardTitleComponent,
+		CardContentComponent,
 		AccountCredentialsComponent,
 		AccountAppComponent,
 		GroupPipe,
+		MemberPipe,
 	],
 })
 export class AccountComponent {
 	user = toSignal(this.userService.user);
 
-	constructor(private userService: UserService) {}
+	constructor(private userService: UserService) {
+		addIcons({ mailOutline, peopleOutline });
+	}
 }

--- a/frontend/src/app/features/account/pages/account.component.ts
+++ b/frontend/src/app/features/account/pages/account.component.ts
@@ -1,8 +1,9 @@
 import { Component } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { IonButton, IonIcon } from "@ionic/angular/standalone";
+import { IonIcon } from "@ionic/angular/standalone";
 import { addIcons } from "ionicons";
-import { createOutline, mailOutline, peopleOutline } from "ionicons/icons";
+import { mailOutline, peopleOutline } from "ionicons/icons";
+import { UserRoles } from "src/app/core/config/user-roles";
 import { ApiService } from "src/app/core/services/api.service";
 import { ModalService } from "src/app/core/services/modal.service";
 import { ToastService } from "src/app/core/services/toast.service";
@@ -12,6 +13,8 @@ import { CardContentComponent } from "src/app/shared/components/card-content/car
 import { CardHeaderComponent } from "src/app/shared/components/card-header/card-header.component";
 import { CardTitleComponent } from "src/app/shared/components/card-title/card-title.component";
 import { CardComponent } from "src/app/shared/components/card/card.component";
+import { EditButtonComponent } from "src/app/shared/components/edit-button/edit-button.component";
+import { EditButtonTextComponent } from "src/app/shared/components/edit-button-text/edit-button-text.component";
 import { PageContentComponent } from "src/app/shared/components/page-content/page-content.component";
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { GroupPipe } from "src/app/shared/pipes/group.pipe";
@@ -19,7 +22,6 @@ import { MemberPipe } from "src/app/shared/pipes/member.pipe";
 import { SDK } from "src/sdk";
 import { AccountAppComponent } from "../components/account-app/account-app.component";
 import { AccountCredentialsComponent } from "../components/account-credentials/account-credentials.component";
-import { AccountEditModalComponent } from "../components/account-edit-modal/account-edit-modal.component";
 
 @Component({
 	selector: "bo-account",
@@ -29,7 +31,6 @@ import { AccountEditModalComponent } from "../components/account-edit-modal/acco
 		PageHeaderComponent,
 		PageContentComponent,
 		IonIcon,
-		IonButton,
 		AvatarComponent,
 		CardComponent,
 		CardHeaderComponent,
@@ -37,6 +38,8 @@ import { AccountEditModalComponent } from "../components/account-edit-modal/acco
 		CardContentComponent,
 		AccountCredentialsComponent,
 		AccountAppComponent,
+		EditButtonComponent,
+		EditButtonTextComponent,
 		GroupPipe,
 		MemberPipe,
 	],
@@ -44,27 +47,43 @@ import { AccountEditModalComponent } from "../components/account-edit-modal/acco
 export class AccountComponent {
 	user = toSignal(this.userService.user);
 
+	roles = UserRoles;
+
 	constructor(
 		private userService: UserService,
 		private api: ApiService,
 		private modalService: ModalService,
 		private toastService: ToastService,
 	) {
-		addIcons({ mailOutline, peopleOutline, createOutline });
+		addIcons({ mailOutline, peopleOutline });
 	}
 
-	async editAccount() {
+	async updateAccount(data: SDK.UserUpdateBody) {
 		const user = this.user();
 		if (!user?._links.updateUser.allowed) return;
 
-		const data = await this.modalService.componentModal(AccountEditModalComponent, { user });
-
-		if (!data) return;
-
-		await this.api.UsersApi.updateUser(user.id, data satisfies SDK.UserUpdateBody);
+		await this.api.UsersApi.updateUser(user.id, data);
 
 		this.toastService.toast("Uloženo.");
 
 		await this.userService.loadUser();
+	}
+
+	async editRoles() {
+		const user = this.user();
+		if (!user?._links.updateUser.allowed) return;
+
+		const roles = await this.modalService.multiSelectModal<SDK.UserUpdateBodyRolesEnum>({
+			header: "Role",
+			values: Object.entries(this.roles).map(([value, role]) => ({
+				label: role.title,
+				value: value as SDK.UserUpdateBodyRolesEnum,
+			})),
+			value: (user.roles ?? []) as SDK.UserUpdateBodyRolesEnum[],
+		});
+
+		if (!roles) return;
+
+		await this.updateAccount({ roles });
 	}
 }

--- a/frontend/src/app/features/account/pages/account.component.ts
+++ b/frontend/src/app/features/account/pages/account.component.ts
@@ -1,8 +1,11 @@
 import { Component } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { IonIcon } from "@ionic/angular/standalone";
+import { IonButton, IonIcon } from "@ionic/angular/standalone";
 import { addIcons } from "ionicons";
-import { mailOutline, peopleOutline } from "ionicons/icons";
+import { createOutline, mailOutline, peopleOutline } from "ionicons/icons";
+import { ApiService } from "src/app/core/services/api.service";
+import { ModalService } from "src/app/core/services/modal.service";
+import { ToastService } from "src/app/core/services/toast.service";
 import { UserService } from "src/app/core/services/user.service";
 import { AvatarComponent } from "src/app/shared/components/avatar/avatar.component";
 import { CardContentComponent } from "src/app/shared/components/card-content/card-content.component";
@@ -13,8 +16,10 @@ import { PageContentComponent } from "src/app/shared/components/page-content/pag
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { GroupPipe } from "src/app/shared/pipes/group.pipe";
 import { MemberPipe } from "src/app/shared/pipes/member.pipe";
+import { SDK } from "src/sdk";
 import { AccountAppComponent } from "../components/account-app/account-app.component";
 import { AccountCredentialsComponent } from "../components/account-credentials/account-credentials.component";
+import { AccountEditModalComponent } from "../components/account-edit-modal/account-edit-modal.component";
 
 @Component({
 	selector: "bo-account",
@@ -24,6 +29,7 @@ import { AccountCredentialsComponent } from "../components/account-credentials/a
 		PageHeaderComponent,
 		PageContentComponent,
 		IonIcon,
+		IonButton,
 		AvatarComponent,
 		CardComponent,
 		CardHeaderComponent,
@@ -38,7 +44,27 @@ import { AccountCredentialsComponent } from "../components/account-credentials/a
 export class AccountComponent {
 	user = toSignal(this.userService.user);
 
-	constructor(private userService: UserService) {
-		addIcons({ mailOutline, peopleOutline });
+	constructor(
+		private userService: UserService,
+		private api: ApiService,
+		private modalService: ModalService,
+		private toastService: ToastService,
+	) {
+		addIcons({ mailOutline, peopleOutline, createOutline });
+	}
+
+	async editAccount() {
+		const user = this.user();
+		if (!user?._links.updateUser.allowed) return;
+
+		const data = await this.modalService.componentModal(AccountEditModalComponent, { user });
+
+		if (!data) return;
+
+		await this.api.UsersApi.updateUser(user.id, data satisfies SDK.UserUpdateBody);
+
+		this.toastService.toast("Uloženo.");
+
+		await this.userService.loadUser();
 	}
 }

--- a/frontend/src/styles/general.scss
+++ b/frontend/src/styles/general.scss
@@ -67,6 +67,11 @@ h3 {
 		color: var(--bo-green);
 	}
 
+	&.bo-pill-red {
+		background: var(--bo-red-tint);
+		color: var(--bo-red);
+	}
+
 	&.bo-pill-danger-dashed {
 		background: transparent;
 		border: 1px dashed var(--bo-red);
@@ -96,6 +101,46 @@ h3 {
 	p {
 		margin: 0.25rem 0 1rem;
 	}
+}
+
+/* card section title with a leading section icon (Můj účet & detail cards) */
+.bo-card-section-title {
+	display: flex;
+	align-items: center;
+	gap: 9px;
+
+	ion-icon {
+		font-size: 1.25rem;
+		color: var(--card-color, var(--bo-heading));
+		flex: 0 0 auto;
+	}
+}
+
+/* label / value rows inside a card, separated by a hairline divider */
+.bo-info-list {
+	display: flex;
+	flex-direction: column;
+}
+
+.bo-info-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 13px 20px;
+	border-top: 1px solid var(--bo-card-line);
+}
+
+.bo-info-label {
+	color: var(--bo-muted);
+	font-weight: 600;
+}
+
+.bo-info-value {
+	color: var(--bo-ink);
+	text-align: right;
+	min-width: 0;
+	word-break: break-word;
 }
 
 .clickable {

--- a/frontend/src/styles/variables.scss
+++ b/frontend/src/styles/variables.scss
@@ -80,6 +80,9 @@ body {
 	--bo-neutral-pill-text: #6b7185;
 	--bo-paper: #f6f7fb;
 
+	// subtle divider between rows inside a card (lighter than --bo-line)
+	--bo-card-line: #f0f2f7;
+
 	// semantic
 	--bo-heading: var(--bo-blue);
 	--bo-link: var(--bo-blue);
@@ -131,6 +134,8 @@ body.dark {
 	--bo-neutral-pill: #2a2d3a;
 	--bo-neutral-pill-text: #aab0c2;
 	--bo-paper: #16181f;
+
+	--bo-card-line: #23262f;
 
 	--bo-heading: #aeb7f0;
 	--bo-link: #aeb7f0;


### PR DESCRIPTION
# Změny

- Přepracován layout stránky "Můj účet" z jednoduchého seznamu na moderní design s kartami
- Přidána profilová hlavička s avatarem, jménem, rolemi a skupinou
- Reorganizovány sekce (Uživatelský účet, Člen skupiny, Přihlašování, Aplikace) do samostatných karet
- Přidána možnost inline editace e-mailu a rolí přímo ze stránky
- Vylepšen design komponenty "Přihlašování" s jasnějšími stavovými indikátory
- Vylepšen design komponenty "Aplikace" s lepší vizuální hierarchií
- Přidána nová komponenta `AccountEditModalComponent` pro editaci účtu (e-mail, role)
- Přidána metoda `multiSelectModal()` do `ModalService` pro výběr více hodnot
- Responsive design: na mobilu jednosloupcový layout, na desktopu dvousloupcový
- Přidány nové CSS třídy pro konzistentní styling informačních řádků (`.bo-info-list`, `.bo-info-row`, `.bo-info-label`, `.bo-info-value`)
- Přidána nová CSS proměnná `--bo-card-line` pro jemné dělící čáry v kartách
- Přidán nový styl `.bo-pill-red` pro červené pillule

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že …
   - Stránka "Můj účet" se zobrazuje s novou kartou profilové hlavičky s avatarem
   - Sekce jsou rozděleny do čtyř karet: Uživatelský účet, Člen skupiny, Přihlašování, Aplikace
   - Na desktopu (≥992px) se karty zobrazují ve dvou sloupcích
   - Na mobilu se karty zobrazují v jednom sloupci
   - Kliknutí na ikonu tužky u e-mailu otevře inline editor
   - Kliknutí na tlačítko "Upravit" u rolí otevře dialog pro výběr rolí
   - Komponenta "Přihlašování" zobrazuje stavové pillule (Zapnuto/Vypnuto) a tlačítka pro změnu
   - Komponenta "Aplikace" se zobrazuje s ikonou a textem podle stavu instalace

https://claude.ai/code/session_019yXHCBSxqV6tmTAeSY866V