### PR TITLE
perf(members): batch contact loading and aggregate age filter query

### DIFF
--- a/backend/src/api/members/controllers/members.controller.ts
+++ b/backend/src/api/members/controllers/members.controller.ts
@@ -49,6 +49,14 @@ export class MembersController {
 		return members;
 	}
 
+	@Get("ages")
+	@ApiResponse({ status: 200, type: Number, isArray: true })
+	async listMemberAges(@Req() req: Request): Promise<number[]> {
+		const where = MembersListPermission.canWhere(req, "members");
+
+		return this.members.getMemberAges(where);
+	}
+
 	@Post()
 	@AcLinks(MemberCreatePermission)
 	@ApiResponse({ status: 200, type: WithLinks(MemberResponse) })

--- a/backend/src/api/members/dto/member.dto.ts
+++ b/backend/src/api/members/dto/member.dto.ts
@@ -106,4 +106,9 @@ export class MembersListQuery extends PaginationQuery {
 	age?: number[];
 
 	@EnsureBoolean() @IsOptional() active?: boolean;
+
+	@ApiPropertyOptional({ type: "boolean" })
+	@EnsureBoolean()
+	@IsOptional()
+	contacts?: boolean;
 }

--- a/backend/src/models/members/repositories/members.repository.ts
+++ b/backend/src/models/members/repositories/members.repository.ts
@@ -12,6 +12,8 @@ export interface GetMembersOptions extends PaginationOptions {
 	membership?: string[];
 	age?: number[];
 	active?: boolean;
+	// eagerly load each member's contacts in the same query (avoids N+1 per-member fetches)
+	contacts?: boolean;
 }
 
 @Injectable()
