### PR TITLE
refactor(events): use eventGroups only, add dedicated groups endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,10 @@
 ## Backend entities
 
 - **One table, one entity mapping.** Never map the same table twice (e.g. an explicit `@Entity("x")` *and* a `@ManyToMany`/`@JoinTable` over `"x"`). TypeORM then builds two metadata objects for it, and the schema builder drops and recreates that table's indexes in **every** generated migration — permanent drift that survives being applied. `events_groups` was in this state for years; it is now mapped only by `EventGroup`.
-- **`Event.groups` / `Event.groupsIds` are derived, not relations.** Because `events_groups` is mapped explicitly, the real relation is `Event.eventGroups` (`@OneToMany` → `EventGroup`) and the two public fields are populated by the `setGroups()` `@AfterLoad` hook. Consequences:
-  - Any **new query returning events must `leftJoinAndSelect("events.eventGroups", "eventGroups")`**, otherwise `groupsIds` comes back `undefined` and the frontend loses group assignments. `groups` additionally needs `eventGroups.group` joined. The hook deliberately leaves both fields untouched when the relation was not loaded, rather than defaulting to `[]` — a missing join shows up as `undefined` instead of silently claiming the event has no groups.
-  - **Writes go through `EventsRepository.setEventGroups()`**, which syncs the join rows in a transaction. Do not expect a cascading `save()` to sync them the way `@JoinTable` used to.
-  - Keep `eventGroups` out of API DTOs (`EventResponse` omits it) so the SDK contract stays `groups` + `groupsIds`.
+- **`Event.eventGroups` is the single source of truth for group membership.** Because `events_groups` is mapped explicitly, the real relation is `Event.eventGroups` (`@OneToMany` → `EventGroup`). There are no derived `Event.groups` / `Event.groupsIds` fields — consumers read the group ids straight off `eventGroups[].groupId`. Consequences:
+  - Any **new query returning events must `leftJoinAndSelect("events.eventGroups", "eventGroups")`**, otherwise `eventGroups` comes back `undefined` and the frontend loses group assignments. To also expose the full `Group` on each row (the public program needs the short name), additionally join `eventGroups.group`.
+  - **Writes go through `EventsRepository.updateEventGroups()`**, which syncs the join rows in a transaction. Do not expect a cascading `save()` to sync them the way `@JoinTable` used to. `EventUpdateBody` (the `PATCH /events/:id` body) does **not** carry groups — membership is edited via the dedicated `PUT /events/:id/groups` endpoint (`EventGroupsUpdateBody { groupsIds }`).
+  - `EventResponse` exposes `eventGroups` (`EventGroupResponse[]`) directly, so the SDK contract is `eventGroups`, not `groups` / `groupsIds`. The public bosan.cz program keeps its own legacy shape (a `groups` array of short names), derived from `eventGroups` in `PublicService.serializeEvent()`.
 
 ## Database migrations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@
 
 - The frontend SDK (`frontend/src/sdk`) is generated from the backend's OpenAPI spec — do **not** hand-edit `frontend/src/sdk/api.ts`. After changing a backend controller/DTO, regenerate it: from `frontend/`, run `npm run generate:sdk` (it reads the spec from the running backend at `http://127.0.0.1:3000/api/openapi-json`, so the dev server must be up). Every NestJS route needs a unique `operationId` (method name) or generation fails validation.
 
+## Backend entities
+
+- **One table, one entity mapping.** Never map the same table twice (e.g. an explicit `@Entity("x")` *and* a `@ManyToMany`/`@JoinTable` over `"x"`). TypeORM then builds two metadata objects for it, and the schema builder drops and recreates that table's indexes in **every** generated migration — permanent drift that survives being applied. `events_groups` was in this state for years; it is now mapped only by `EventGroup`.
+- **`Event.groups` / `Event.groupsIds` are derived, not relations.** Because `events_groups` is mapped explicitly, the real relation is `Event.eventGroups` (`@OneToMany` → `EventGroup`) and the two public fields are populated by the `setGroups()` `@AfterLoad` hook. Consequences:
+  - Any **new query returning events must `leftJoinAndSelect("events.eventGroups", "eventGroups")`**, otherwise `groupsIds` comes back `undefined` and the frontend loses group assignments. `groups` additionally needs `eventGroups.group` joined. The hook deliberately leaves both fields untouched when the relation was not loaded, rather than defaulting to `[]` — a missing join shows up as `undefined` instead of silently claiming the event has no groups.
+  - **Writes go through `EventsRepository.setEventGroups()`**, which syncs the join rows in a transaction. Do not expect a cascading `save()` to sync them the way `@JoinTable` used to.
+  - Keep `eventGroups` out of API DTOs (`EventResponse` omits it) so the SDK contract stays `groups` + `groupsIds`.
+
 ## Database migrations
 
 - **Always** produce migrations with `npm run migrations:generate --name=<MigrationName>` (from `backend/`), never by hand and never with `migrations:create`. The generator diffs the entities against the DB, so the migration comes out in TypeORM's own format and naming — hand-written files drift from that shape.

