### PR TITLE
Dashboard kalendář: zobrazení aktuálního měsíce s přepínáním

### DIFF
--- a/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.html
+++ b/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.html
@@ -58,13 +58,36 @@
 				</div>
 			</div>
 			<div class="col-lg-6 col-xl-4 pl-lg-2">
-				<bo-event-calendar
-					[dateFrom]="dateFrom()"
-					[dateTill]="dateTill()"
-					[events]="events()"
-					[cpv]="true"
-					[headingLevel]="3"
-				></bo-event-calendar>
+				<div class="calendar-card">
+					<div class="calendar-nav">
+						<h3 class="calendar-nav-title mb-0">{{ monthTitle() }}</h3>
+						<div class="calendar-nav-buttons">
+							<button
+								type="button"
+								class="calendar-nav-button"
+								aria-label="Předchozí měsíc"
+								(click)="previousMonth()"
+							>
+								<ion-icon name="chevron-back-outline"></ion-icon>
+							</button>
+							<button
+								type="button"
+								class="calendar-nav-button"
+								aria-label="Následující měsíc"
+								(click)="nextMonth()"
+							>
+								<ion-icon name="chevron-forward-outline"></ion-icon>
+							</button>
+						</div>
+					</div>
+					<bo-event-calendar
+						[dateFrom]="dateFrom()"
+						[dateTill]="dateTill()"
+						[events]="events()"
+						[cpv]="true"
+						[headingLevel]="3"
+					></bo-event-calendar>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.scss
+++ b/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.scss
@@ -20,8 +20,10 @@
 }
 
 .calendar-nav-title {
+	margin: 0;
 	font-size: 1.1rem;
 	font-weight: 600;
+	line-height: 2rem;
 }
 
 .calendar-nav-buttons {

--- a/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.scss
+++ b/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.scss
@@ -5,12 +5,50 @@
 }
 
 // calendar column sits in a soft white card
-bo-event-calendar {
-	display: block;
+.calendar-card {
 	background-color: var(--bo-white);
 	border-radius: var(--bo-radius-card);
 	box-shadow: var(--bo-shadow-card);
 	padding: 0.75rem 1rem;
+}
+
+.calendar-nav {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 0.5rem;
+}
+
+.calendar-nav-title {
+	font-size: 1.1rem;
+	font-weight: 600;
+}
+
+.calendar-nav-buttons {
+	display: flex;
+	gap: 0.25rem;
+}
+
+.calendar-nav-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	padding: 0;
+	border: none;
+	border-radius: var(--bo-radius-btn);
+	background-color: transparent;
+	color: var(--bo-dark);
+	cursor: pointer;
+
+	&:hover {
+		background-color: var(--bo-light);
+	}
+
+	ion-icon {
+		font-size: 1.25rem;
+	}
 }
 
 .ribbon {

--- a/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.ts
+++ b/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.ts
@@ -1,7 +1,9 @@
-import { Component, OnInit, signal } from "@angular/core";
+import { Component, computed, OnInit, signal } from "@angular/core";
 import { RouterLink } from "@angular/router";
-import { PopoverController } from "@ionic/angular/standalone";
+import { IonIcon, PopoverController } from "@ionic/angular/standalone";
 import { UntilDestroy } from "@ngneat/until-destroy";
+import { addIcons } from "ionicons";
+import { chevronBackOutline, chevronForwardOutline } from "ionicons/icons";
 import { DateTime } from "luxon";
 import { ApiService } from "src/app/core/services/api.service";
 import { UserService } from "src/app/core/services/user.service";
@@ -11,6 +13,21 @@ import { PageContentComponent } from "src/app/shared/components/page-content/pag
 import { SDK } from "src/sdk";
 import { HomeCardMyEventsComponent } from "../home-card-my-events/home-card-my-events.component";
 import { HomeCardNoleaderEventsComponent } from "../home-card-noleader-events/home-card-noleader-events.component";
+
+const months = [
+	"Leden",
+	"Únor",
+	"Březen",
+	"Duben",
+	"Květen",
+	"Červen",
+	"Červenec",
+	"Srpen",
+	"Září",
+	"Říjen",
+	"Listopad",
+	"Prosinec",
+];
 
 @UntilDestroy()
 @Component({
@@ -23,14 +40,19 @@ import { HomeCardNoleaderEventsComponent } from "../home-card-noleader-events/ho
 		HomeCardNoleaderEventsComponent,
 		PageContentComponent,
 		ButtonSquareComponent,
+		IonIcon,
 		RouterLink,
 	],
 })
 export class HomeDashboardComponent implements OnInit {
 	view = signal("home");
 
-	dateFrom = signal(DateTime.local());
-	dateTill = signal(DateTime.local().plus({ months: 1 }));
+	currentMonth = signal(DateTime.local().startOf("month"));
+
+	dateFrom = computed(() => this.currentMonth().startOf("month"));
+	dateTill = computed(() => this.currentMonth().endOf("month"));
+
+	monthTitle = computed(() => `${months[this.currentMonth().month - 1]} ${this.currentMonth().year}`);
 
 	events = signal<SDK.EventResponseWithLinks[]>([]);
 
@@ -40,25 +62,23 @@ export class HomeDashboardComponent implements OnInit {
 		private api: ApiService,
 		private userService: UserService,
 		public popoverController: PopoverController,
-	) {}
+	) {
+		addIcons({ chevronBackOutline, chevronForwardOutline });
+	}
 
 	ngOnInit(): void {
 		this.loadCalendarEvents();
 	}
 
+	previousMonth() {
+		this.currentMonth.update((month) => month.minus({ months: 1 }));
+	}
+
+	nextMonth() {
+		this.currentMonth.update((month) => month.plus({ months: 1 }));
+	}
+
 	async loadCalendarEvents() {
-		const options: any = {
-			sort: "dateFrom",
-		};
-
-		this.dateTill.set(DateTime.local().plus({ months: 1 }));
-
-		options.filter = {
-			dateTill: { $gte: this.dateFrom().toISODate() },
-			dateFrom: { $lte: this.dateTill().toISODate() },
-		};
-
-		// TODO: use options above
 		const events = await this.api.EventsApi.listEvents().then((res: any) => res.data);
 		this.events.set(events);
 	}


### PR DESCRIPTION
# Změny

 - Kalendářová karta na nástěnce (home) nyní místo rolujícího zobrazení příštích týdnů ukazuje **aktuální měsíc**.
 - Nad kalendářem přibyl **název měsíce a rok** v nadpisu.
 - Vpravo na stejném řádku jako název jsou **šipky vlevo/vpravo** pro přepnutí na předchozí/následující měsíc.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že na nástěnce (úvodní stránka) kalendářová karta zobrazuje aktuální měsíc a nad ním je název měsíce s rokem.
3. Zkontroluj, že šipky jsou zarovnané vpravo na stejném řádku jako název měsíce.
4. Klikni na pravou šipku – kalendář se přepne na následující měsíc a název se aktualizuje.
5. Klikni na levou šipku – kalendář se přepne na předchozí měsíc a název se aktualizuje.
6. Zkontroluj, že akce se v kalendáři zobrazují ve správných dnech daného měsíce.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015nTHanxY2sXcTAZX2xykp8)_