@@ -29,6 +31,10 @@ export class MembersRepository {
 			.orderBy("CONCAT(members.nickname,members.first_name,members.last_name)", "ASC")
 			.take(options.limit)
 			.skip(options.offset);
+
+		// Join contacts up-front only when requested (i.e. the contacts column is visible).
+		// TypeORM keeps pagination correct with a distinct-id subquery despite the one-to-many join.
+		if (options.contacts) q.leftJoinAndSelect("members.contacts", "contacts");
 
 		if (options.groups) q.andWhere("members.groupId IN (:...groupIds)", { groupIds: options.groups });
 
@@ -53,6 +59,20 @@ export class MembersRepository {
 		if (options.active !== undefined) q.andWhere("members.active = :active", { active: options.active });
 
 		return q.getMany();
+	}
+
+	// Distinct ages across all members in a single query, so the age filter no longer
+	// needs to page through the entire members table client-side.
+	async getMemberAges(where: Brackets | string = "1=1"): Promise<number[]> {
+		const rows = await this.membersRepository
+			.createQueryBuilder("members")
+			.select("DISTINCT DATE_PART('year', AGE(CURRENT_DATE, members.birthday))::int", "age")
+			.where(where)
+			.andWhere("members.birthday IS NOT NULL")
+			.orderBy("age", "ASC")
+			.getRawMany<{ age: number }>();
+
+		return rows.map((row) => Number(row.age)).filter((age) => Number.isFinite(age));
 	}
 
 	async getMember(id: number, options?: FindOneOptions<Member>) {

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.ts
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.ts
@@ -212,32 +212,24 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 			groups: this.normalizeFilterValueToArray(filter["groups"]).map((group) => parseInt(group, 10)),
 			// default: active only; "all" reveals inactive members too
 			active: ((filter["active"] as string) || "active") === "all" ? undefined : true,
+			// Fetch contacts in the same request instead of one call per member,
+			// and only when a contact column is actually visible.
+			contacts: this.needsContacts() || undefined,
 		};
 
-		var members = await this.api.MembersApi.listMembers(params).then((res) => res.data);
+		const members = await this.api.MembersApi.listMembers(params).then((res) => res.data);
 
 		if (loadId !== this.latestLoadId) return;
 
-		if (this.view() == "table") {
-			console.log("Loading contacts for members in table view...");
-			members = await Promise.all(
-				members.map(async (member) => {
-					try {
-						const contacts = await this.api.MembersApi.listContacts(member.id).then((res) => res.data);
-
-						return { ...member, contacts: contacts };
-					} catch (error) {
-						console.error(`Failed to load contacts for member ${member.id}`, error);
-						return { ...member, contacts: [] }; // Fallback to empty array on failure
-					}
-				}),
-			);
-
-			if (loadId !== this.latestLoadId) return;
-		}
-
 		const currentMembers = this.members() || [];
 		this.members.set([...currentMembers, ...members]);
+	}
+
+	// Contacts are only needed when the phone/email columns are shown in the table view.
+	private needsContacts(): boolean {
+		if (this.view() !== "table") return false;
+		const selections = this.viewSelections();
+		return !!selections["firstTelephone"] || !!selections["firstEmail"];
 	}
 
 	private normalizeFilterValueToArray(value: string | string[] | null | undefined): string[] {
@@ -256,28 +248,11 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 	}
 
 	private async loadAllAges() {
-		let page = 1;
-		let allMembers: SDK.MemberResponseWithLinks[] = [];
+		// Single aggregated request instead of paging through the whole members table
+		// just to collect the distinct ages for the filter dropdown.
+		const ages = await this.api.MembersApi.listMemberAges().then((res) => res.data);
 
-		while (true) {
-			const members = await this.api.MembersApi.listMembers({
-				limit: this.pageSize,
-				offset: (page - 1) * this.pageSize,
-			}).then((res) => res.data);
-
-			allMembers = [...allMembers, ...members];
-
-			if (members.length < this.pageSize) break;
-			page++;
-		}
-
-		const ages = allMembers
-			.map((member) => member.birthday)
-			.filter((birthday): birthday is string => !!birthday)
-			.map((birthday) => Number(this.getAge(birthday)))
-			.filter((age) => Number.isFinite(age));
-
-		this.allMemberAges.set([...new Set(ages)].sort((a, b) => a - b));
+		this.allMemberAges.set([...new Set(ages)].filter((age) => Number.isFinite(age)).sort((a, b) => a - b));
 	}
 
 	async create() {
@@ -320,6 +295,14 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 
 	setViewSelection(key: string, value: boolean) {
 		this.viewSelections.update((selections) => ({ ...selections, [key]: value }));
+
+		// Enabling a contact column after the list was already loaded without contacts:
+		// re-fetch so the newly visible column has data (still a single request).
+		if (value && (key === "firstTelephone" || key === "firstEmail")) {
+			const members = this.members();
+			const contactsLoaded = !!members?.some((member) => member.contacts !== undefined);
+			if (!contactsLoaded) this.loadMembers(this.filter);
+		}
 	}
 
 	public getViewSelectionLabel(key: string): string {

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -6932,6 +6932,14 @@ export namespace SDK {
          * @memberof MembersApiListMembers
          */
         active?: boolean
+
+        //contacts
+        /**
+         *
+         * @type {boolean}
+         * @memberof MembersApiListMembers
+         */
+        contacts?: boolean
     }
     
     
@@ -7619,17 +7627,57 @@ export namespace SDK {
             if (queryParams.active !== undefined) {
                 requestQueryParameter['active'] = queryParams.active;
             }
-    
-    
-    
+
+            if (queryParams.contacts !== undefined) {
+                requestQueryParameter['contacts'] = queryParams.contacts;
+            }
+
+
+
             setSearchParams(requestUrlObj, requestQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             axiosRequestConfig.headers = {...requestHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-    
+
             axiosRequestConfig["url"] = toPathString(requestUrlObj);
             axiosRequestConfig["baseURL"] = this.configuration.basePath;
-            
+
             return this.axios.request<Array<MemberResponseWithLinks>>(axiosRequestConfig);
+        }
+
+        /**
+         *
+
+         * @param {AxiosRequestConfig} [options] Override http request option.
+         * @throws {RequiredError}
+         * @memberof MembersApi
+         */
+
+        public async listMemberAges(
+            options: AxiosRequestConfig = {}
+        ) {
+
+            const localVarPath = `/api/members/ages`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (this.configuration) {
+                baseOptions = this.configuration.baseOptions;
+            }
+
+            const axiosRequestConfig: AxiosRequestConfig = { method: 'GET', ...baseOptions, ...options};
+            const requestHeaderParameter = {} as any;
+            const requestQueryParameter = {} as any;
+
+
+
+            setSearchParams(requestUrlObj, requestQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            axiosRequestConfig.headers = {...requestHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            axiosRequestConfig["url"] = toPathString(requestUrlObj);
+            axiosRequestConfig["baseURL"] = this.configuration.basePath;
+
+            return this.axios.request<Array<number>>(axiosRequestConfig);
         }
     
         /**


### PR DESCRIPTION
# Změny

 - Členská databáze v tabulkovém zobrazení už nenačítá kontakty jedním requestem na člena (N+1). Kontakty se načítají společně se členy v jednom requestu, a to jen když je sloupec s telefonem/e‑mailem skutečně zobrazený.
 - Backend: nový volitelný parametr `contacts` u výpisu členů, který kontakty připojí přes `leftJoinAndSelect` v jednom dotazu.
 - Backend: nový endpoint `GET /members/ages` vracející unikátní věky jedním agregovaným SQL dotazem.
 - Frontend: filtr věku už neprochází celou databázi členů po stránkách (rostoucí offset) — místo toho se ptá nového agregovaného endpointu. Tím zmizí spousta zbytečných requestů na `members` i při zobrazení jen pár řádků (např. děti z jednoho oddílu).
 - SDK doplněno o parametr `contacts` a metodu `listMemberAges`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že v Členské databázi (tabulkové zobrazení):
    - Při načtení bez zobrazeného sloupce telefon/e‑mail se v Network záložce neděje žádný request na `/members/{id}/contacts`.
    - Po zapnutí sloupce „První telefon" nebo „První email" se seznam znovu načte a kontakty se zobrazí (přes jeden request na `/members`, ne na člena).
    - Otevření stránky nevyvolá dlouhou sérii requestů na `/members` s rostoucím offsetem — nabídka věků se načte jedním requestem na `/members/ages`.
    - Filtry (oddíl, role, členství, věk) i nekonečné scrollování fungují jako dřív.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyEofEBUHh623AdD9JAf4U)_