--- a/backend/src/api/events/acl/events.acl.ts
+++ b/backend/src/api/events/acl/events.acl.ts
@@ -72,6 +72,14 @@ export const EventEditPermission = new Permission({
 	applicable: ({ doc }) => !doc.deletedAt,
 });
 
+export const EventGroupsEditPermission = new Permission({
+	linkTo: EventResponse,
+
+	inherit: EventEditPermission,
+
+	path: (e) => `${e.id}/groups`,
+});
+
 export const EventDeletePermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {

--- a/backend/src/api/events/controllers/events.controller.ts
+++ b/backend/src/api/events/controllers/events.controller.ts
@@ -10,6 +10,7 @@ import {
 	Param,
 	Patch,
 	Post,
+	Put,
 	Query,
 	Req,
 	Res,
@@ -28,6 +29,7 @@ import {
 	EventDeletePermanentPermission,
 	EventDeletePermission,
 	EventEditPermission,
+	EventGroupsEditPermission,
 	EventLeadPermission,
 	EventPublishPermission,
 	EventReadPermission,
@@ -41,7 +43,13 @@ import {
 	EventUncancelPermission,
 	EventUnpublishPermission,
 } from "../acl/events.acl";
-import { EventCreateBody, EventResponse, EventStatusChangeBody, EventUpdateBody } from "../dto/event.dto";
+import {
+	EventCreateBody,
+	EventGroupsUpdateBody,
+	EventResponse,
+	EventStatusChangeBody,
+	EventUpdateBody,
+} from "../dto/event.dto";
 import { ListEventsQuery } from "../dto/events.dto";
 
 @Controller("events")
@@ -153,6 +161,23 @@ export class EventsController {
 		};
 
 		await this.events.updateEvent(id, updateData);
+	}
+
+	@Put(":id/groups")
+	@HttpCode(204)
+	@AcLinks(EventGroupsEditPermission)
+	@ApiResponse({ status: 204 })
+	async updateEventGroups(
+		@Req() req: Request,
+		@Param("id") id: number,
+		@Body() body: EventGroupsUpdateBody,
+	): Promise<void> {
+		const event = await this.events.getEvent(id, { leaders: true });
+		if (!event) throw new NotFoundException();
+
+		EventGroupsEditPermission.canOrThrow(req, event);
+
+		await this.events.updateEventGroups(id, body.groupsIds);
 	}
 
 	@Delete(":id")

--- a/backend/src/api/events/dto/event.dto.ts
+++ b/backend/src/api/events/dto/event.dto.ts
@@ -1,26 +1,33 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsBoolean, IsEnum, IsNumber, IsOptional, IsString } from "class-validator";
+import { ArrayUnique, IsBoolean, IsEnum, IsNumber, IsOptional, IsString } from "class-validator";
 import { AlbumResponse } from "src/api/albums/dto/album.dto";
 import { GroupResponse } from "src/api/members/dto/group.dto";
 import { MemberResponse } from "src/api/members/dto/member.dto";
 import { Album } from "src/models/albums/entities/album.entity";
 import { EventAttendee } from "src/models/events/entities/event-attendee.entity";
 import { EventExpense } from "src/models/events/entities/event-expense.entity";
+import { EventGroup } from "src/models/events/entities/event-group.entity";
 import { Event, EventPlaceGeometry, EventStates } from "src/models/events/entities/event.entity";
 import { Group } from "src/models/members/entities/group.entity";
 import { Member } from "src/models/members/entities/member.entity";
 import { EventAttendeeResponse } from "./event-attendee.dto";
 import { EventExpenseResponse } from "./event-expense.dto";
 
-// eventGroups is the raw join-table relation; the response exposes the derived groups/groupsIds instead.
-export class EventResponse implements Omit<Event, "setLeaders" | "setGroups" | "eventGroups"> {
+// A single event<->group membership row. Consumers read group ids off `groupId`; `group` is only
+// populated on read paths that join eventGroups.group.
+export class EventGroupResponse implements Omit<EventGroup, "event"> {
+	eventId!: number;
+	groupId!: number;
+	@ApiPropertyOptional({ type: GroupResponse }) group?: Group | undefined;
+}
+
+export class EventResponse implements Omit<Event, "setLeaders"> {
 	id!: number;
 	name!: string;
 	@ApiProperty({ enum: EventStates, enumName: "EventStatesEnum" }) status!: EventStates;
 	dateFrom!: string;
 	dateTill!: string;
 	leadersEvent!: boolean;
-	groupsIds!: number[];
 	hasRegistration!: boolean;
 
 	type!: string | null;
@@ -39,8 +46,8 @@ export class EventResponse implements Omit<Event, "setLeaders" | "setGroups" | "
 	deletedAt?: Date | null;
 	report!: string | null;
 
+	@ApiPropertyOptional({ type: EventGroupResponse, isArray: true }) eventGroups?: EventGroup[] | undefined;
 	@ApiPropertyOptional({ type: AlbumResponse }) album?: Album | undefined;
-	@ApiPropertyOptional({ type: GroupResponse, isArray: true }) groups?: Group[] | undefined;
 	@ApiPropertyOptional({ type: EventAttendeeResponse, isArray: true }) attendees?: EventAttendee[] | undefined;
 	@ApiPropertyOptional({ type: EventExpenseResponse, isArray: true }) expenses?: EventExpense[] | undefined;
 	@ApiPropertyOptional({ type: MemberResponse, isArray: true }) leaders?: Member[] | undefined;
@@ -62,11 +69,6 @@ export class EventUpdateBody {
 	@IsOptional() @IsBoolean() leadersEvent?: boolean;
 	@IsOptional() @IsBoolean() hasRegistration?: boolean;
 
-	@ApiPropertyOptional({ type: "number", isArray: true })
-	@IsOptional()
-	@IsNumber({}, { each: true })
-	groupsIds?: number[];
-
 	@IsOptional() @IsString() type?: string | null;
 	@IsOptional() @IsString() description?: string | null;
 	@ApiPropertyOptional({ type: "number" }) @IsOptional() @IsNumber() price?: number | null;
@@ -85,4 +87,12 @@ export class EventUpdateBody {
 
 export class EventStatusChangeBody {
 	@IsString() @IsOptional() statusNote?: string;
+}
+
+// Replaces the full set of groups an event belongs to (see EventsController.updateEventGroups).
+export class EventGroupsUpdateBody {
+	@ApiProperty({ type: "number", isArray: true })
+	@IsNumber({}, { each: true })
+	@ArrayUnique()
+	groupsIds!: number[];
 }

--- a/backend/src/api/events/dto/event.dto.ts
+++ b/backend/src/api/events/dto/event.dto.ts
@@ -12,7 +12,8 @@ import { Member } from "src/models/members/entities/member.entity";
 import { EventAttendeeResponse } from "./event-attendee.dto";
 import { EventExpenseResponse } from "./event-expense.dto";
 
-export class EventResponse implements Omit<Event, "setLeaders"> {
+// eventGroups is the raw join-table relation; the response exposes the derived groups/groupsIds instead.
+export class EventResponse implements Omit<Event, "setLeaders" | "setGroups" | "eventGroups"> {
 	id!: number;
 	name!: string;
 	@ApiProperty({ enum: EventStates, enumName: "EventStatesEnum" }) status!: EventStates;

--- a/backend/src/api/public/services/public.service.ts
+++ b/backend/src/api/public/services/public.service.ts
@@ -111,8 +111,8 @@ export class PublicService {
 	}
 
 	private serializeEvent(event: Event, groupNameById: Map<number, string>) {
-		const groups = (event.groupsIds ?? [])
-			.map((id) => groupNameById.get(id))
+		const groups = (event.eventGroups ?? [])
+			.map((eventGroup) => groupNameById.get(eventGroup.groupId))
 			.filter((name): name is string => !!name);
 
 		return {

--- a/backend/src/models/events/entities/event-group.entity.ts
+++ b/backend/src/models/events/entities/event-group.entity.ts
@@ -1,16 +1,21 @@
 import { Group } from "src/models/members/entities/group.entity";
-import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
+import { Entity, Index, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
 import { Event } from "./event.entity";
 
+// The events<->groups join table is mapped explicitly by this entity only. Do not add a
+// @ManyToMany/@JoinTable over "events_groups" as well — two metadata objects for one table make
+// the schema builder drop and recreate the FK indexes in every generated migration.
 @Entity("events_groups")
 export class EventGroup {
 	@PrimaryColumn()
+	@Index()
 	eventId!: number;
 
 	@PrimaryColumn()
+	@Index()
 	groupId!: number;
 
-	@ManyToOne(() => Event, { onDelete: "CASCADE", onUpdate: "CASCADE" })
+	@ManyToOne(() => Event, (event) => event.eventGroups, { onDelete: "CASCADE", onUpdate: "CASCADE" })
 	@JoinColumn({ name: "event_id" })
 	event?: Event;
 

--- a/backend/src/models/events/entities/event.entity.ts
+++ b/backend/src/models/events/entities/event.entity.ts
@@ -2,19 +2,9 @@ import { ApiProperty } from "@nestjs/swagger";
 import { Album } from "src/models/albums/entities/album.entity";
 import { Group } from "src/models/members/entities/group.entity";
 import { Member } from "src/models/members/entities/member.entity";
-import {
-	AfterLoad,
-	Column,
-	DeleteDateColumn,
-	Entity,
-	JoinTable,
-	ManyToMany,
-	OneToMany,
-	OneToOne,
-	PrimaryGeneratedColumn,
-	RelationId,
-} from "typeorm";
+import { AfterLoad, Column, DeleteDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import { EventAttendee, EventAttendeeType } from "./event-attendee.entity";
+import { EventGroup } from "./event-group.entity";
 import { EventExpense } from "./event-expense.entity";
 
 export enum EventStates {
@@ -38,11 +28,13 @@ export class Event {
 	@OneToOne(() => Album, (album) => album.event)
 	album?: Album;
 
-	@RelationId((event: Event) => event.groups)
-	groupsIds!: number[];
+	@OneToMany(() => EventGroup, (eventGroup) => eventGroup.event, { onDelete: "CASCADE", onUpdate: "CASCADE" })
+	eventGroups?: EventGroup[];
 
-	@ManyToMany(() => Group, { onDelete: "CASCADE", onUpdate: "CASCADE" })
-	@JoinTable({ name: "events_groups", joinColumn: { name: "event_id" }, inverseJoinColumn: { name: "group_id" } })
+	// Derived from eventGroups by setGroups() — the join table is mapped explicitly (EventGroup),
+	// so these are not relations themselves. Every read path has to join eventGroups for them to
+	// be populated; `groups` additionally needs eventGroups.group joined.
+	groupsIds!: number[];
 	groups?: Group[];
 
 	@OneToMany(() => EventAttendee, (ea) => ea.event, { onDelete: "CASCADE", onUpdate: "CASCADE" })
@@ -76,6 +68,21 @@ export class Event {
 	@DeleteDateColumn() deletedAt?: Date | null;
 
 	leaders?: Member[];
+
+	// Only fills what was actually joined: without eventGroups both stay untouched (rather than
+	// being set to an empty array, which would claim the event has no groups), and `groups` is
+	// left alone unless the group relation itself was selected too.
+	@AfterLoad()
+	setGroups() {
+		if (!this.eventGroups) return;
+
+		this.groupsIds = this.eventGroups.map((eventGroup) => eventGroup.groupId);
+
+		const groups = this.eventGroups
+			.map((eventGroup) => eventGroup.group)
+			.filter((group): group is Group => !!group);
+		if (groups.length && groups.length === this.eventGroups.length) this.groups = groups;
+	}
 
 	@AfterLoad()
 	setLeaders() {

--- a/backend/src/models/events/entities/event.entity.ts
+++ b/backend/src/models/events/entities/event.entity.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Album } from "src/models/albums/entities/album.entity";
-import { Group } from "src/models/members/entities/group.entity";
 import { Member } from "src/models/members/entities/member.entity";
 import { AfterLoad, Column, DeleteDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 import { EventAttendee, EventAttendeeType } from "./event-attendee.entity";
@@ -28,14 +27,11 @@ export class Event {
 	@OneToOne(() => Album, (album) => album.event)
 	album?: Album;
 
+	// The events<->groups membership. The join table is mapped explicitly (EventGroup), so this is
+	// the single source of truth for an event's groups — reads join it, writes go through
+	// EventsRepository.updateEventGroups(). Consumers read the group ids off eventGroups[].groupId.
 	@OneToMany(() => EventGroup, (eventGroup) => eventGroup.event, { onDelete: "CASCADE", onUpdate: "CASCADE" })
 	eventGroups?: EventGroup[];
-
-	// Derived from eventGroups by setGroups() — the join table is mapped explicitly (EventGroup),
-	// so these are not relations themselves. Every read path has to join eventGroups for them to
-	// be populated; `groups` additionally needs eventGroups.group joined.
-	groupsIds!: number[];
-	groups?: Group[];
 
 	@OneToMany(() => EventAttendee, (ea) => ea.event, { onDelete: "CASCADE", onUpdate: "CASCADE" })
 	attendees?: EventAttendee[];
@@ -68,21 +64,6 @@ export class Event {
 	@DeleteDateColumn() deletedAt?: Date | null;
 
 	leaders?: Member[];
-
-	// Only fills what was actually joined: without eventGroups both stay untouched (rather than
-	// being set to an empty array, which would claim the event has no groups), and `groups` is
-	// left alone unless the group relation itself was selected too.
-	@AfterLoad()
-	setGroups() {
-		if (!this.eventGroups) return;
-
-		this.groupsIds = this.eventGroups.map((eventGroup) => eventGroup.groupId);
-
-		const groups = this.eventGroups
-			.map((eventGroup) => eventGroup.group)
-			.filter((group): group is Group => !!group);
-		if (groups.length && groups.length === this.eventGroups.length) this.groups = groups;
-	}
 
 	@AfterLoad()
 	setLeaders() {

--- a/backend/src/models/events/repositories/events.repository.ts
+++ b/backend/src/models/events/repositories/events.repository.ts
@@ -44,7 +44,7 @@ export class EventsRepository {
 				"events.meetingPlaceStart",
 				"events.meetingPlaceEnd",
 			])
-			// joined so Event.setGroups() can populate groupsIds, which every list consumer expects
+			// joined so the response carries eventGroups (group ids), which every list consumer expects
 			.leftJoinAndSelect("events.eventGroups", "eventGroups")
 			.leftJoinAndSelect("events.attendees", "attendees", "attendees.type = :type", { type: "leader" })
 			.leftJoinAndSelect("attendees.member", "leaders")
@@ -224,16 +224,7 @@ export class EventsRepository {
 	}
 
 	async updateEvent(id: number, data: Partial<Event>) {
-		const groupsIds = data.groupsIds;
-		delete data.groupsIds;
-
-		data.id = id;
-
-		const event = await this.eventsRepository.save(data);
-
-		if (groupsIds) await this.setEventGroups(id, groupsIds);
-
-		return event;
+		return this.eventsRepository.save({ ...data, id });
 	}
 
 	/**
@@ -241,7 +232,7 @@ export class EventsRepository {
 	 * (EventGroup) rather than through @JoinTable, so membership is synced here instead of falling
 	 * out of a cascading save. Delete-then-insert is fine at this size and keeps it order-independent.
 	 */
-	private async setEventGroups(eventId: number, groupsIds: number[]) {
+	async updateEventGroups(eventId: number, groupsIds: number[]) {
 		await this.eventGroupsRepository.manager.transaction(async (manager) => {
 			const eventGroups = manager.getRepository(EventGroup);
 

--- a/backend/src/models/events/repositories/events.repository.ts
+++ b/backend/src/models/events/repositories/events.repository.ts
@@ -2,10 +2,10 @@ import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { PaginationOptions } from "src/helpers/pagination";
 import { applySort } from "src/helpers/sort";
-import { Group } from "src/models/members/entities/group.entity";
-import { Brackets, FindOptionsSelect, Repository } from "typeorm";
+import { Brackets, FindOptionsSelect, In, Not, Repository } from "typeorm";
 import { EventAttendee, EventAttendeeType } from "../entities/event-attendee.entity";
 import { EventExpense } from "../entities/event-expense.entity";
+import { EventGroup } from "../entities/event-group.entity";
 import { Event, EventStates } from "../entities/event.entity";
 
 export interface GetEventsOptions extends PaginationOptions {
@@ -23,6 +23,7 @@ export interface GetEventsOptions extends PaginationOptions {
 export class EventsRepository {
 	constructor(
 		@InjectRepository(Event) private eventsRepository: Repository<Event>,
+		@InjectRepository(EventGroup) private eventGroupsRepository: Repository<EventGroup>,
 		@InjectRepository(EventAttendee) private eventAttendeesRepository: Repository<EventAttendee>,
 		@InjectRepository(EventExpense) private eventExpensesRepository: Repository<EventExpense>,
 	) {}
@@ -43,6 +44,8 @@ export class EventsRepository {
 				"events.meetingPlaceStart",
 				"events.meetingPlaceEnd",
 			])
+			// joined so Event.setGroups() can populate groupsIds, which every list consumer expects
+			.leftJoinAndSelect("events.eventGroups", "eventGroups")
 			.leftJoinAndSelect("events.attendees", "attendees", "attendees.type = :type", { type: "leader" })
 			.leftJoinAndSelect("attendees.member", "leaders")
 			// row-level permission filter (see Permission.canWhere)
@@ -126,7 +129,8 @@ export class EventsRepository {
 				"events.leadersEvent",
 				"events.hasRegistration",
 			])
-			.leftJoinAndSelect("events.groups", "groups")
+			.leftJoinAndSelect("events.eventGroups", "eventGroups")
+			.leftJoinAndSelect("eventGroups.group", "groups")
 			.leftJoinAndSelect("events.attendees", "attendees", "attendees.type = :type", { type: "leader" })
 			.leftJoinAndSelect("attendees.member", "leaders")
 			.where("events.status IN (:...statuses)", { statuses: [EventStates.public, EventStates.cancelled] })
@@ -159,7 +163,7 @@ export class EventsRepository {
 		const event = await this.eventsRepository.findOne({
 			where: { id },
 			select: options.select,
-			relations: { album: true },
+			relations: { album: true, eventGroups: true },
 			withDeleted: true,
 		});
 		if (!event) return null;
@@ -190,6 +194,7 @@ export class EventsRepository {
 				"events.type",
 				"events.deletedAt",
 			])
+			.leftJoinAndSelect("events.eventGroups", "eventGroups")
 			.leftJoinAndSelect("events.attendees", "attendees", "attendees.type = :type", { type: "leader" })
 			.leftJoinAndSelect("attendees.member", "leaders")
 			.withDeleted()
@@ -219,14 +224,39 @@ export class EventsRepository {
 	}
 
 	async updateEvent(id: number, data: Partial<Event>) {
-		if (data.groupsIds) {
-			data.groups = data.groupsIds.map((id) => ({ id }) as Group);
-			delete data.groupsIds;
-		}
+		const groupsIds = data.groupsIds;
+		delete data.groupsIds;
 
 		data.id = id;
 
-		return this.eventsRepository.save(data);
+		const event = await this.eventsRepository.save(data);
+
+		if (groupsIds) await this.setEventGroups(id, groupsIds);
+
+		return event;
+	}
+
+	/**
+	 * Replaces the event's rows in the events_groups join table. The table is mapped explicitly
+	 * (EventGroup) rather than through @JoinTable, so membership is synced here instead of falling
+	 * out of a cascading save. Delete-then-insert is fine at this size and keeps it order-independent.
+	 */
+	private async setEventGroups(eventId: number, groupsIds: number[]) {
+		await this.eventGroupsRepository.manager.transaction(async (manager) => {
+			const eventGroups = manager.getRepository(EventGroup);
+
+			if (groupsIds.length) {
+				await eventGroups.delete({ eventId, groupId: Not(In(groupsIds)) });
+				await eventGroups
+					.createQueryBuilder()
+					.insert()
+					.values(groupsIds.map((groupId) => ({ eventId, groupId })))
+					.orIgnore()
+					.execute();
+			} else {
+				await eventGroups.delete({ eventId });
+			}
+		});
 	}
 
 	async deleteEvent(id: number) {

--- a/backend/src/models/users/entities/user.entity.ts
+++ b/backend/src/models/users/entities/user.entity.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Member } from "src/models/members/entities/member.entity";
-import { Column, Entity, Index, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 export enum UserRoles {
 	"admin" = "admin",
@@ -8,8 +8,9 @@ export enum UserRoles {
 	"program" = "program",
 }
 
+// No @Index on login — @Column({ unique: true }) below already enforces it (constraint
+// UQ_2d443082eccd5198f95f2a36e2c); a second unique index would only duplicate it.
 @Entity("users")
-@Index(["login"], { unique: true })
 export class User {
 	@PrimaryGeneratedColumn()
 	id!: number;

--- a/backend/src/mongo-import/services/mongo-import.service.ts
+++ b/backend/src/mongo-import/services/mongo-import.service.ts
@@ -216,13 +216,11 @@ export class MongoImportService {
 			let status = <any>mongoEvent.status ?? EventStates.draft;
 			if (status === "rejected") status = EventStates.pending;
 
-			const groups = await Promise.all(
-				mongoEvent.groups
-					?.filter((g) => g !== "V")
-					.map((g) => this.getGroupId(t, g).then((id) => ({ id }) as Group)) ?? [],
+			const groupsIds = await Promise.all(
+				mongoEvent.groups?.filter((g) => g !== "V").map((g) => this.getGroupId(t, g)) ?? [],
 			);
 
-			const eventData: Omit<Event, "id" | "setLeaders" | "groupsIds"> = {
+			const eventData: Omit<Event, "id" | "setLeaders" | "setGroups" | "groupsIds" | "eventGroups"> = {
 				name: mongoEvent.name,
 				status,
 				statusNote: mongoEvent.statusNote ?? null,
@@ -243,10 +241,19 @@ export class MongoImportService {
 				leadersEvent: mongoEvent.groups?.includes("V") || false,
 				hasRegistration: false, // TODO: migrate registration
 				report: null,
-				groups,
+				groups: undefined,
 			};
 
 			const event = await t.save(Event, eventData);
+
+			// events_groups is mapped explicitly (EventGroup), so the join rows are written directly
+			// instead of cascading out of the event save
+			if (groupsIds.length) {
+				await t.insert(
+					EventGroup,
+					groupsIds.map((groupId) => ({ eventId: event.id, groupId })),
+				);
+			}
 
 			eventIds[mongoEvent._id.toString()] = event.id;
 

--- a/backend/src/mongo-import/services/mongo-import.service.ts
+++ b/backend/src/mongo-import/services/mongo-import.service.ts
@@ -220,7 +220,7 @@ export class MongoImportService {
 				mongoEvent.groups?.filter((g) => g !== "V").map((g) => this.getGroupId(t, g)) ?? [],
 			);
 
-			const eventData: Omit<Event, "id" | "setLeaders" | "setGroups" | "groupsIds" | "eventGroups"> = {
+			const eventData: Omit<Event, "id" | "setLeaders" | "eventGroups"> = {
 				name: mongoEvent.name,
 				status,
 				statusNote: mongoEvent.statusNote ?? null,
@@ -241,7 +241,6 @@ export class MongoImportService {
 				leadersEvent: mongoEvent.groups?.includes("V") || false,
 				hasRegistration: false, // TODO: migrate registration
 				report: null,
-				groups: undefined,
 			};
 
 			const event = await t.save(Event, eventData);

--- a/frontend/src/app/features/events/components/event-info/event-info.component.html
+++ b/frontend/src/app/features/events/components/event-info/event-info.component.html
@@ -85,8 +85,8 @@
 			<bo-item label="Oddíl" [loading]="!event()">
 				<bo-group-select
 					[disabled]="!canEdit()"
-					[ngModel]="event()?.groupsIds ?? []"
-					(ngModelChange)="update.emit({ groupsIds: $event })"
+					[ngModel]="groupsIds()"
+					(ngModelChange)="updateGroups.emit($event)"
 					[multiple]="true"
 				></bo-group-select>
 			</bo-item>

--- a/frontend/src/app/features/events/components/event-info/event-info.component.ts
+++ b/frontend/src/app/features/events/components/event-info/event-info.component.ts
@@ -46,8 +46,12 @@ import { EventRegistrationComponent } from "../event-registration/event-registra
 export class EventInfoComponent {
 	event = input<SDK.EventResponseWithLinks | undefined>(undefined);
 	update = output<SDK.EventUpdateBody>();
+	updateGroups = output<number[]>();
 
 	canEdit = computed(() => this.event()?._links?.updateEvent?.allowed ?? false);
+
+	// group ids are read off the eventGroups join rows (there is no derived groupsIds field anymore)
+	groupsIds = computed(() => this.event()?.eventGroups?.map((eventGroup) => eventGroup.groupId) ?? []);
 
 	placeCoordinates = computed(() => {
 		const geom = this.event()?.placeGeometry;

--- a/frontend/src/app/features/events/pages/event-view/event-view.component.html
+++ b/frontend/src/app/features/events/pages/event-view/event-view.component.html
@@ -30,6 +30,7 @@
 				class="mb-5"
 				[class.d-none]="view() !== 'info'"
 				(update)="updateEvent($event)"
+				(updateGroups)="updateEventGroups($event)"
 			></bo-event-info>
 
 			<bo-event-attendees

--- a/frontend/src/app/features/events/pages/event-view/event-view.component.ts
+++ b/frontend/src/app/features/events/pages/event-view/event-view.component.ts
@@ -116,6 +116,21 @@ export class EventViewComponent implements ViewWillEnter, ViewWillLeave {
 		await this.loadEvent(this.event()!.id);
 	}
 
+	async updateEventGroups(groupsIds: number[]) {
+		const event = this.event();
+		if (!event) return;
+
+		try {
+			this.event.set({ ...event, eventGroups: groupsIds.map((groupId) => ({ eventId: event.id, groupId })) });
+			await this.api.EventsApi.updateEventGroups(event.id, { groupsIds });
+			this.toastService.toast("Uloženo.");
+		} catch (e) {
+			this.toastService.toast("Nepodařilo se uložit změny.", { color: "warning" });
+		}
+
+		await this.loadEvent(event.id);
+	}
+
 	private async loadEvent(eventId: number) {
 		const event = await this.api.EventsApi.getEvent(eventId).then((res) => res.data);
 		this.event.set(event);

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -743,16 +743,10 @@ export namespace SDK {
         'album'?: Album;
         /**
          * 
-         * @type {Array<number>}
+         * @type {Array<EventGroup>}
          * @memberof Event
          */
-        'groupsIds': Array<number>;
-        /**
-         * 
-         * @type {Array<Group>}
-         * @memberof Event
-         */
-        'groups'?: Array<Group>;
+        'eventGroups'?: Array<EventGroup>;
         /**
          * 
          * @type {Array<EventAttendee>}
@@ -1452,6 +1446,78 @@ export namespace SDK {
         /**
      * 
      * @export
+     * @interface EventGroup
+     */
+    export interface EventGroup {
+        /**
+         * 
+         * @type {number}
+         * @memberof EventGroup
+         */
+        'eventId': number;
+        /**
+         * 
+         * @type {number}
+         * @memberof EventGroup
+         */
+        'groupId': number;
+        /**
+         * 
+         * @type {Event}
+         * @memberof EventGroup
+         */
+        'event'?: Event;
+        /**
+         * 
+         * @type {Group}
+         * @memberof EventGroup
+         */
+        'group'?: Group;
+    }
+    
+        /**
+     * 
+     * @export
+     * @interface EventGroupResponse
+     */
+    export interface EventGroupResponse {
+        /**
+         * 
+         * @type {GroupResponse}
+         * @memberof EventGroupResponse
+         */
+        'group'?: GroupResponse;
+        /**
+         * 
+         * @type {number}
+         * @memberof EventGroupResponse
+         */
+        'eventId': number;
+        /**
+         * 
+         * @type {number}
+         * @memberof EventGroupResponse
+         */
+        'groupId': number;
+    }
+    
+        /**
+     * 
+     * @export
+     * @interface EventGroupsUpdateBody
+     */
+    export interface EventGroupsUpdateBody {
+        /**
+         * 
+         * @type {Array<number>}
+         * @memberof EventGroupsUpdateBody
+         */
+        'groupsIds': Array<number>;
+    }
+    
+        /**
+     * 
+     * @export
      * @interface EventPlaceGeometry
      */
     export interface EventPlaceGeometry {
@@ -1483,16 +1549,16 @@ export namespace SDK {
         'status': EventStatesEnum;
         /**
          * 
+         * @type {Array<EventGroupResponse>}
+         * @memberof EventResponse
+         */
+        'eventGroups'?: Array<EventGroupResponse>;
+        /**
+         * 
          * @type {Album}
          * @memberof EventResponse
          */
         'album'?: Album;
-        /**
-         * 
-         * @type {Array<GroupResponse>}
-         * @memberof EventResponse
-         */
-        'groups'?: Array<GroupResponse>;
         /**
          * 
          * @type {Array<EventAttendeeResponse>}
@@ -1541,12 +1607,6 @@ export namespace SDK {
          * @memberof EventResponse
          */
         'leadersEvent': boolean;
-        /**
-         * 
-         * @type {Array<number>}
-         * @memberof EventResponse
-         */
-        'groupsIds': Array<number>;
         /**
          * 
          * @type {boolean}
@@ -1754,6 +1814,12 @@ export namespace SDK {
          * @type {AcLink}
          * @memberof EventResponseLinks
          */
+        'updateEventGroups': AcLink;
+        /**
+         * 
+         * @type {AcLink}
+         * @memberof EventResponseLinks
+         */
         'deleteEvent': AcLink;
         /**
          * 
@@ -1825,16 +1891,16 @@ export namespace SDK {
         'status': EventStatesEnum;
         /**
          * 
+         * @type {Array<EventGroupResponse>}
+         * @memberof EventResponseWithLinks
+         */
+        'eventGroups'?: Array<EventGroupResponse>;
+        /**
+         * 
          * @type {Album}
          * @memberof EventResponseWithLinks
          */
         'album'?: Album;
-        /**
-         * 
-         * @type {Array<GroupResponse>}
-         * @memberof EventResponseWithLinks
-         */
-        'groups'?: Array<GroupResponse>;
         /**
          * 
          * @type {Array<EventAttendeeResponse>}
@@ -1889,12 +1955,6 @@ export namespace SDK {
          * @memberof EventResponseWithLinks
          */
         'leadersEvent': boolean;
-        /**
-         * 
-         * @type {Array<number>}
-         * @memberof EventResponseWithLinks
-         */
-        'groupsIds': Array<number>;
         /**
          * 
          * @type {boolean}
@@ -2031,12 +2091,6 @@ export namespace SDK {
      * @interface EventUpdateBody
      */
     export interface EventUpdateBody {
-        /**
-         * 
-         * @type {Array<number>}
-         * @memberof EventUpdateBody
-         */
-        'groupsIds'?: Array<number>;
         /**
          * 
          * @type {number}
@@ -5246,6 +5300,10 @@ export namespace SDK {
     
     
     
+    
+    
+    
+    
     /**
      * EventsApi - object-oriented interface
      * @export
@@ -6869,6 +6927,57 @@ export namespace SDK {
             }
     
             const axiosRequestConfig: AxiosRequestConfig = { method: 'PATCH', ...baseOptions, ...options};
+            const requestHeaderParameter = {} as any;
+            const requestQueryParameter = {} as any;
+    
+    
+    
+            requestHeaderParameter['Content-Type'] = 'application/json';
+    
+            setSearchParams(requestUrlObj, requestQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            axiosRequestConfig.headers = {...requestHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            axiosRequestConfig.data = serializeDataIfNeeded(body, axiosRequestConfig, this.configuration)
+    
+            axiosRequestConfig["url"] = toPathString(requestUrlObj);
+            axiosRequestConfig["baseURL"] = this.configuration.basePath;
+            
+            return this.axios.request<void>(axiosRequestConfig);
+        }
+    
+        /**
+         * 
+    
+         * @param {number} id 
+         * @param {AxiosRequestConfig} [options] Override http request option.
+         * @throws {RequiredError}
+         * @memberof EventsApi
+         */
+        
+        public async updateEventGroups(
+            id: number,
+            body: EventGroupsUpdateBody,
+            options: AxiosRequestConfig = {}
+        ) {
+    
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('updateEventGroups', 'id', id)
+            assertParamExists('updateEventGroups', 'eventGroupsUpdateBody', body)
+            
+            // verify required parameter 'eventGroupsUpdateBody' is not null or undefined
+            assertParamExists('updateEventGroups', 'id', id)
+            assertParamExists('updateEventGroups', 'eventGroupsUpdateBody', body)
+            
+            const localVarPath = `/api/events/{id}/groups`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (this.configuration) {
+                baseOptions = this.configuration.baseOptions;
+            }
+    
+            const axiosRequestConfig: AxiosRequestConfig = { method: 'PUT', ...baseOptions, ...options};
             const requestHeaderParameter = {} as any;
             const requestQueryParameter = {} as any;
     


### PR DESCRIPTION
# Změny

Přiřazení oddílů k akci teď stojí výhradně na explicitně mapované relaci `eventGroups`; odvozená pole `groups` / `groupsIds` mizí.

 - Odstraněna odvozená pole `Event.groups` a `Event.groupsIds` i `@AfterLoad` hook `setGroups()`. ID oddílů se čtou z `eventGroups[].groupId`.
 - `EventResponse` nově vystavuje `eventGroups` (nový `EventGroupResponse`) místo `groups` / `groupsIds`.
 - Úprava oddílů přesunuta z obecného `PATCH /events/:id` do samostatného endpointu `PUT /events/:id/groups` (`EventGroupsUpdateBody`), chráněného novým `EventGroupsEditPermission`. `updateEvent()` už oddíly neřeší; synchronizace řádků join tabulky (`setEventGroups` → veřejné `updateEventGroups`) se volá z endpointu.
 - Veřejné API (program pro bosan.cz) **zachovává stejné schéma odpovědi** — pole `groups` s krátkými názvy oddílů, nově odvozené z `eventGroups` v `PublicService.serializeEvent()`.
 - Přegenerováno frontend SDK; editační formulář akce čte ID oddílů z `eventGroups` a ukládá je přes nový endpoint.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že u detailu akce v poli **Oddíl** vidíš správně přiřazené oddíly.
3. Změň přiřazení oddílů (přidej/odeber) a ověř, že se změna uloží (toast „Uloženo.“) a po obnovení stránky zůstane zachovaná.
4. Zkontroluj veřejný program na webu bosan.cz — u akcí se stále zobrazují správné krátké názvy oddílů (schéma se nezměnilo).

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xriVgCvHQsMGtQNKwN6JA

---
_Generated by [Claude Code](https://claude.ai/code/session_019xriVgCvHQsMGtQNKwN6JA)_