### PR TITLE
Responzivní admin-table (mobil = ion-list)

### DIFF
--- a/frontend/src/app/features/events/pages/events-list/events-list.component.html
+++ b/frontend/src/app/features/events/pages/events-list/events-list.component.html
@@ -32,131 +32,81 @@
 </bo-filter>
 
 <bo-page-content>
-	@switch (view()) {
-		@case ("list") {
-			<ion-list>
-				@if (events === undefined) {
-					<ion-item><ion-skeleton-text animated></ion-skeleton-text></ion-item>
-					<ion-item><ion-skeleton-text animated></ion-skeleton-text></ion-item>
-					<ion-item><ion-skeleton-text animated></ion-skeleton-text></ion-item>
-					<ion-item><ion-skeleton-text animated></ion-skeleton-text></ion-item>
-					<ion-item><ion-skeleton-text animated></ion-skeleton-text></ion-item>
+	<admin-table
+		[class]="'events-table'"
+		[rows]="events()"
+		[rowLink]="rowLink"
+		[rowId]="rowId"
+	>
+		<admin-table-column header="Název" [primary]="true" cellClass="events-name-column" headerClass="align-middle events-name-column">
+			<ng-container *adminCell="let event">{{ event.name }}</ng-container>
+		</admin-table-column>
+
+		<admin-table-column header="Datum" cellClass="events-date-column" headerClass="events-date-column align-middle">
+			<ng-container *adminCell="let event">
+				{{ event.dateFrom | date: "EEEEEE d. M." }} -
+				{{ event.dateTill | date: "EEEEEE d. M. y" }}
+			</ng-container>
+		</admin-table-column>
+
+		<!-- Stav is placed here so it keeps its column position in the desktop table, but is
+		     flagged [right] so it renders on the right of each item in the mobile list. -->
+		<admin-table-column header="Stav" [right]="true" cellClass="events-status-column" headerClass="events-status-column">
+			<ng-container *adminHeader>
+				<div class="column-filter">
+					<ion-select
+						label="Stav"
+						interface="popover"
+						justify="start"
+						[ngModel]="selectedStatuses()"
+						(ngModelChange)="setFilterParam('status', $event)"
+						[multiple]="true"
+					>
+						@for (status of statuses() | keyvalue; track status.key) {
+							<ion-select-option [value]="status.key">
+								{{ status.value.name }}
+							</ion-select-option>
+						}
+					</ion-select>
+				</div>
+			</ng-container>
+			<ng-container *adminCell="let event">
+				<bo-event-status-badge [event]="event"></bo-event-status-badge>
+			</ng-container>
+		</admin-table-column>
+
+		<admin-table-column header="Vedoucí" cellClass="events-leaders-column" headerClass="events-leaders-column">
+			<ng-container *adminHeader>
+				<div class="column-filter">
+					<ion-select
+						label="Vedoucí"
+						interface="popover"
+						justify="start"
+						[ngModel]="selectedLeaderFilters()"
+						(ngModelChange)="setFilterParam('leaders', $event)"
+						[multiple]="true"
+					>
+						<ion-select-option value="my">Moje akce</ion-select-option>
+						<ion-select-option value="noleader">Akce bez vedoucího</ion-select-option>
+					</ion-select>
+				</div>
+			</ng-container>
+			<ng-container *adminCell="let event">
+				@for (leader of event.leaders; track leader.id; let isLast = $last) {
+					<span class="leader"
+						><span
+							class="leader-avatar"
+							[style.background-color]="leader.groupId | group: 'color'"
+							>{{ (leader | member: "nickname")?.charAt(0) }}</span
+						>{{ leader | member: "nickname" }}{{ isLast ? "" : "," }}</span
+					>
 				}
-
-				@for (event of events(); track event.id) {
-					<ion-item [routerLink]="'' + event.id" [attr.id]="'event-' + event.id">
-						<ion-avatar
-							aria-hidden="true"
-							slot="start"
-							[style.background-color]="(event | event: 'color') || '#000'"
-						>
-							@if (event | event: "image") {
-								<img class="img-fluid" [src]="event | event: 'image'" />
-							}
-						</ion-avatar>
-						<ion-label>
-							<h3>{{ event.name }}</h3>
-							<p>
-								{{ event.dateFrom | date: "EEEEEE d. M." }} -
-								{{ event.dateTill | date: "EEEEEE d. M. y" }}
-								<br />
-								@for (leader of event.leaders; track leader.id; let isLast = $last) {
-									<span class="leader"
-										><span
-											class="leader-avatar"
-											[style.background-color]="leader.groupId | group: 'color'"
-											>{{ (leader | member: "nickname")?.charAt(0) }}</span
-										>{{ leader | member: "nickname" }}{{ isLast ? "" : "," }}</span
-									>
-								}
-								@if (!event.leaders?.length) {
-									<span class="bo-pill bo-pill-danger-dashed">Bez vedoucího</span>
-								}
-							</p>
-						</ion-label>
-
-						<bo-event-status-badge [event]="event"></bo-event-status-badge>
-					</ion-item>
+				@if (!event.leaders?.length) {
+					<span class="bo-pill bo-pill-danger-dashed">Bez vedoucího</span>
 				}
-			</ion-list>
-		}
-
-		@case ("table") {
-			<admin-table [class]="'events-table'">
-				<thead>
-					<tr >
-						<th class="align-middle events-name-column" >Název</th>					
-						<th class="events-date-column align-middle">Datum</th>
-						<th class="events-status-column">
-							<div class="column-filter">
-								<ion-select
-									label ="Stav"
-									interface="popover"
-									justify="start"
-									[ngModel]="selectedStatuses()"
-									(ngModelChange)="setFilterParam('status', $event)"
-									[multiple]="true"
-
-								>
-									@for (status of statuses() | keyvalue; track status.key) {
-										<ion-select-option [value]="status.key">
-											{{ status.value.name }}
-										</ion-select-option>
-									}
-								</ion-select>
-							</div>
-						</th>
-						<th class="events-leaders-column">
-							<div class="column-filter">
-								<ion-select
-									label="Vedoucí"
-									interface="popover"
-									justify="start"
-									[ngModel]="selectedLeaderFilters()"
-									(ngModelChange)="setFilterParam('leaders', $event)"
-									[multiple]="true"
-
-								>
-									<ion-select-option value="my">Moje akce</ion-select-option>
-									<ion-select-option value="noleader">Akce bez vedoucího</ion-select-option>
-
-								</ion-select>
-							</div>
-						</th>					 
-					</tr>
-				</thead>
-
-				<tbody>
-					@for (event of events(); track event.id) {
-						<tr [routerLink]="'' + event.id" [attr.id]="'event-' + event.id">
-							<td class="events-name-column">{{ event.name }}</td>
-							<td class="events-date-column">
-								{{ event.dateFrom | date: "EEEEEE d. M." }} -
-								{{ event.dateTill | date: "EEEEEE d. M. y" }}
-							</td>
-							<td class="events-status-column">
-								<bo-event-status-badge [event]="event"></bo-event-status-badge>
-							</td>
-							<td class="events-leaders-column">
-								@for (leader of event.leaders; track leader.id; let isLast = $last) {
-									<span class="leader"
-										><span
-											class="leader-avatar"
-											[style.background-color]="leader.groupId | group: 'color'"
-											>{{ (leader | member: "nickname")?.charAt(0) }}</span
-										>{{ leader | member: "nickname" }}{{ isLast ? "" : "," }}</span
-									>
-								}
-								@if (!event.leaders?.length) {
-									<span class="bo-pill bo-pill-danger-dashed">Bez vedoucího</span>
-								}
-							</td>
-						</tr>
-					}
-				</tbody>
-			</admin-table>
-		}
-	}
+			</ng-container>
+		</admin-table-column>
+	</admin-table>
 
 	<ion-infinite-scroll (ionInfinite)="onInfiniteScroll($any($event))">
 		<ion-infinite-scroll-content></ion-infinite-scroll-content>

--- a/frontend/src/app/features/events/pages/events-list/events-list.component.ts
+++ b/frontend/src/app/features/events/pages/events-list/events-list.component.ts
@@ -1,18 +1,13 @@
 import { CommonModule } from "@angular/common";
 import { afterNextRender, Component, computed, Injector, OnInit, signal } from "@angular/core";
 import { FormsModule } from "@angular/forms";
-import { ActivatedRoute, Params, Router, RouterLink } from "@angular/router";
+import { ActivatedRoute, Params, Router } from "@angular/router";
 import {
 	InfiniteScrollCustomEvent,
-	IonAvatar,
 	IonInfiniteScroll,
 	IonInfiniteScrollContent,
-	IonItem,
-	IonLabel,
-	IonList,
 	IonSelect,
 	IonSelectOption,
-	IonSkeletonText,
 } from "@ionic/angular/standalone";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { addIcons } from "ionicons";
@@ -21,9 +16,11 @@ import { DateTime } from "luxon";
 import { EventStatus, EventStatusID, EventStatuses } from "src/app/core/config/event-statuses";
 import { ApiService } from "src/app/core/services/api.service";
 import { ModalService } from "src/app/core/services/modal.service";
-import { PlatformService } from "src/app/core/services/platform.service";
 import { ToastService } from "src/app/core/services/toast.service";
 import { Action } from "src/app/shared/components/action-buttons/action-buttons.component";
+import { AdminTableCellDirective } from "src/app/shared/components/admin-table/admin-table-cell.directive";
+import { AdminTableColumnComponent } from "src/app/shared/components/admin-table/admin-table-column.component";
+import { AdminTableHeaderDirective } from "src/app/shared/components/admin-table/admin-table-header.directive";
 import { AdminTableComponent } from "src/app/shared/components/admin-table/admin-table.component";
 import { EventStatusBadgeComponent } from "src/app/shared/components/event-status-badge/event-status-badge.component";
 import { FilterPillComponent, FilterPillOption } from "src/app/shared/components/filter-pill/filter-pill.component";
@@ -32,7 +29,6 @@ import { PageContentComponent } from "src/app/shared/components/page-content/pag
 import { PageHeaderComponent } from "src/app/shared/components/page-header/page-header.component";
 import { UrlParams } from "src/helpers/typings";
 import { SDK } from "src/sdk";
-import { EventPipe } from "../../../../shared/pipes/event.pipe";
 import { GroupPipe } from "../../../../shared/pipes/group.pipe";
 import { MemberPipe } from "../../../../shared/pipes/member.pipe";
 import { EventCreateModalComponent } from "../../components/event-create-modal/event-create-modal.component";
@@ -45,13 +41,7 @@ import { EventCreateModalComponent } from "../../components/event-create-modal/e
 
 	imports: [
 		CommonModule,
-		RouterLink,
 		FormsModule,
-		IonList,
-		IonItem,
-		IonSkeletonText,
-		IonLabel,
-		IonAvatar,
 		IonInfiniteScroll,
 		IonInfiniteScrollContent,
 		IonSelect,
@@ -60,7 +50,9 @@ import { EventCreateModalComponent } from "../../components/event-create-modal/e
 		GroupPipe,
 		MemberPipe,
 		AdminTableComponent,
-		EventPipe,
+		AdminTableColumnComponent,
+		AdminTableCellDirective,
+		AdminTableHeaderDirective,
 		PageContentComponent,
 		PageHeaderComponent,
 		FilterComponent,
@@ -109,11 +101,12 @@ export class EventsListComponent implements OnInit {
 
 	filter: UrlParams = {};
 
-	view = signal<"table" | "list" | undefined>(undefined);
+	// Row helpers for admin-table (bound as inputs, so keep stable references).
+	rowLink = (event: SDK.EventResponseWithLinks) => "" + event.id;
+	rowId = (event: SDK.EventResponseWithLinks) => "event-" + event.id;
 
 	constructor(
 		private api: ApiService,
-		private platformService: PlatformService,
 		private router: Router,
 		private route: ActivatedRoute,
 		private injector: Injector,
@@ -136,10 +129,6 @@ export class EventsListComponent implements OnInit {
 	ngOnInit(): void {
 		this.loadYears();
 		this.loadStatuses();
-
-		this.platformService.isPortrait.subscribe((isPortrait: boolean) => {
-			this.view.set(isPortrait ? "list" : "table");
-		});
 
 		// All filter state (year/status/search/leaders) is written to the URL, so drive loading
 		// from the query params directly rather than the FilterComponent's `(change)` output

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.html
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.html
@@ -121,183 +121,131 @@
 
 
 <ion-content>
-	@switch (view()) {
-		@case ("list") {
-			<ion-list>
-				@if (members() === undefined) {
-					@for (item of loadingItems; track $index) {
-						<ion-item>
-							<ion-label><ion-skeleton-text></ion-skeleton-text></ion-label>
-						</ion-item>
-					}
-				}
-
-				@for (member of members(); track member.id) {
-					<ion-item class="clickable" [class.member-inactive]="!member.active" [routerLink]="'' + member.id">
-						<ion-label>
-							<h2>{{ member.nickname || member.firstName || member.lastName }}</h2>
-							<p>
-								<span [style.color]="member.groupId | group: 'color'">{{
-									member.groupId | group: "name"
-								}}</span
-								>,
-								<span>{{ member | member: "age" }}</span>
-							</p>
-						</ion-label>
-					</ion-item>
-				}
-			</ion-list>
+	<admin-table
+		[class]="'members-table'"
+		[rows]="members()"
+		[loading]="members() === undefined"
+		[rowLink]="rowLink"
+		[rowClass]="rowClass"
+	>
+		@if (viewSelections().nickname) {
+			<admin-table-column header="Přezdívka" [primary]="true" headerClass="align-middle members-nickname-column">
+				<ng-container *adminCell="let member">{{ member.nickname }}</ng-container>
+			</admin-table-column>
 		}
-		@case ("table") {
-			<admin-table [class]="'members-table'">
-				<thead>
-					<tr>
-						@if (viewSelections().nickname){
-							<th class="align-middle members-nickname-column" >Přezdívka</th>					
-						}
-						@if (viewSelections().name){
-							<th class="align-middle members-name-column" >Jméno</th>					
-						}
-						@if (viewSelections().group){
-							<th class="align-middle">Oddíl</th>
-						}
 
-						@if (viewSelections().role){
-							<th class="align-middle">Role</th>
-						}
-
-						@if (viewSelections().age){
-							<th>
-								<div class="column-filter">
-									<ion-select
-										label="Věk"
-										interface="popover"
-										justify="start"
-										[ngModel]="selectedAges()"
-										(ngModelChange)="setFilterParam('age', $event)"
-										[multiple]="true"
-									>
-										@for (age of availableAges; track age) {
-											<ion-select-option [value]="'' + age">{{ age }}</ion-select-option>
-										}
-									</ion-select>
-								</div>
-							</th>
-						}
-
-						@if (viewSelections().membership){
-							<th>
-								<div class="column-filter">
-									<ion-select
-										label="Členství"
-										interface="popover"
-										justify="start"
-										[ngModel]="selectedMembership()"
-										(ngModelChange)="setFilterParam('membership', $event)"
-										[multiple]="true"
-									>
-										@for (state of membershipStates | keyvalue; track state.key) {
-											<ion-select-option [value]="state.key">
-												{{ state.value.title }}
-											</ion-select-option>
-										}
-									</ion-select>
-								</div>
-							</th>					
-						}
-						@if (viewSelections().birthday){
-							<th class="align-middle events-name-column" >Datum narození</th>					
-						}
-						@if (viewSelections().addressCity){
-							<th class="align-middle events-name-column" >Město</th>					
-						}
-						@if (viewSelections().addressStreet){
-							<th class="align-middle events-name-column" >Ulice</th>					
-						}
-						@if (viewSelections().firstTelephone){
-							<th class="align-middle events-name-column" >Telefon</th>					
-						}
-						@if (viewSelections().firstEmail){
-							<th class="align-middle events-name-column" >E-mail</th>
-						}
-
-						@if (viewSelections().status){
-							<th class="align-middle members-status-column">Stav</th>
-						}
-
-					</tr>
-				</thead>
-				<tbody>
-					@if (members()) {
-						@for (member of members()!; track member.id) {
-							<tr
-								class="clickable"
-								[routerLink]="'' + member.id"
-								[class.member-inactive]="!member.active"
-								[class.member-paused]="member.membership === 'pozastaveno'"
-							>
-								@if (viewSelections().nickname){
-									<td>{{ member.nickname }}</td>
-								}
-
-								@if (viewSelections().name){
-									<td>{{ member.firstName }} {{ member.lastName }}</td>
-								}
-
-								@if (viewSelections().group){
-									<td>
-										<bo-group-badge [groupId]="member.groupId"></bo-group-badge>
-									</td>
-								}
-								@if (viewSelections().role){
-									<td>{{ member | member: "role" }}</td>
-								}
-
-								@if (viewSelections().age){
-									<td>{{ member | member: "age" }}</td>
-								}
-
-								@if (viewSelections().membership){
-									<td>{{ member | member: "membership" }}</td>
-								}
-
-								@if (viewSelections().birthday){
-									<td>{{ member.birthday ? (member.birthday | date: "d. M. y") : "" }}</td>
-								}
-								
-								@if (viewSelections().addressCity) {
-								<td> {{ member.addressCity}} </td>
-								}
-
-								@if (viewSelections().addressStreet) {
-								<td> {{ member.addressStreet}} </td>
-								}
-								
-								@if (viewSelections().firstTelephone) {
-								<td> <strong> {{ member.contacts?.[0]?.relationship || "" }} </strong> {{ member.contacts?.[0]?.mobile || "" }} </td>							
-								}
-
-								@if (viewSelections().firstEmail) {
-								<td> <strong> {{ member.contacts?.[0]?.relationship || "" }} </strong> {{ member.contacts?.[0]?.email || "" }} </td>
-								}
-
-								@if (viewSelections().status){
-									<td class="members-status-column">
-										@if (member.active) {
-											<span class="bo-pill bo-pill-green">AKTIVNÍ</span>
-										} @else {
-											<span class="bo-pill">NEAKTIVNÍ</span>
-										}
-									</td>
-								}
-
-							</tr>
-						}
-					}
-				</tbody>
-			</admin-table>
+		@if (viewSelections().name) {
+			<admin-table-column header="Jméno" headerClass="align-middle members-name-column">
+				<ng-container *adminCell="let member">{{ member.firstName }} {{ member.lastName }}</ng-container>
+			</admin-table-column>
 		}
-	}
+
+		@if (viewSelections().group) {
+			<admin-table-column header="Oddíl" headerClass="align-middle">
+				<ng-container *adminCell="let member">
+					<bo-group-badge [groupId]="member.groupId"></bo-group-badge>
+				</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().role) {
+			<admin-table-column header="Role" headerClass="align-middle">
+				<ng-container *adminCell="let member">{{ member | member: "role" }}</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().age) {
+			<admin-table-column header="Věk">
+				<ng-container *adminHeader>
+					<div class="column-filter">
+						<ion-select
+							label="Věk"
+							interface="popover"
+							justify="start"
+							[ngModel]="selectedAges()"
+							(ngModelChange)="setFilterParam('age', $event)"
+							[multiple]="true"
+						>
+							@for (age of availableAges; track age) {
+								<ion-select-option [value]="'' + age">{{ age }}</ion-select-option>
+							}
+						</ion-select>
+					</div>
+				</ng-container>
+				<ng-container *adminCell="let member">{{ member | member: "age" }}</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().membership) {
+			<admin-table-column header="Členství">
+				<ng-container *adminHeader>
+					<div class="column-filter">
+						<ion-select
+							label="Členství"
+							interface="popover"
+							justify="start"
+							[ngModel]="selectedMembership()"
+							(ngModelChange)="setFilterParam('membership', $event)"
+							[multiple]="true"
+						>
+							@for (state of membershipStates | keyvalue; track state.key) {
+								<ion-select-option [value]="state.key">
+									{{ state.value.title }}
+								</ion-select-option>
+							}
+						</ion-select>
+					</div>
+				</ng-container>
+				<ng-container *adminCell="let member">{{ member | member: "membership" }}</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().birthday) {
+			<admin-table-column header="Datum narození" headerClass="align-middle">
+				<ng-container *adminCell="let member">{{ member.birthday ? (member.birthday | date: "d. M. y") : "" }}</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().addressCity) {
+			<admin-table-column header="Město" headerClass="align-middle">
+				<ng-container *adminCell="let member">{{ member.addressCity }}</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().addressStreet) {
+			<admin-table-column header="Ulice" headerClass="align-middle">
+				<ng-container *adminCell="let member">{{ member.addressStreet }}</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().firstTelephone) {
+			<admin-table-column header="Telefon" headerClass="align-middle">
+				<ng-container *adminCell="let member">
+					<strong>{{ member.contacts?.[0]?.relationship || "" }}</strong> {{ member.contacts?.[0]?.mobile || "" }}
+				</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().firstEmail) {
+			<admin-table-column header="E-mail" headerClass="align-middle">
+				<ng-container *adminCell="let member">
+					<strong>{{ member.contacts?.[0]?.relationship || "" }}</strong> {{ member.contacts?.[0]?.email || "" }}
+				</ng-container>
+			</admin-table-column>
+		}
+
+		@if (viewSelections().status) {
+			<admin-table-column header="Stav" [right]="true" cellClass="members-status-column" headerClass="align-middle members-status-column">
+				<ng-container *adminCell="let member">
+					@if (member.active) {
+						<span class="bo-pill bo-pill-green">AKTIVNÍ</span>
+					} @else {
+						<span class="bo-pill">NEAKTIVNÍ</span>
+					}
+				</ng-container>
+			</admin-table-column>
+		}
+	</admin-table>
 
 	@if (members()?.length) {
 		<p class="ion-padding members-active-toggle">

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.scss
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.scss
@@ -1,15 +1,13 @@
-.member {
-	cursor: pointer;
-}
-
-.member-inactive {
+// Row-state classes are applied by admin-table (rows live in its view), so pierce
+// encapsulation with ::ng-deep to reach them from this page's stylesheet.
+:host ::ng-deep .member-inactive {
 	color: var(--bo-muted);
 	opacity: 0.65;
 }
-ion-item.member-inactive {
+:host ::ng-deep ion-item.member-inactive {
 	--color: var(--bo-muted);
 }
-tr.member-paused {
+:host ::ng-deep tr.member-paused {
 	color: var(--bo-muted);
 }
 

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.ts
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.ts
@@ -12,12 +12,10 @@ import {
 	IonInfiniteScrollContent,
 	IonItem,
 	IonItemDivider,
-	IonLabel,
 	IonList,
 	IonPopover,
 	IonSelect,
 	IonSelectOption,
-	IonSkeletonText,
 	IonToggle,
 	ViewWillEnter,
 } from "@ionic/angular/standalone";
@@ -38,9 +36,11 @@ import { DateTime } from "luxon";
 import { MemberRoles } from "src/app/core/config/member-roles";
 import { ApiService } from "src/app/core/services/api.service";
 import { ModalService } from "src/app/core/services/modal.service";
-import { PlatformService } from "src/app/core/services/platform.service";
 import { ToastService } from "src/app/core/services/toast.service";
 import { Action } from "src/app/shared/components/action-buttons/action-buttons.component";
+import { AdminTableCellDirective } from "src/app/shared/components/admin-table/admin-table-cell.directive";
+import { AdminTableColumnComponent } from "src/app/shared/components/admin-table/admin-table-column.component";
+import { AdminTableHeaderDirective } from "src/app/shared/components/admin-table/admin-table-header.directive";
 import { AdminTableComponent } from "src/app/shared/components/admin-table/admin-table.component";
 import { FilterPillComponent, FilterPillOption } from "src/app/shared/components/filter-pill/filter-pill.component";
 import { FilterComponent, FilterData } from "src/app/shared/components/filter/filter.component";
@@ -65,8 +65,6 @@ import { MemberCreateModalComponent } from "../../components/member-create-modal
 		IonList,
 		IonItem,
 		IonItemDivider,
-		IonLabel,
-		IonSkeletonText,
 		IonSelect,
 		IonSelectOption,
 		IonButton,
@@ -75,10 +73,12 @@ import { MemberCreateModalComponent } from "../../components/member-create-modal
 		IonToggle,
 		IonIcon,
 		AdminTableComponent,
+		AdminTableColumnComponent,
+		AdminTableCellDirective,
+		AdminTableHeaderDirective,
 		FormsModule,
 		RouterLink,
 		KeyValuePipe,
-		GroupPipe,
 		MemberPipe,
 		GroupBadgeComponent,
 		IonInfiniteScroll,
@@ -117,7 +117,12 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 		label: role.title,
 	}));
 
-	loadingItems = new Array(10).fill(null);
+	// Row helpers for admin-table (bound as inputs, so keep stable references).
+	rowLink = (member: SDK.MemberResponseWithLinks) => "" + member.id;
+	rowClass = (member: SDK.MemberResponseWithLinks) => ({
+		"member-inactive": !member.active,
+		"member-paused": member.membership === "pozastaveno",
+	});
 
 	actions = signal<Action[]>([
 		{
@@ -136,9 +141,6 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 
 	filter: FilterData = {};
 
-
-	view = signal<"table" | "list" | undefined>(undefined);
-
 	page = 1;
 	pageSize = 50;
 
@@ -151,7 +153,6 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 		private route: ActivatedRoute,
 		private router: Router,
 		private toasts: ToastService,
-		private platformService: PlatformService,
 		private modalService: ModalService,
 		private groupPipe: GroupPipe,
 	) {
@@ -170,10 +171,6 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 	}
 
 	ngAfterViewInit(): void {
-		this.platformService.isPortrait.subscribe((isPortrait) => {
-			this.view.set(isPortrait ? "list" : "table");
-		});
-
 		this.loadViewSelections();
 	}
 
@@ -286,9 +283,8 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 		this.members.set([...currentMembers, ...members]);
 	}
 
-	// Contacts are only needed when the phone/email columns are shown in the table view.
+	// Contacts are only needed when the phone/email columns are shown.
 	private needsContacts(): boolean {
-		if (this.view() !== "table") return false;
 		const selections = this.viewSelections();
 		return !!selections["firstTelephone"] || !!selections["firstEmail"];
 	}

--- a/frontend/src/app/shared/components/admin-table/admin-table-actions.component.ts
+++ b/frontend/src/app/shared/components/admin-table/admin-table-actions.component.ts
@@ -14,17 +14,19 @@ import { PlatformService } from "src/app/core/services/platform.service";
 import { Action } from "../action-buttons/action-buttons.component";
 
 /**
- * Trailing three-dots menu cell for `admin-table` rows. Drop it in as the last
- * `<td>` of a row and pass the row's applicable `actions`; it swallows the click
- * so a row-level `routerLink` doesn't fire. On desktop it opens a dropdown
- * popover, on mobile a native ActionSheet.
+ * Trailing three-dots menu for `admin-table` rows. `admin-table` renders it
+ * automatically (as a trailing `<td>` on desktop and inside the item on mobile)
+ * when given an `[actions]` callback, so both views expose the same row actions.
+ * The attribute selector lets it host on any element (`<td>` or a `<div>`). It
+ * swallows the click so a row-level `routerLink` doesn't fire; on desktop it
+ * opens a dropdown popover, on mobile a native ActionSheet.
  *
  * ```html
  * <td admin-table-actions [actions]="rowActions(item)" [header]="item.name"></td>
  * ```
  */
 @Component({
-	selector: "td[admin-table-actions]",
+	selector: "[admin-table-actions]",
 	template: `
 		@if (visibleActions().length) {
 			<ion-button fill="clear" size="small" (click)="openActions($event)">

--- a/frontend/src/app/shared/components/admin-table/admin-table-cell.directive.ts
+++ b/frontend/src/app/shared/components/admin-table/admin-table-cell.directive.ts
@@ -1,0 +1,20 @@
+import { Directive, TemplateRef } from "@angular/core";
+
+/**
+ * Marks the template that renders a column's cell. The row is exposed as the
+ * implicit context, so consumers write `<ng-container *adminCell="let row">`.
+ */
+@Directive({
+	selector: "[adminCell]",
+})
+export class AdminTableCellDirective {
+	constructor(public readonly template: TemplateRef<{ $implicit: any }>) {}
+
+	// Lets the template's `let row` be typed instead of falling back to `any`-only.
+	static ngTemplateContextGuard(
+		_dir: AdminTableCellDirective,
+		_ctx: unknown,
+	): _ctx is { $implicit: any } {
+		return true;
+	}
+}

--- a/frontend/src/app/shared/components/admin-table/admin-table-column.component.ts
+++ b/frontend/src/app/shared/components/admin-table/admin-table-column.component.ts
@@ -1,0 +1,44 @@
+import { Component, computed, contentChild, input } from "@angular/core";
+import { AdminTableCellDirective } from "./admin-table-cell.directive";
+import { AdminTableHeaderDirective } from "./admin-table-header.directive";
+
+/**
+ * Declares one column of an `admin-table`. Renders nothing on its own — it is a
+ * configuration holder that the parent `admin-table` reads via a content query.
+ *
+ * Usage:
+ * ```html
+ * <admin-table-column header="Název" [primary]="true">
+ *   <ng-container *adminCell="let row">{{ row.name }}</ng-container>
+ * </admin-table-column>
+ * ```
+ */
+@Component({
+	selector: "admin-table-column",
+	template: "",
+})
+export class AdminTableColumnComponent {
+	/** Header text; also used as the line label in the mobile list view. */
+	header = input<string>("");
+
+	/** On mobile, render this column on the right (`slot="end"`) instead of as a line. */
+	right = input<boolean>(false);
+
+	/** On mobile, render this column as the item title (`<h3>`, no label) instead of a labelled line. */
+	primary = input<boolean>(false);
+
+	/** On mobile, suppress the `header:` label prefix for this line. */
+	hideMobileLabel = input<boolean>(false);
+
+	/** Extra class(es) applied to the `<td>` in table view. */
+	cellClass = input<string>("");
+
+	/** Extra class(es) applied to the `<th>` in table view. */
+	headerClass = input<string>("");
+
+	private readonly cellDef = contentChild(AdminTableCellDirective);
+	private readonly headerDef = contentChild(AdminTableHeaderDirective);
+
+	readonly cellTemplate = computed(() => this.cellDef()?.template ?? null);
+	readonly headerTemplate = computed(() => this.headerDef()?.template ?? null);
+}

--- a/frontend/src/app/shared/components/admin-table/admin-table-header.directive.ts
+++ b/frontend/src/app/shared/components/admin-table/admin-table-header.directive.ts
@@ -1,0 +1,12 @@
+import { Directive, TemplateRef } from "@angular/core";
+
+/**
+ * Optional custom header content for a column (e.g. an inline filter select).
+ * When omitted, the column falls back to its plain `header` text input.
+ */
+@Directive({
+	selector: "[adminHeader]",
+})
+export class AdminTableHeaderDirective {
+	constructor(public readonly template: TemplateRef<unknown>) {}
+}

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.html
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.html
@@ -13,6 +13,9 @@
 								}
 							</th>
 						}
+						@if (actions()) {
+							<th class="admin-table-actions-column" aria-label="Akce"></th>
+						}
 					</tr>
 				</thead>
 
@@ -22,6 +25,9 @@
 							<tr>
 								@for (column of columns(); track column) {
 									<td><ion-skeleton-text animated></ion-skeleton-text></td>
+								}
+								@if (actions()) {
+									<td class="admin-table-actions-column"></td>
 								}
 							</tr>
 						}
@@ -41,6 +47,14 @@
 											[ngTemplateOutletContext]="{ $implicit: row }"
 										></ng-container>
 									</td>
+								}
+								@if (actions()) {
+									<td
+										class="admin-table-actions-column"
+										admin-table-actions
+										[actions]="resolveActions(row)"
+										[header]="resolveActionsHeader(row)"
+									></td>
 								}
 							</tr>
 						}
@@ -90,12 +104,21 @@
 							}
 						</ion-label>
 
-						@if (rightColumn(); as rightColumn) {
+						@if (rightColumn() || actions()) {
 							<div slot="end" class="admin-table-end">
-								<ng-container
-									[ngTemplateOutlet]="rightColumn.cellTemplate()"
-									[ngTemplateOutletContext]="{ $implicit: row }"
-								></ng-container>
+								@if (rightColumn(); as rightColumn) {
+									<ng-container
+										[ngTemplateOutlet]="rightColumn.cellTemplate()"
+										[ngTemplateOutletContext]="{ $implicit: row }"
+									></ng-container>
+								}
+								@if (actions()) {
+									<div
+										admin-table-actions
+										[actions]="resolveActions(row)"
+										[header]="resolveActionsHeader(row)"
+									></div>
+								}
 							</div>
 						}
 					</ion-item>

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.html
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.html
@@ -1,5 +1,113 @@
-<div class="table-responsive">
-	<table [class]="tableClass()">
-		<ng-content></ng-content>
-	</table>
-</div>
+@if (columns().length) {
+	@if (mode() === "table") {
+		<div class="table-responsive">
+			<table [class]="tableClass()">
+				<thead>
+					<tr>
+						@for (column of columns(); track column) {
+							<th [class]="column.headerClass()">
+								@if (column.headerTemplate(); as headerTemplate) {
+									<ng-container [ngTemplateOutlet]="headerTemplate"></ng-container>
+								} @else {
+									{{ column.header() }}
+								}
+							</th>
+						}
+					</tr>
+				</thead>
+
+				<tbody>
+					@if (loading()) {
+						@for (skeleton of skeletonArray(); track $index) {
+							<tr>
+								@for (column of columns(); track column) {
+									<td><ion-skeleton-text animated></ion-skeleton-text></td>
+								}
+							</tr>
+						}
+					} @else {
+						@for (row of rows() ?? []; track trackRow($index, row)) {
+							<tr
+								[attr.id]="resolveId(row)"
+								[ngClass]="resolveClass(row)"
+								[class.clickable]="!!rowLink()"
+								[routerLink]="resolveLink(row)"
+								(click)="onRowClick(row)"
+							>
+								@for (column of columns(); track column) {
+									<td [class]="column.cellClass()">
+										<ng-container
+											[ngTemplateOutlet]="column.cellTemplate()"
+											[ngTemplateOutletContext]="{ $implicit: row }"
+										></ng-container>
+									</td>
+								}
+							</tr>
+						}
+					}
+				</tbody>
+			</table>
+		</div>
+	} @else {
+		<ion-list>
+			@if (loading()) {
+				@for (skeleton of skeletonArray(); track $index) {
+					<ion-item>
+						<ion-label><ion-skeleton-text animated></ion-skeleton-text></ion-label>
+					</ion-item>
+				}
+			} @else {
+				@for (row of rows() ?? []; track trackRow($index, row)) {
+					<ion-item
+						[attr.id]="resolveId(row)"
+						[ngClass]="resolveClass(row)"
+						[class.clickable]="!!rowLink()"
+						[routerLink]="resolveLink(row)"
+						(click)="onRowClick(row)"
+					>
+						<ion-label>
+							@for (column of lineColumns(); track column) {
+								@if (column.primary()) {
+									<h3>
+										<ng-container
+											[ngTemplateOutlet]="column.cellTemplate()"
+											[ngTemplateOutletContext]="{ $implicit: row }"
+										></ng-container>
+									</h3>
+								} @else {
+									<p class="admin-table-line">
+										@if (column.header() && !column.hideMobileLabel()) {
+											<span class="admin-table-line-label">{{ column.header() }}:</span>
+										}
+										<span class="admin-table-line-value">
+											<ng-container
+												[ngTemplateOutlet]="column.cellTemplate()"
+												[ngTemplateOutletContext]="{ $implicit: row }"
+											></ng-container>
+										</span>
+									</p>
+								}
+							}
+						</ion-label>
+
+						@if (rightColumn(); as rightColumn) {
+							<div slot="end" class="admin-table-end">
+								<ng-container
+									[ngTemplateOutlet]="rightColumn.cellTemplate()"
+									[ngTemplateOutletContext]="{ $implicit: row }"
+								></ng-container>
+							</div>
+						}
+					</ion-item>
+				}
+			}
+		</ion-list>
+	}
+} @else {
+	<!-- Legacy API: no declarative columns, project raw <thead>/<tbody> markup (table only). -->
+	<div class="table-responsive">
+		<table [class]="tableClass()">
+			<ng-content></ng-content>
+		</table>
+	</div>
+}

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.scss
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.scss
@@ -67,9 +67,21 @@ table.table {
 	}
 }
 
+// trailing actions column stays compact and centered
+.admin-table-actions-column {
+	width: 1%;
+	white-space: nowrap;
+	text-align: center;
+}
+
 // mobile list view — each column becomes a line; the [right] column sits at slot="end"
 ion-item.clickable {
 	cursor: pointer;
+}
+
+// keep the right-slot content (right column + actions menu) on one row
+.admin-table-end {
+	gap: 0.25rem;
 }
 
 .admin-table-line {

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.scss
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.scss
@@ -66,3 +66,24 @@ table.table {
 		}
 	}
 }
+
+// mobile list view — each column becomes a line; the [right] column sits at slot="end"
+ion-item.clickable {
+	cursor: pointer;
+}
+
+.admin-table-line {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35em;
+}
+
+.admin-table-line-label {
+	color: var(--bo-muted);
+	font-weight: 600;
+}
+
+.admin-table-end {
+	display: flex;
+	align-items: center;
+}

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.ts
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.ts
@@ -4,6 +4,8 @@ import { RouterLink } from "@angular/router";
 import { IonItem, IonLabel, IonList, IonSkeletonText } from "@ionic/angular/standalone";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { PlatformService } from "src/app/core/services/platform.service";
+import { Action } from "../action-buttons/action-buttons.component";
+import { AdminTableActionsComponent } from "./admin-table-actions.component";
 import { AdminTableColumnComponent } from "./admin-table-column.component";
 
 export type AdminTableDisplay = "auto" | "table" | "list";
@@ -26,7 +28,15 @@ type RowFn<T> = ((row: any) => T) | null;
 	selector: "admin-table",
 	templateUrl: "./admin-table.component.html",
 	styleUrls: ["./admin-table.component.scss"],
-	imports: [CommonModule, RouterLink, IonList, IonItem, IonLabel, IonSkeletonText],
+	imports: [
+		CommonModule,
+		RouterLink,
+		IonList,
+		IonItem,
+		IonLabel,
+		IonSkeletonText,
+		AdminTableActionsComponent,
+	],
 })
 export class AdminTableComponent {
 	defaultTableClass = "table table-hover";
@@ -56,6 +66,16 @@ export class AdminTableComponent {
 
 	/** Number of skeleton rows to show while `loading`. */
 	skeletonRows = input<number>(5);
+
+	/**
+	 * `(row) => Action[]` — per-row three-dots menu. Rendered as a trailing cell in
+	 * table mode and inside the item (right side) in list mode, so the actions are
+	 * available on both desktop and mobile.
+	 */
+	actions = input<((row: any) => Action[]) | null>(null);
+
+	/** `(row) => header` — title shown above the actions on the mobile ActionSheet. */
+	actionsHeader = input<((row: any) => string | null | undefined) | null>(null);
 
 	rowClick = output<any>();
 
@@ -98,6 +118,14 @@ export class AdminTableComponent {
 
 	resolveClass(row: any) {
 		return this.rowClass()?.(row) ?? null;
+	}
+
+	resolveActions(row: any) {
+		return this.actions()?.(row) ?? [];
+	}
+
+	resolveActionsHeader(row: any) {
+		return this.actionsHeader()?.(row) ?? null;
 	}
 
 	onRowClick(row: any) {

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.ts
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.ts
@@ -1,14 +1,106 @@
-import { Component, computed, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { Component, computed, contentChildren, input, output, signal } from "@angular/core";
+import { RouterLink } from "@angular/router";
+import { IonItem, IonLabel, IonList, IonSkeletonText } from "@ionic/angular/standalone";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { PlatformService } from "src/app/core/services/platform.service";
+import { AdminTableColumnComponent } from "./admin-table-column.component";
 
+export type AdminTableDisplay = "auto" | "table" | "list";
+
+/** Signature of the per-row callbacks (link / id / class). */
+type RowFn<T> = ((row: any) => T) | null;
+
+/**
+ * Responsive data table.
+ *
+ * - With declarative `<admin-table-column>` children it renders as a `<table>` on
+ *   desktop and as an `<ion-list>` on mobile (each column becomes a line, one
+ *   column can be flagged `[right]` to sit on the right). Use `[display]` to force
+ *   `"table"` or `"list"` regardless of viewport.
+ * - Without columns it falls back to projecting raw `<thead>`/`<tbody>` markup
+ *   (table-only), preserving the original, pre-responsive API.
+ */
+@UntilDestroy()
 @Component({
 	selector: "admin-table",
 	templateUrl: "./admin-table.component.html",
 	styleUrls: ["./admin-table.component.scss"],
+	imports: [CommonModule, RouterLink, IonList, IonItem, IonLabel, IonSkeletonText],
 })
 export class AdminTableComponent {
 	defaultTableClass = "table table-hover";
 
 	class = input<string>("");
 
-	tableClass = computed(() => this.defaultTableClass + (this.class() ? " " + this.class() : ""));
+	/** Row data. Leave unset when using the legacy raw-markup projection. */
+	rows = input<readonly any[] | null | undefined>(undefined);
+
+	/** Force a rendering mode, or `"auto"` (default) to switch on viewport width. */
+	display = input<AdminTableDisplay>("auto");
+
+	/** `(row) => routerLink` — makes each row navigate/clickable. */
+	rowLink = input<RowFn<any[] | string | null | undefined>>(null);
+
+	/** `(row) => elementId` — sets the id on each row element (e.g. for scroll targeting). */
+	rowId = input<RowFn<string | null | undefined>>(null);
+
+	/** `(row) => ngClass value` — extra class(es) per row. */
+	rowClass = input<RowFn<string | Record<string, boolean> | null | undefined>>(null);
+
+	/** `(index, row) => trackBy key`. Defaults to `row.id` (or the row itself). */
+	trackBy = input<((index: number, row: any) => any) | null>(null);
+
+	/** Show skeleton placeholder rows instead of data. */
+	loading = input<boolean>(false);
+
+	/** Number of skeleton rows to show while `loading`. */
+	skeletonRows = input<number>(5);
+
+	rowClick = output<any>();
+
+	readonly columns = contentChildren(AdminTableColumnComponent);
+
+	readonly tableClass = computed(() => this.defaultTableClass + (this.class() ? " " + this.class() : ""));
+
+	// Desktop when the viewport is at least the lg breakpoint (992px), matching the
+	// `d-*-lg` utility breakpoint used across the app.
+	private readonly isDesktop = signal(true);
+
+	readonly mode = computed<"table" | "list">(() => {
+		const display = this.display();
+		if (display === "table" || display === "list") return display;
+		return this.isDesktop() ? "table" : "list";
+	});
+
+	readonly lineColumns = computed(() => this.columns().filter((column) => !column.right()));
+	readonly rightColumn = computed(() => this.columns().find((column) => column.right()) ?? null);
+
+	readonly skeletonArray = computed(() => Array.from({ length: this.skeletonRows() }));
+
+	constructor(private readonly platformService: PlatformService) {
+		this.platformService.isLg.pipe(untilDestroyed(this)).subscribe((isLg) => this.isDesktop.set(isLg));
+	}
+
+	trackRow = (index: number, row: any) => {
+		const fn = this.trackBy();
+		if (fn) return fn(index, row);
+		return row?.id ?? row;
+	};
+
+	resolveLink(row: any) {
+		return this.rowLink()?.(row) ?? null;
+	}
+
+	resolveId(row: any) {
+		return this.rowId()?.(row) ?? null;
+	}
+
+	resolveClass(row: any) {
+		return this.rowClass()?.(row) ?? null;
+	}
+
+	onRowClick(row: any) {
+		this.rowClick.emit(row);
+	}
 }


### PR DESCRIPTION
# Změny

 - `admin-table` je nově responzivní a řídí se sloupci: pomocí `<admin-table-column>` se na desktopu vykreslí jako tabulka a na mobilu jako `ion-list`. Stránky se seznamy už se o přepínání zobrazení nestarají.
 - Na mobilu se každý sloupec vykreslí jako řádek; sloupec označený `[right]` se zobrazí vpravo (`slot="end"`) – např. stav akce. Sloupec `[primary]` se stane nadpisem položky.
 - Nový vstup `[display]` umožňuje vynutit `"table"` nebo `"list"` bez ohledu na velikost obrazovky (výchozí `"auto"`).
 - Zachována zpětná kompatibilita: staré projektování `<thead>`/`<tbody>` dál funguje (users-list, albums-list).
 - `events-list` a `members-list` převedeny na nové API a zbaveny vlastního přepínání portrait/tabulka-vs-seznam.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že na **desktopu** se Přehled akcí i Členská databáze zobrazují jako tabulka jako dříve (včetně filtrů v hlavičkách sloupců a řazení sloupců – stav zůstává na svém místě).
3. Zúž okno / otevři na **mobilu** a zkontroluj, že se stejné seznamy zobrazí jako `ion-list`, kde je každý sloupec jako řádek a stav akce je vpravo.
4. Ověř, že kliknutí na položku (tabulka i seznam) naviguje na detail a že u členů zůstává zvýraznění neaktivních / pozastavených.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBRwk5kdiRqrsfToyFoJpE)_