### PR TITLE
Vícesloupcové řazení tabulek (desktop)

### DIFF
--- a/backend/src/api/helpers/dto.ts
+++ b/backend/src/api/helpers/dto.ts
@@ -1,18 +1,24 @@
 import { ApiPropertyOptional } from "@nestjs/swagger";
 import { Transform, Type } from "class-transformer";
-import { IsIn, IsNumber, IsOptional, IsString } from "class-validator";
+import { IsNumber, IsOptional, IsString, Matches } from "class-validator";
 
 export class PaginationQuery {
 	@ApiPropertyOptional() @Type(() => Number) @IsNumber() @IsOptional() limit?: number;
 	@ApiPropertyOptional() @Type(() => Number) @IsNumber() @IsOptional() offset?: number;
 
-	/** Column key to order by. Each endpoint whitelists which keys are honoured. */
-	@ApiPropertyOptional() @IsString() @IsOptional() sort?: string;
+	/**
+	 * Column key(s) to order by, comma-separated in priority order (e.g. `"group,role"`).
+	 * Each endpoint whitelists which keys are honoured.
+	 */
+	@ApiPropertyOptional({ example: "group,role" }) @IsString() @IsOptional() sort?: string;
 
-	/** Order direction; defaults per endpoint when omitted. */
-	@ApiPropertyOptional({ enum: ["ASC", "DESC"] })
+	/**
+	 * Order direction(s), comma-separated to match each `sort` key (e.g. `"ASC,DESC"`);
+	 * missing entries default to ASC. Defaults per endpoint when omitted.
+	 */
+	@ApiPropertyOptional({ example: "ASC,DESC" })
 	@Transform(({ value }) => (typeof value === "string" ? value.toUpperCase() : value))
-	@IsIn(["ASC", "DESC"])
+	@Matches(/^(ASC|DESC)(,(ASC|DESC)){0,3}$/)
 	@IsOptional()
-	order?: "ASC" | "DESC";
+	order?: string;
 }

--- a/backend/src/helpers/sort.ts
+++ b/backend/src/helpers/sort.ts
@@ -3,29 +3,76 @@ import { ObjectLiteral, SelectQueryBuilder } from "typeorm";
 export type SortOrder = "ASC" | "DESC";
 
 export interface SortOptions {
+	/** One or more sort keys, comma-separated in priority order (e.g. `"group,role"`). */
 	sort?: string;
-	order?: SortOrder;
+	/** Matching directions, comma-separated (e.g. `"ASC,DESC"`); missing entries default to ASC. */
+	order?: string;
+}
+
+export interface SortSpec {
+	column: string;
+	order: SortOrder;
+}
+
+// Cheap guard against a pathological `?sort=a,a,a,…`; no table has this many sortable columns.
+const MAX_SORT_KEYS = 4;
+
+/**
+ * Whitelisted sort keys the client actually asked for, in priority order.
+ *
+ * Parses the comma-separated `options.sort`, keeps only keys present in `whitelist`
+ * (so an injected key never reaches the query), de-duplicates keeping the first
+ * occurrence, and caps the result at {@link MAX_SORT_KEYS}. Repositories can reuse
+ * this for their own tie-breaker logic.
+ */
+export function parseSortKeys(options: SortOptions, whitelist: Record<string, string>): string[] {
+	if (!options.sort) return [];
+
+	const keys: string[] = [];
+	for (const raw of options.sort.split(",")) {
+		const key = raw.trim();
+		if (!key || !(key in whitelist)) continue; // drop unknown/unwhitelisted keys
+		if (keys.includes(key)) continue; // de-duplicate, first occurrence wins
+		keys.push(key);
+		if (keys.length >= MAX_SORT_KEYS) break;
+	}
+	return keys;
+}
+
+/** Parse `options` into whitelisted `[column, order]` pairs, in priority order. */
+function parseSortSpecs(options: SortOptions, whitelist: Record<string, string>): SortSpec[] {
+	const keys = parseSortKeys(options, whitelist);
+	const orders = (options.order ?? "").split(",");
+
+	return keys.map((key, i) => {
+		const order = (orders[i] ?? "").trim().toUpperCase();
+		return { column: whitelist[key], order: order === "DESC" ? "DESC" : "ASC" };
+	});
 }
 
 /**
- * Applies a whitelisted ORDER BY to a query builder.
+ * Applies a whitelisted ORDER BY to a query builder, supporting multi-column sorting.
  *
- * `whitelist` maps a client-facing sort key to a trusted SQL column/expression —
- * only keys present in it are ever ordered by, so the raw `options.sort` string
- * never reaches the query. When `options.sort` is missing or not whitelisted the
- * `fallback` order is used, preserving each endpoint's original default sort.
+ * `whitelist` maps each client-facing sort key to a trusted SQL column/expression —
+ * only keys present in it are ever ordered by, so the raw `options.sort` string never
+ * reaches the query. `options.sort` / `options.order` may be comma-separated lists
+ * (`"group,role"` / `"ASC,DESC"`), applied in priority order via `orderBy` for the
+ * first key and `addOrderBy` for the rest. When no whitelisted key survives, the
+ * `fallback` order is used, preserving each endpoint's original default sort. The
+ * fallback may itself be a list of specs (e.g. the members group+role default).
  */
 export function applySort<T extends ObjectLiteral>(
 	q: SelectQueryBuilder<T>,
 	options: SortOptions,
 	whitelist: Record<string, string>,
-	fallback: { column: string; order: SortOrder },
+	fallback: SortSpec | SortSpec[],
 ): SelectQueryBuilder<T> {
-	const column = options.sort ? whitelist[options.sort] : undefined;
-	if (column) {
-		q.orderBy(column, options.order ?? "ASC");
-	} else {
-		q.orderBy(fallback.column, fallback.order);
-	}
+	const specs = parseSortSpecs(options, whitelist);
+	const applied = specs.length ? specs : [fallback].flat();
+
+	applied.forEach((spec, i) =>
+		i === 0 ? q.orderBy(spec.column, spec.order) : q.addOrderBy(spec.column, spec.order),
+	);
+
 	return q;
 }

--- a/backend/src/models/members/repositories/members.repository.ts
+++ b/backend/src/models/members/repositories/members.repository.ts
@@ -1,8 +1,8 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { PaginationOptions } from "src/helpers/pagination";
-import { applySort } from "src/helpers/sort";
-import { Brackets, FindOneOptions, Repository } from "typeorm";
+import { applySort, parseSortKeys } from "src/helpers/sort";
+import { Brackets, FindOneOptions, In, Repository } from "typeorm";
 import { MemberContact } from "../entities/member-contact.entity";
 import { Member } from "../entities/member.entity";
 
@@ -32,36 +32,40 @@ export class MembersRepository {
 			.take(options.limit)
 			.skip(options.offset);
 
-		applySort(
-			q,
-			options,
-			{
-				nickname: "CONCAT(members.nickname,members.first_name,members.last_name)",
-				name: "CONCAT(members.last_name,members.first_name)",
-				role: "members.role",
-				membership: "members.membership",
-				age: "DATE_PART('year', AGE(CURRENT_DATE, members.birthday))",
-				birthday: "members.birthday",
-				// Sort by the *displayed* group (its name, e.g. "6. oddíl"), not the internal group
-				// id. `groups.name` carries the `natural_numeric` ICU collation (see Group entity),
-				// so embedded numbers order naturally: "3. oddíl" precedes "22. oddíl", and
-				// non-numeric names ("Klub přátel", …) sort after them.
-				group: "(SELECT g.name FROM groups g WHERE g.id = members.group_id)",
-				city: "members.addressCity",
-				street: "members.addressStreet",
-				status: "members.active",
-			},
-			{ column: "CONCAT(members.nickname,members.first_name,members.last_name)", order: "ASC" },
-		);
+		// Sort by the *displayed* group (its name, e.g. "6. oddíl"), not the internal group
+		// id. `groups.name` carries the `natural_numeric` ICU collation (see Group entity),
+		// so embedded numbers order naturally: "3. oddíl" precedes "22. oddíl", and
+		// non-numeric names ("Klub přátel", …) sort after them.
+		const GROUP_NAME = "(SELECT g.name FROM groups g WHERE g.id = members.group_id)";
+		const NICKNAME = "CONCAT(members.nickname,members.first_name,members.last_name)";
 
-		// Keep members within the same group in a readable order.
-		if (options.sort === "group") {
-			q.addOrderBy("CONCAT(members.nickname,members.first_name,members.last_name)", "ASC");
+		const sortWhitelist = {
+			nickname: NICKNAME,
+			name: "CONCAT(members.last_name,members.first_name)",
+			role: "members.role",
+			membership: "members.membership",
+			age: "DATE_PART('year', AGE(CURRENT_DATE, members.birthday))",
+			birthday: "members.birthday",
+			group: GROUP_NAME,
+			city: "members.addressCity",
+			street: "members.addressStreet",
+			status: "members.active",
+		};
+
+		applySort(q, options, sortWhitelist, [
+			// Default order: group name ASC, then role. `role` is a Postgres enum declared
+			// `dite, instruktor, vedouci`, so DESC yields vedoucí → instruktor → dítě, matching
+			// the group detail screen.
+			{ column: GROUP_NAME, order: "ASC" },
+			{ column: "members.role", order: "DESC" },
+		]);
+
+		// Keep members within the same (group, role) bucket in a readable order: append a
+		// nickname tie-breaker whenever the client's sort doesn't already order by a name key.
+		const sortKeys = parseSortKeys(options, sortWhitelist);
+		if (!sortKeys.includes("nickname") && !sortKeys.includes("name")) {
+			q.addOrderBy(NICKNAME, "ASC");
 		}
-
-		// Join contacts up-front only when requested (i.e. the contacts column is visible).
-		// TypeORM keeps pagination correct with a distinct-id subquery despite the one-to-many join.
-		if (options.contacts) q.leftJoinAndSelect("members.contacts", "contacts");
 
 		if (options.groups) q.andWhere("members.groupId IN (:...groupIds)", { groupIds: options.groups });
 
@@ -85,7 +89,30 @@ export class MembersRepository {
 
 		if (options.active !== undefined) q.andWhere("members.active = :active", { active: options.active });
 
-		return q.getMany();
+		const members = await q.getMany();
+
+		// Load contacts up-front only when requested (i.e. the contacts column is visible), via a
+		// *separate* batched query rather than a leftJoinAndSelect. A one-to-many join combined with
+		// take/skip forces TypeORM to build a distinct-id pagination subquery, and that subquery
+		// cannot resolve our expression-based ORDER BY keys (the group-name subquery, the nickname
+		// CONCAT) — it throws "alias was not found". A single WHERE-IN query keeps the multi-column
+		// sort and pagination intact while still avoiding an N+1 fetch per member.
+		if (options.contacts && members.length) {
+			const contacts = await this.membersContactsRepository.find({
+				where: { memberId: In(members.map((member) => member.id)) },
+			});
+
+			const contactsByMember = new Map<number, MemberContact[]>();
+			for (const contact of contacts) {
+				const list = contactsByMember.get(contact.memberId) ?? [];
+				list.push(contact);
+				contactsByMember.set(contact.memberId, list);
+			}
+
+			for (const member of members) member.contacts = contactsByMember.get(member.id) ?? [];
+		}
+
+		return members;
 	}
 
 	// Distinct ages across all members in a single query, so the age filter no longer

--- a/frontend/src/app/features/albums/pages/albums-list/albums-list.component.ts
+++ b/frontend/src/app/features/albums/pages/albums-list/albums-list.component.ts
@@ -97,7 +97,8 @@ export class AlbumsListComponent implements OnInit, ViewWillEnter, ViewWillLeave
 	selectedStatuses = signal<string[]>([]);
 
 	sortColumn = signal<string | null>(null);
-	sortOrder = signal<"ASC" | "DESC">("ASC");
+	// String, not "ASC" | "DESC": a multi-column sort carries a comma-separated list (e.g. "ASC,DESC").
+	sortOrder = signal<string>("ASC");
 
 	readonly sortOptions: SortOption[] = [
 		{ key: "name", label: "Název alba" },
@@ -162,7 +163,8 @@ export class AlbumsListComponent implements OnInit, ViewWillEnter, ViewWillLeave
 		this.selectedYears.set(this.normalizeFilterValueToArray(params["year"]));
 		this.selectedStatuses.set(this.normalizeFilterValueToArray(params["status"]));
 		this.sortColumn.set(params["sort"] ?? null);
-		this.sortOrder.set(params["order"] === "DESC" ? "DESC" : "ASC");
+		// Keep the raw param — it may be a comma-separated list of directions for a multi-column sort.
+		this.sortOrder.set(params["order"] ?? "ASC");
 		this.loadAlbums(this.filter);
 	}
 
@@ -228,7 +230,7 @@ export class AlbumsListComponent implements OnInit, ViewWillEnter, ViewWillLeave
 			status: this.normalizeFilterValueToArray(filter.status) as SDK.ListAlbumsStatusEnum[],
 			year: this.normalizeFilterValueToArray(filter.year).map((year) => parseInt(year, 10)),
 			sort: (filter.sort as string) || undefined,
-			order: (filter.order as SDK.ListAlbumsOrderEnum) || undefined,
+			order: (filter.order as string) || undefined,
 			offset: (this.page() - 1) * this.pageSize,
 			limit: this.pageSize,
 		};

--- a/frontend/src/app/features/events/pages/events-list/events-list.component.ts
+++ b/frontend/src/app/features/events/pages/events-list/events-list.component.ts
@@ -92,7 +92,8 @@ export class EventsListComponent implements OnInit, OnDestroy {
 	selectedLeaderFilters = signal<string[]>([]);
 
 	sortColumn = signal<string | null>(null);
-	sortOrder = signal<"ASC" | "DESC">("ASC");
+	// String, not "ASC" | "DESC": a multi-column sort carries a comma-separated list (e.g. "ASC,DESC").
+	sortOrder = signal<string>("ASC");
 
 	readonly sortOptions: SortOption[] = [
 		{ key: "name", label: "Název" },
@@ -345,7 +346,8 @@ export class EventsListComponent implements OnInit, OnDestroy {
 		this.selectedStatuses.set(this.normalizeFilterValueToArray(params["status"]));
 		this.selectedLeaderFilters.set(this.normalizeFilterValueToArray(params["leaders"]));
 		this.sortColumn.set(params["sort"] ?? null);
-		this.sortOrder.set(params["order"] === "DESC" ? "DESC" : "ASC");
+		// Keep the raw param — it may be a comma-separated list of directions for a multi-column sort.
+		this.sortOrder.set(params["order"] ?? "ASC");
 		this.loadEvents(this.filter);
 	}
 

--- a/frontend/src/app/features/members/components/group-members/group-members.component.ts
+++ b/frontend/src/app/features/members/components/group-members/group-members.component.ts
@@ -81,7 +81,8 @@ export class GroupMembersComponent implements OnInit {
 	selectedMembership = signal<string[]>([]);
 
 	sortColumn = signal<string | null>("role");
-	sortOrder = signal<"ASC" | "DESC">("DESC");
+	// String, not "ASC" | "DESC": desktop multisort carries a comma-separated list (e.g. "ASC,DESC").
+	sortOrder = signal<string>("DESC");
 
 	readonly sortOptions: SortOption[] = [
 		{ key: "nickname", label: "Přezdívka" },

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.ts
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.ts
@@ -94,7 +94,8 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 	selectedMembership = signal<string[]>([]);
 
 	sortColumn = signal<string | null>(null);
-	sortOrder = signal<"ASC" | "DESC">("ASC");
+	// String, not "ASC" | "DESC": a multi-column sort carries a comma-separated list (e.g. "ASC,DESC").
+	sortOrder = signal<string>("ASC");
 
 	readonly sortOptions: SortOption[] = [
 		{ key: "nickname", label: "Přezdívka" },
@@ -275,7 +276,8 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 		this.selectedMembership.set(this.normalizeFilterValueToArray(params["membership"]));
 		this.showInactive.set(((params["active"] as string) || "active") === "all");
 		this.sortColumn.set(params["sort"] ?? null);
-		this.sortOrder.set(params["order"] === "DESC" ? "DESC" : "ASC");
+		// Keep the raw param — it may be a comma-separated list of directions for a multi-column sort.
+		this.sortOrder.set(params["order"] ?? "ASC");
 		this.loadMembers(this.filter);
 	}
 
@@ -334,7 +336,7 @@ export class MembersListComponent implements OnInit, AfterViewInit, ViewWillEnte
 			// and only when a contact column is actually visible.
 			contacts: this.needsContacts() || undefined,
 			sort: (filter["sort"] as string) || undefined,
-			order: (filter["order"] as SDK.ListMembersOrderEnum) || undefined,
+			order: (filter["order"] as string) || undefined,
 		};
 
 		const members = await this.api.MembersApi.listMembers(params).then((res) => res.data);

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.html
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.html
@@ -7,15 +7,36 @@
 						@for (column of columns(); track column) {
 							<th [class]="column.headerClass()">
 								@if (column.sort()) {
+									@let idx = sortIndex(column.sort());
 									<button
 										type="button"
 										class="admin-table-sort"
-										[class.admin-table-sort-active]="sort() === column.sort()"
+										[class.admin-table-sort-active]="idx >= 0"
+										[attr.aria-label]="
+											column.header() +
+											(idx < 0
+												? ': seřadit vzestupně'
+												: activeSort()[idx].order === 'ASC'
+													? ': seřadit sestupně'
+													: ': zrušit řazení')
+										"
+										[title]="
+											idx < 0
+												? 'Seřadit vzestupně'
+												: activeSort()[idx].order === 'ASC'
+													? 'Seřadit sestupně'
+													: 'Zrušit řazení'
+										"
 										(click)="onSort(column)"
 									>
 										<span>{{ column.header() }}</span>
-										@if (sort() === column.sort()) {
-											<ion-icon [name]="order() === 'ASC' ? 'caret-up' : 'caret-down'"></ion-icon>
+										@if (idx >= 0) {
+											<ion-icon
+												[name]="activeSort()[idx].order === 'ASC' ? 'caret-up' : 'caret-down'"
+											></ion-icon>
+											@if (activeSort().length > 1) {
+												<span class="admin-table-sort-index">{{ idx + 1 }}</span>
+											}
 										} @else {
 											<ion-icon name="swap-vertical" class="admin-table-sort-idle"></ion-icon>
 										}

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.scss
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.scss
@@ -80,6 +80,17 @@ table.table {
 			color: var(--bo-blue);
 		}
 
+		// priority badge (1, 2, 3 …) next to the caret, shown only while more than one
+		// column is active — small, muted and non-wrapping so it reads as a superscript
+		.admin-table-sort-index {
+			font-size: 0.7em;
+			font-weight: 700;
+			line-height: 1;
+			color: var(--bo-muted);
+			white-space: nowrap;
+			margin-left: -0.15em;
+		}
+
 		tbody td {
 			border-bottom: 1px solid var(--bo-line);
 			padding: 0.7rem 1rem;

--- a/frontend/src/app/shared/components/admin-table/admin-table.component.ts
+++ b/frontend/src/app/shared/components/admin-table/admin-table.component.ts
@@ -13,8 +13,10 @@ import { AdminTableColumnComponent } from "./admin-table-column.component";
 export type AdminTableDisplay = "auto" | "table" | "list";
 export type AdminTableSortOrder = "ASC" | "DESC";
 export interface AdminTableSort {
+	/** Active sort key(s), comma-joined in priority order (e.g. `"group,role"`); `""` when unsorted. */
 	sort: string;
-	order: AdminTableSortOrder;
+	/** Matching direction(s), comma-joined to line up with `sort` (e.g. `"ASC,DESC"`). */
+	order: string;
 }
 
 /** Signature of the per-row callbacks (link / id / class). */
@@ -85,11 +87,11 @@ export class AdminTableComponent {
 	/** `(row) => header` — title shown above the actions on the mobile ActionSheet. */
 	actionsHeader = input<((row: any) => string | null | undefined) | null>(null);
 
-	/** Active sort column key (matches a column's `[sort]`), or `null` when unsorted. */
+	/** Active sort key(s), comma-separated in priority order (e.g. `"group,role"`), or `null` when unsorted. */
 	sort = input<string | null>(null);
 
-	/** Active sort direction for the `sort` column. */
-	order = input<AdminTableSortOrder>("ASC");
+	/** Active sort direction(s), comma-separated to match each `sort` key (e.g. `"ASC,DESC"`). */
+	order = input<AdminTableSortOrder | string>("ASC");
 
 	rowClick = output<any>();
 
@@ -115,20 +117,51 @@ export class AdminTableComponent {
 
 	readonly skeletonArray = computed(() => Array.from({ length: this.skeletonRows() }));
 
+	/** Parsed active sort, in priority order — pairs each `sort` key with its direction. */
+	readonly activeSort = computed<{ key: string; order: AdminTableSortOrder }[]>(() => {
+		const keys = (this.sort() ?? "").split(",").map((k) => k.trim()).filter((k) => !!k);
+		const orders = String(this.order() ?? "").split(",");
+		return keys.map((key, i) => ({
+			key,
+			order: (orders[i] ?? "").trim().toUpperCase() === "DESC" ? "DESC" : "ASC",
+		}));
+	});
+
+	/** Zero-based position of a column in the active sort, or -1 when it is not sorted. */
+	sortIndex(key: string | null): number {
+		if (!key) return -1;
+		return this.activeSort().findIndex((s) => s.key === key);
+	}
+
 	constructor(private readonly platformService: PlatformService) {
 		addIcons({ caretUp, caretDown, swapVertical });
 		this.platformService.isLg.pipe(untilDestroyed(this)).subscribe((isLg) => this.isDesktop.set(isLg));
 	}
 
 	/**
-	 * Toggle sorting for a column header click: switching to a new column starts
-	 * ascending; clicking the active column flips its direction.
+	 * Cycle a column header through the three-state multi-sort: an unsorted column is
+	 * appended as the last (lowest-priority) key ascending; a key sorted ASC flips to
+	 * DESC in place; a key sorted DESC is removed, so the remaining keys shift up in
+	 * priority. Emits the whole list comma-joined, or `{ sort: "", order: "" }` once the
+	 * last key is cycled off (which pages treat as "back to default").
 	 */
 	onSort(column: AdminTableColumnComponent) {
 		const key = column.sort();
 		if (!key) return;
-		const order: AdminTableSortOrder = this.sort() === key && this.order() === "ASC" ? "DESC" : "ASC";
-		this.sortChange.emit({ sort: key, order });
+
+		const current = this.activeSort();
+		const i = current.findIndex((s) => s.key === key);
+
+		let next: { key: string; order: AdminTableSortOrder }[];
+		if (i < 0) next = [...current, { key, order: "ASC" }];
+		else if (current[i].order === "ASC")
+			next = current.map((s, j) => (j === i ? { ...s, order: "DESC" as const } : s));
+		else next = current.filter((_, j) => j !== i);
+
+		this.sortChange.emit({
+			sort: next.map((s) => s.key).join(","),
+			order: next.map((s) => s.order).join(","),
+		});
 	}
 
 	trackRow = (index: number, row: any) => {

--- a/frontend/src/app/shared/components/sort-select/sort-select.component.html
+++ b/frontend/src/app/shared/components/sort-select/sort-select.component.html
@@ -1,13 +1,13 @@
 <ion-list lines="full">
 	<ion-item-divider>{{ label() }}</ion-item-divider>
 
-	<ion-item [lines]="sort() ? 'full' : 'none'">
+	<ion-item [lines]="primaryKey() ? 'full' : 'none'">
 		<ion-select
 			label="Seřadit podle"
 			interface="popover"
 			justify="start"
 			placeholder="Výchozí"
-			[ngModel]="sort()"
+			[ngModel]="primaryKey()"
 			(ngModelChange)="selectColumn($event)"
 		>
 			<ion-select-option [value]="null">Výchozí</ion-select-option>
@@ -17,9 +17,9 @@
 		</ion-select>
 	</ion-item>
 
-	@if (sort()) {
+	@if (primaryKey()) {
 		<ion-item lines="none">
-			<ion-segment [value]="order()" (ionChange)="selectOrder($any($event.detail.value))">
+			<ion-segment [value]="primaryOrder()" (ionChange)="selectOrder($any($event.detail.value))">
 				<ion-segment-button value="ASC">
 					<ion-label>Vzestupně</ion-label>
 				</ion-segment-button>

--- a/frontend/src/app/shared/components/sort-select/sort-select.component.ts
+++ b/frontend/src/app/shared/components/sort-select/sort-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output } from "@angular/core";
+import { Component, computed, input, output } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import {
 	IonItem,
@@ -23,6 +23,11 @@ export interface SortOption {
  * ascending/descending segment. Mirrors the desktop `admin-table` header sorting,
  * emitting the same `sortChange` shape so pages reuse their existing handler.
  * Selecting "Výchozí" emits an empty key to fall back to the default order.
+ *
+ * This control stays single-column: the `[sort]`/`[order]` inputs may arrive with
+ * commas (a desktop multi-key URL opened on a phone), so it shows only the *first*
+ * key/direction, and selecting a column emits a single key/order pair — replacing any
+ * multi-key sort with the user's single-column choice.
  */
 @Component({
 	selector: "bo-sort-select",
@@ -42,21 +47,33 @@ export interface SortOption {
 export class SortSelectComponent {
 	options = input.required<SortOption[]>();
 	sort = input<string | null>(null);
-	order = input<AdminTableSortOrder>("ASC");
+	order = input<AdminTableSortOrder | string>("ASC");
 	label = input<string>("Řazení");
 
 	sortChange = output<AdminTableSort>();
+
+	/** First key of a (possibly comma-separated) `sort`, so the select always has a matching option. */
+	readonly primaryKey = computed<string | null>(() => {
+		const first = (this.sort() ?? "").split(",")[0]?.trim();
+		return first || null;
+	});
+
+	/** Direction paired with {@link primaryKey}; falls back to ASC. */
+	readonly primaryOrder = computed<AdminTableSortOrder>(() => {
+		const first = String(this.order() ?? "").split(",")[0]?.trim().toUpperCase();
+		return first === "DESC" ? "DESC" : "ASC";
+	});
 
 	selectColumn(key: string | null) {
 		if (!key) {
 			this.sortChange.emit({ sort: "", order: "ASC" });
 			return;
 		}
-		this.sortChange.emit({ sort: key, order: this.order() ?? "ASC" });
+		this.sortChange.emit({ sort: key, order: this.primaryOrder() });
 	}
 
 	selectOrder(order: AdminTableSortOrder) {
-		const key = this.sort();
+		const key = this.primaryKey();
 		if (!key) return;
 		this.sortChange.emit({ sort: key, order });
 	}

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -5054,14 +5054,6 @@ export namespace SDK {
     
     
     
-    /**
-     * @export
-     */
-    export const ListEventsOrderEnum = {
-        Asc: 'ASC',
-        Desc: 'DESC'
-    } as const;
-    export type ListEventsOrderEnum = typeof ListEventsOrderEnum[keyof typeof ListEventsOrderEnum];
     
     
     /**
@@ -5094,13 +5086,13 @@ export namespace SDK {
          */
         sort?: string
     
-        //orderisEnumOrderEnum
+        //order
         /**
          * 
-         * @type {'ASC' | 'DESC'}
+         * @type {string}
          * @memberof EventsApiListEvents
          */
-        order?: ListEventsOrderEnum
+        order?: string
     
         //year
         /**
@@ -6952,14 +6944,6 @@ export namespace SDK {
     /**
      * @export
      */
-    export const ExportMembersXlsxOrderEnum = {
-        Asc: 'ASC',
-        Desc: 'DESC'
-    } as const;
-    export type ExportMembersXlsxOrderEnum = typeof ExportMembersXlsxOrderEnum[keyof typeof ExportMembersXlsxOrderEnum];
-    /**
-     * @export
-     */
     export const ExportMembersXlsxRolesEnum = {
         Dite: 'dite',
         Instruktor: 'instruktor',
@@ -7007,13 +6991,13 @@ export namespace SDK {
          */
         sort?: string
     
-        //orderisEnumOrderEnum
+        //order
         /**
          * 
-         * @type {'ASC' | 'DESC'}
+         * @type {string}
          * @memberof MembersApiExportMembersXlsx
          */
-        order?: ExportMembersXlsxOrderEnum
+        order?: string
     
         //contacts
         /**
@@ -7136,14 +7120,6 @@ export namespace SDK {
     /**
      * @export
      */
-    export const ListMembersOrderEnum = {
-        Asc: 'ASC',
-        Desc: 'DESC'
-    } as const;
-    export type ListMembersOrderEnum = typeof ListMembersOrderEnum[keyof typeof ListMembersOrderEnum];
-    /**
-     * @export
-     */
     export const ListMembersRolesEnum = {
         Dite: 'dite',
         Instruktor: 'instruktor',
@@ -7191,13 +7167,13 @@ export namespace SDK {
          */
         sort?: string
     
-        //orderisEnumOrderEnum
+        //order
         /**
          * 
-         * @type {'ASC' | 'DESC'}
+         * @type {string}
          * @memberof MembersApiListMembers
          */
-        order?: ListMembersOrderEnum
+        order?: string
     
         //contacts
         /**
@@ -8490,14 +8466,6 @@ export namespace SDK {
     /**
      * @export
      */
-    export const ListAlbumsOrderEnum = {
-        Asc: 'ASC',
-        Desc: 'DESC'
-    } as const;
-    export type ListAlbumsOrderEnum = typeof ListAlbumsOrderEnum[keyof typeof ListAlbumsOrderEnum];
-    /**
-     * @export
-     */
     export const ListAlbumsStatusEnum = {
         Public: 'public',
         Draft: 'draft'
@@ -8535,13 +8503,13 @@ export namespace SDK {
          */
         sort?: string
     
-        //orderisEnumOrderEnum
+        //order
         /**
          * 
-         * @type {'ASC' | 'DESC'}
+         * @type {string}
          * @memberof PhotoGalleryApiListAlbums
          */
-        order?: ListAlbumsOrderEnum
+        order?: string
     
         //search
         /**
@@ -10343,14 +10311,6 @@ export namespace SDK {
     
     
     
-    /**
-     * @export
-     */
-    export const ListUsersOrderEnum = {
-        Asc: 'ASC',
-        Desc: 'DESC'
-    } as const;
-    export type ListUsersOrderEnum = typeof ListUsersOrderEnum[keyof typeof ListUsersOrderEnum];
     
     
     /**
@@ -10383,13 +10343,13 @@ export namespace SDK {
          */
         sort?: string
     
-        //orderisEnumOrderEnum
+        //order
         /**
          * 
-         * @type {'ASC' | 'DESC'}
+         * @type {string}
          * @memberof UsersApiListUsers
          */
-        order?: ListUsersOrderEnum
+        order?: string
     
         //search
         /**


### PR DESCRIPTION
# Změny

Přidává řazení podle více sloupců najednou (např. členové podle oddílu, pak podle role), ovládané z hlavičky `admin-table` na desktopu. Mobil si ponechává jednosloupcové řazení přes `bo-sort-select`.

**Backend**
- `applySort` nově přijímá seznam klíčů/směrů oddělených čárkou (`?sort=group,role&order=ASC,DESC`) a seznamový fallback. První klíč se aplikuje přes `orderBy`, zbytek přes `addOrderBy`. Klíče se validují proti whitelistu, deduplikují a omezují na max. 4. Přidán sdílený helper `parseSortKeys`.
- Validace `order` v `PaginationQuery` přešla z `@IsIn(["ASC","DESC"])` na regex povolující čárkou oddělený seznam až 4 směrů. `order` v OpenAPI je tím pádem prostý `string` a generované typy `SDK.List*OrderEnum` zmizely.
- Výchozí řazení seznamu členů je nyní oddíl ASC, pak role DESC (vedoucí → instruktor → dítě, dle pořadí enum hodnot), s přezdívkou jako tie-break v rámci každé skupiny.
- Kontakty členů se načítají samostatným dávkovým dotazem (`WHERE ... IN`) místo `leftJoinAndSelect`. Spojení one-to-many spolu s `take/skip` nutí TypeORM sestavit distinct-id stránkovací poddotaz, který neumí přeložit výrazové `ORDER BY` klíče (poddotaz na jméno oddílu, `CONCAT` přezdívky) a padal s „alias was not found" — šlo o **existující** chybu pro jakékoli řazení, jakmile byl zobrazen sloupec telefon/e-mail. Samostatný dotaz zachová vícesloupcové řazení i stránkování a stále se vyhne N+1.

**Frontend**
- `admin-table` parsuje čárkou spojené `sort`/`order` do seznamu aktivního řazení, cykluje kliknutý sloupec ASC → DESC → vypnuto, nové sloupce přidává na konec priority a zobrazuje odznak priority (1, 2, …), pokud je aktivní více než jeden sloupec. Přidán `aria-label`/`title` popisující další akci.
- `bo-sort-select` zůstává jednosloupcový, ale toleruje čárkový vstup (zobrazí první klíč/směr) a emituje jediný pár klíč/směr.
- Stránky rozšiřují typ stavu `order` na `string`, ruší odstraněné enum přetypování a nechávají syrový parametr `order` beze změny.
- Přegenerovaný SDK.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
    - V seznamu členů na desktopu klikni na **Oddíl**, pak na **Role** — u hlaviček se objeví odznaky `1` a `2` a tabulka je seřazená podle oddílu, pak role.
    - Opětovné kliknutí na sloupec cykluje ASC → DESC → zrušení řazení; po zrušení všech klíčů se tabulka vrátí do výchozího řazení (oddíl, role) bez odznaků.
    - Po každém kliknutí obnov stránku — řazení přežije díky query parametrům.
    - Bez zvoleného řazení jsou členové seskupení podle oddílu, uvnitř podle role (vedoucí → dítě) a podle přezdívky.
    - Zapni sloupec **telefon** nebo **e-mail** (načítá kontakty) a projdi stránkování / nekonečné rolování — seznam se korektně načte a řadí (dříve zde vznikala chyba 500).
    - Na mobilu seznam členů ukazuje „Výchozí" řazení a výběr sloupce vytvoří jednosloupcové řazení.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DbX7rgJdFBKF9FiBfS89m

---
_Generated by [Claude Code](https://claude.ai/code/session_019DbX7rgJdFBKF9FiBfS89m)_