### PR TITLE
fix(login): make Google login work with the single service-account key file

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -8,6 +8,20 @@ CORS_ORIGINS="http://localhost:4200"
 MONGODB_URI="mongodb://mongo:27017/bosan"
 MAPY_CZ_API_KEY=your_mapy_cz_api_key_here
 
+# Google
+# Directory that holds the mounted JSON key file(s). Default: ../keys (repo-root `keys/`).
+# KEYS_DIR=/keys
+# Service-account key used to send mail through the Gmail API (client_email + private_key).
+# Relative to KEYS_DIR. Default: google.json
+# GOOGLE_KEY_FILE=google.json
+# Mailbox the service account impersonates when sending. Default: interni@bosan.cz
+# GOOGLE_IMPERSONATE=interni@bosan.cz
+# "Web application" OAuth client used by the Google login popup. These can instead be read
+# from the `web`/`installed` block of the key file above (see backend/src/config.ts); set
+# them here to override the file.
+# GOOGLE_CLIENT_ID=xxxxxxxx.apps.googleusercontent.com
+# GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
+
 # Wiki.js SSO (OAuth2). See WIKI-SSO.md for setup.
 OAUTH_WIKI_CLIENT_ID=bosan-wiki
 OAUTH_WIKI_CLIENT_SECRET=change_me_generate_a_long_random_secret

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -9,18 +9,18 @@ MONGODB_URI="mongodb://mongo:27017/bosan"
 MAPY_CZ_API_KEY=your_mapy_cz_api_key_here
 
 # Google
-# Directory that holds the mounted JSON key file(s). Default: ../keys (repo-root `keys/`).
+# A single service-account key file drives the whole Google setup (mail + login), exactly
+# like the old server — no client secret is needed.
+# Directory that holds the mounted key file. Default: ../keys (repo-root `keys/`).
 # KEYS_DIR=/keys
 # Service-account key used to send mail through the Gmail API (client_email + private_key).
 # Relative to KEYS_DIR. Default: google.json
 # GOOGLE_KEY_FILE=google.json
 # Mailbox the service account impersonates when sending. Default: interni@bosan.cz
 # GOOGLE_IMPERSONATE=interni@bosan.cz
-# "Web application" OAuth client used by the Google login popup. These can instead be read
-# from the `web`/`installed` block of the key file above (see backend/src/config.ts); set
-# them here to override the file.
+# Public "Web application" OAuth client id used by the login popup. Not a secret; has a
+# sensible default in code. Override only if this deployment uses a different Google client.
 # GOOGLE_CLIENT_ID=xxxxxxxx.apps.googleusercontent.com
-# GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
 
 # Wiki.js SSO (OAuth2). See WIKI-SSO.md for setup.
 OAUTH_WIKI_CLIENT_ID=bosan-wiki

--- a/backend/src/api/account/controllers/login.controller.ts
+++ b/backend/src/api/account/controllers/login.controller.ts
@@ -9,7 +9,6 @@ import {
 	Query,
 	Req,
 	Res,
-	UnauthorizedException,
 } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { Request, Response } from "express";
@@ -68,11 +67,10 @@ export class LoginController {
 		@Res({ passthrough: true }) res: Response,
 		@Body() body: LoginGoogleBody,
 	) {
-		const tokenInfo = await this.googleService.validateOauthToken(body.token);
-		if (!tokenInfo?.email) throw new UnauthorizedException("Email missing in Google user account.");
+		const { email } = await this.googleService.validateAccessToken(body.token);
 
-		const user = await this.users.findUser({ email: tokenInfo.email });
-		if (!user) throw new NotFoundException(`User with email ${tokenInfo.email} not found.`);
+		const user = await this.users.findUser({ email });
+		if (!user) throw new NotFoundException(`User with email ${email} not found.`);
 
 		LoginGooglePermission.canOrThrow(req);
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,6 +1,5 @@
 import { Global, Injectable, Logger, LogLevel, Module } from "@nestjs/common";
 import { config } from "dotenv";
-import { readFileSync } from "fs";
 import * as path from "path";
 import { DataSourceOptions } from "typeorm";
 import { SnakeNamingStrategy } from "./database/snake-naming.strategy";
@@ -112,43 +111,24 @@ const photos = {
 };
 
 /**
- * Google credentials.
+ * Google.
  *
- * Two distinct Google artifacts are involved, and both can be supplied through the mounted
- * JSON key file (in {@link fs.keysDir}, default `keys/google.json`) — mirroring the old
- * server, which loaded everything from `google.json` — with environment variables taking
- * precedence when set:
- *   - a **service-account** key (`client_email` + `private_key`) used to send mail through
- *     the Gmail API. Always read from the file, lazily, by GoogleService (`google.keyFile`).
- *   - the **"Web application" OAuth client** (`client_id` + `client_secret`) used by the
- *     Google login popup / auth-code exchange. Read from the same file's `web` / `installed`
- *     block (the shape Google Cloud downloads), or a hand-merged top-level block, and
- *     overridable via GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET.
+ * The whole Google setup runs off a single mounted service-account key file (default
+ * `keys/google.json`), exactly like the old server: it is used to send mail through the
+ * Gmail API, and login only *verifies* the token the frontend obtains, which needs no
+ * client secret and no code exchange. So there is deliberately no GOOGLE_CLIENT_SECRET.
+ *
+ * `clientId` is the public "Web application" OAuth client id. It is not a secret (it ships
+ * in the frontend and is delivered to it via the API), so it carries a sensible default and
+ * is used only to check that login tokens were issued for this app. Override with
+ * GOOGLE_CLIENT_ID if the deployment uses a different Google Cloud OAuth client.
  */
-function loadJsonKeyfile(filePath: string): Record<string, any> {
-	try {
-		return JSON.parse(readFileSync(filePath, "utf8"));
-	} catch {
-		logger.log(`Google key file not found or unreadable at ${filePath}; relying on environment variables.`);
-		return {};
-	}
-}
-
-const googleKeyFile = path.join(fs.keysDir, process.env["GOOGLE_KEY_FILE"] ?? "google.json");
-const googleKeyfile = loadJsonKeyfile(googleKeyFile);
-// OAuth web-client credentials, if this file carries them. A pure service-account file
-// (type === "service_account") never does, and its numeric `client_id` must not be mistaken
-// for the login client id — so it is deliberately ignored in that case.
-const googleOauthClient: Record<string, any> =
-	googleKeyfile["web"] ??
-	googleKeyfile["installed"] ??
-	(googleKeyfile["type"] === "service_account" ? {} : googleKeyfile);
+const GOOGLE_CLIENT_ID = "249555539983-j8rvff7bovgnecsmjffe0a3dj55j33hh.apps.googleusercontent.com";
 
 const google = {
-	keyFile: googleKeyFile,
-	impersonate: process.env["GOOGLE_IMPERSONATE"] ?? googleKeyfile["impersonate"] ?? "interni@bosan.cz",
-	clientId: process.env["GOOGLE_CLIENT_ID"] ?? googleOauthClient["client_id"],
-	clientSecret: process.env["GOOGLE_CLIENT_SECRET"] ?? googleOauthClient["client_secret"],
+	keyFile: path.join(fs.keysDir, process.env["GOOGLE_KEY_FILE"] ?? "google.json"),
+	impersonate: process.env["GOOGLE_IMPERSONATE"] ?? "interni@bosan.cz",
+	clientId: process.env["GOOGLE_CLIENT_ID"] ?? GOOGLE_CLIENT_ID,
 };
 
 const mapy = {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,5 +1,6 @@
 import { Global, Injectable, Logger, LogLevel, Module } from "@nestjs/common";
 import { config } from "dotenv";
+import { readFileSync } from "fs";
 import * as path from "path";
 import { DataSourceOptions } from "typeorm";
 import { SnakeNamingStrategy } from "./database/snake-naming.strategy";
@@ -110,11 +111,44 @@ const photos = {
 	},
 };
 
+/**
+ * Google credentials.
+ *
+ * Two distinct Google artifacts are involved, and both can be supplied through the mounted
+ * JSON key file (in {@link fs.keysDir}, default `keys/google.json`) — mirroring the old
+ * server, which loaded everything from `google.json` — with environment variables taking
+ * precedence when set:
+ *   - a **service-account** key (`client_email` + `private_key`) used to send mail through
+ *     the Gmail API. Always read from the file, lazily, by GoogleService (`google.keyFile`).
+ *   - the **"Web application" OAuth client** (`client_id` + `client_secret`) used by the
+ *     Google login popup / auth-code exchange. Read from the same file's `web` / `installed`
+ *     block (the shape Google Cloud downloads), or a hand-merged top-level block, and
+ *     overridable via GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET.
+ */
+function loadJsonKeyfile(filePath: string): Record<string, any> {
+	try {
+		return JSON.parse(readFileSync(filePath, "utf8"));
+	} catch {
+		logger.log(`Google key file not found or unreadable at ${filePath}; relying on environment variables.`);
+		return {};
+	}
+}
+
+const googleKeyFile = path.join(fs.keysDir, process.env["GOOGLE_KEY_FILE"] ?? "google.json");
+const googleKeyfile = loadJsonKeyfile(googleKeyFile);
+// OAuth web-client credentials, if this file carries them. A pure service-account file
+// (type === "service_account") never does, and its numeric `client_id` must not be mistaken
+// for the login client id — so it is deliberately ignored in that case.
+const googleOauthClient: Record<string, any> =
+	googleKeyfile["web"] ??
+	googleKeyfile["installed"] ??
+	(googleKeyfile["type"] === "service_account" ? {} : googleKeyfile);
+
 const google = {
-	keyFile: path.join(fs.keysDir, process.env["GOOGLE_KEY_FILE"] ?? "google.json"),
-	impersonate: process.env["GOOGLE_IMPERSONATE"] ?? "interni@bosan.cz",
-	clientId: process.env["GOOGLE_CLIENT_ID"],
-	clientSecret: process.env["GOOGLE_CLIENT_SECRET"],
+	keyFile: googleKeyFile,
+	impersonate: process.env["GOOGLE_IMPERSONATE"] ?? googleKeyfile["impersonate"] ?? "interni@bosan.cz",
+	clientId: process.env["GOOGLE_CLIENT_ID"] ?? googleOauthClient["client_id"],
+	clientSecret: process.env["GOOGLE_CLIENT_SECRET"] ?? googleOauthClient["client_secret"],
 };
 
 const mapy = {

--- a/backend/src/models/google/services/google.service.ts
+++ b/backend/src/models/google/services/google.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { TokenPayload } from "google-auth-library";
 import { google } from "googleapis";
 import { Config } from "src/config";
 
@@ -8,12 +7,6 @@ export class GoogleService {
 	private readonly logger = new Logger(GoogleService.name);
 
 	readonly gmail = google.gmail({ version: "v1" });
-
-	readonly oauth = new google.auth.OAuth2({
-		clientId: this.config.google.clientId,
-		clientSecret: this.config.google.clientSecret,
-		redirectUri: "postmessage",
-	});
 
 	constructor(private readonly config: Config) {
 		const keyFilePath = this.config.google.keyFile;
@@ -31,19 +24,28 @@ export class GoogleService {
 		google.options({ auth });
 	}
 
-	async validateOauthToken(code: string): Promise<TokenPayload> {
-		const tokens = await this.oauth.getToken(code).then((res) => res.tokens);
-		if (!tokens.id_token) throw new Error("No id_token in Google response");
+	/**
+	 * Validate the Google OAuth access token the frontend obtained and return the signed-in
+	 * user's email.
+	 *
+	 * This only talks to Google's public tokeninfo endpoint, so it needs no client secret and
+	 * no code exchange — the single service-account key file (used for mail) is enough for the
+	 * whole Google setup, matching the old server.
+	 */
+	async validateAccessToken(accessToken: string): Promise<{ email: string }> {
+		const client = new google.auth.OAuth2();
 
-		const payload = await this.oauth
-			.verifyIdToken({
-				idToken: tokens.id_token,
-				audience: this.config.google.clientId,
-			})
-			.then((res) => res.getPayload());
+		// Throws on an invalid/expired token.
+		const info = await client.getTokenInfo(accessToken);
 
-		if (!payload) throw new Error("No payload in Google id token");
+		if (!info.email) throw new Error("Google account did not expose an email address");
 
-		return payload;
+		// When a login client id is known, make sure the token was actually minted for this
+		// app — otherwise an access token obtained for a different site could be replayed here.
+		if (this.config.google.clientId && info.aud !== this.config.google.clientId) {
+			throw new Error("Google token was not issued for this application");
+		}
+
+		return { email: info.email };
 	}
 }

--- a/frontend/src/app/core/services/google.service.ts
+++ b/frontend/src/app/core/services/google.service.ts
@@ -2,6 +2,7 @@
 
 import { Injectable } from "@angular/core";
 import { firstValueFrom } from "rxjs";
+import { Config } from "src/config";
 import { Logger } from "src/logger";
 import { ApiService } from "./api.service";
 
@@ -25,15 +26,23 @@ export class GoogleService {
 	private readonly logger = new Logger(GoogleService.name);
 
 	// Load the Google Identity Services client exactly once. Kicked off eagerly (see the
-	// constructor) so the library is ready by the time the user clicks: requestCode() has
-	// to run synchronously within the user gesture, otherwise the browser blocks the OAuth
+	// constructor) so the library is ready by the time the user clicks: requestAccessToken()
+	// has to run synchronously within the user gesture, otherwise the browser blocks the OAuth
 	// popup and the sign-in fails silently.
 	private gsiReady?: Promise<void>;
 
-	constructor(private api: ApiService) {
+	constructor(
+		private api: ApiService,
+		private config: Config,
+	) {
 		this.loadGsi().catch((err) => this.logger.error("Failed to preload Google Identity Services", err));
 	}
 
+	/**
+	 * Run the Google login popup and return an OAuth access token. The token is verified
+	 * server-side (see backend GoogleService.validateAccessToken), so the browser never needs
+	 * a client secret — only the public client id.
+	 */
 	async signIn(): Promise<string> {
 		await this.loadGsi();
 
@@ -41,14 +50,16 @@ export class GoogleService {
 			throw new GoogleError("Google Identity Services library is not available");
 		}
 
-		const client_id = await firstValueFrom(this.api.info).then((info) => info.googleClientId);
-		if (!client_id) throw new GoogleError("Google client ID was not provided by the API");
+		// Prefer the id the backend advertises, fall back to the frontend default so login
+		// works even with no backend Google configuration (as in the old deployment).
+		const info = await firstValueFrom(this.api.info);
+		const client_id = info.googleClientId || this.config.googleClientId;
+		if (!client_id) throw new GoogleError("No Google client ID configured");
 
-		const response = await new Promise<google.accounts.oauth2.CodeResponse>((resolve, reject) => {
-			const client = google.accounts.oauth2.initCodeClient({
+		const response = await new Promise<google.accounts.oauth2.TokenResponse>((resolve, reject) => {
+			const client = google.accounts.oauth2.initTokenClient({
 				client_id,
 				scope: "openid email profile",
-				ux_mode: "popup",
 				callback: (res) => resolve(res),
 				// Popup blocked, user cancelled, denied consent, unregistered origin, ... all
 				// arrive here (never in `callback`); without this handler they were dropped and
@@ -57,16 +68,16 @@ export class GoogleService {
 					reject(new GoogleError(err?.message || "Google sign-in was cancelled or failed", err?.type)),
 			});
 
-			client.requestCode();
+			client.requestAccessToken();
 		});
 
-		if (response.error || !response.code) {
+		if (response.error || !response.access_token) {
 			throw new GoogleError(
-				response.error_description || response.error || "No authorization code returned from Google",
+				response.error_description || response.error || "No access token returned from Google",
 			);
 		}
 
-		return response.code;
+		return response.access_token;
 	}
 
 	private loadGsi(): Promise<void> {

--- a/frontend/src/app/core/services/google.service.ts
+++ b/frontend/src/app/core/services/google.service.ts
@@ -2,45 +2,97 @@
 
 import { Injectable } from "@angular/core";
 import { firstValueFrom } from "rxjs";
+import { Logger } from "src/logger";
 import { ApiService } from "./api.service";
+
+const GSI_SRC = "https://accounts.google.com/gsi/client";
 
 export class GoogleError extends Error {
 	name: string = "GoogleError"; // when transpiled to ES5 cant test if instanceof GoogleError
 
 	description?: string;
+
+	constructor(message: string, description?: string) {
+		super(message);
+		this.description = description;
+	}
 }
 
 @Injectable({
 	providedIn: "root",
 })
 export class GoogleService {
-	constructor(private api: ApiService) {}
+	private readonly logger = new Logger(GoogleService.name);
 
-	async signIn() {
-		await new Promise<void>((resolve, reject) => {
-			const script = document.createElement("script");
-			script.src = "https://accounts.google.com/gsi/client";
-			script.onload = () => resolve();
-			script.onerror = (err) => reject(err);
-			document.body.appendChild(script);
-		});
+	// Load the Google Identity Services client exactly once. Kicked off eagerly (see the
+	// constructor) so the library is ready by the time the user clicks: requestCode() has
+	// to run synchronously within the user gesture, otherwise the browser blocks the OAuth
+	// popup and the sign-in fails silently.
+	private gsiReady?: Promise<void>;
+
+	constructor(private api: ApiService) {
+		this.loadGsi().catch((err) => this.logger.error("Failed to preload Google Identity Services", err));
+	}
+
+	async signIn(): Promise<string> {
+		await this.loadGsi();
+
+		if (typeof google === "undefined" || !google.accounts?.oauth2) {
+			throw new GoogleError("Google Identity Services library is not available");
+		}
 
 		const client_id = await firstValueFrom(this.api.info).then((info) => info.googleClientId);
-		if (!client_id) throw new Error("Client ID not provided by API");
+		if (!client_id) throw new GoogleError("Google client ID was not provided by the API");
 
 		const response = await new Promise<google.accounts.oauth2.CodeResponse>((resolve, reject) => {
 			const client = google.accounts.oauth2.initCodeClient({
 				client_id,
-				scope: "email",
+				scope: "openid email profile",
 				ux_mode: "popup",
-				callback: resolve,
+				callback: (res) => resolve(res),
+				// Popup blocked, user cancelled, denied consent, unregistered origin, ... all
+				// arrive here (never in `callback`); without this handler they were dropped and
+				// the promise hung forever.
+				error_callback: (err) =>
+					reject(new GoogleError(err?.message || "Google sign-in was cancelled or failed", err?.type)),
 			});
 
 			client.requestCode();
 		});
 
-		console.log(response);
+		if (response.error || !response.code) {
+			throw new GoogleError(
+				response.error_description || response.error || "No authorization code returned from Google",
+			);
+		}
 
 		return response.code;
+	}
+
+	private loadGsi(): Promise<void> {
+		if (this.gsiReady) return this.gsiReady;
+
+		this.gsiReady = new Promise<void>((resolve, reject) => {
+			const existing = document.querySelector<HTMLScriptElement>(`script[src="${GSI_SRC}"]`);
+			if (existing) {
+				if (typeof google !== "undefined" && google.accounts?.oauth2) return resolve();
+				existing.addEventListener("load", () => resolve());
+				existing.addEventListener("error", () => reject(new GoogleError("Failed to load Google Identity Services")));
+				return;
+			}
+
+			const script = document.createElement("script");
+			script.src = GSI_SRC;
+			script.async = true;
+			script.defer = true;
+			script.onload = () => resolve();
+			script.onerror = () => reject(new GoogleError("Failed to load Google Identity Services"));
+			document.body.appendChild(script);
+		});
+
+		// Allow a later retry if this attempt failed to load the library.
+		this.gsiReady.catch(() => (this.gsiReady = undefined));
+
+		return this.gsiReady;
 	}
 }

--- a/frontend/src/app/core/services/login.service.ts
+++ b/frontend/src/app/core/services/login.service.ts
@@ -2,6 +2,7 @@ import { EventEmitter, Injectable } from "@angular/core";
 
 import { ApiService } from "src/app/core/services/api.service";
 import { GoogleService } from "src/app/core/services/google.service";
+import { Logger } from "src/logger";
 import { ToastService } from "./toast.service";
 import { UserService } from "./user.service";
 
@@ -29,6 +30,8 @@ export class LoginError extends Error {
 	providedIn: "root",
 })
 export class LoginService {
+	private readonly logger = new Logger(LoginService.name);
+
 	onLogin: EventEmitter<void> = new EventEmitter();
 	onLogout: EventEmitter<void> = new EventEmitter();
 
@@ -78,6 +81,9 @@ export class LoginService {
 			// load user
 			await this.userService.loadUser();
 		} catch (err) {
+			// Keep the real cause visible in the console — the UI only shows a generic
+			// message, which previously made Google login failures impossible to diagnose.
+			this.logger.error("Google login failed", err);
 			throw new LoginError("googleFailed", err);
 		}
 	}

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -4,4 +4,9 @@ export class Config {
 	apiRoot = "/";
 
 	jwtDomains = ["bosan.cz"];
+
+	// Public "Web application" OAuth client id for "Sign in with Google". Safe to ship in the
+	// frontend — only the client *secret* is confidential, and this flow never uses one. The
+	// backend can override it through the /api info endpoint (googleClientId).
+	googleClientId = "249555539983-j8rvff7bovgnecsmjffe0a3dj55j33hh.apps.googleusercontent.com";
 }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -4,10 +4,4 @@ export class Config {
 	apiRoot = "/";
 
 	jwtDomains = ["bosan.cz"];
-
-	gapi = {
-		client_id: "249555539983-j8rvff7bovgnecsmjffe0a3dj55j33hh.apps.googleusercontent.com",
-		cookiepolicy: "single_host_origin",
-		scope: "profile email",
-	};
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -25,14 +25,6 @@
 
 		<!-- Google fonts - Roboto Condensed -->
 		<link href="https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap" rel="stylesheet" />
-
-		<!-- Google API -->
-		<script
-			src="https://apis.google.com/js/platform.js"
-			async=""
-			defer=""
-			onload="if(window.gapi_loaded){window.gapi_loaded();}"
-		></script>
 	</head>
 
 	<body>


### PR DESCRIPTION
# Změny

Přihlášení přes Google padalo na obecnou hlášku „Přihlášení přes Google se nezdařilo." bez chyby v konzoli a bez failnutého requestu. Dvě příčiny:

**1. Flow vyžadoval navíc Google web-client *secret* na backendu.** Nová verze používala auth-code flow (`initCodeClient` → backend `getToken(code)`), který potřebuje client id **i** client secret. Ty ale nejsou v jednom sdíleném service-account `google.json` (ten měl starý server pro mail i login). Proto se nová deployment nedala přihlásit se stejným one-file setupem jako dřív.

Návrat k původnímu modelu: frontend získá OAuth access token (`google.accounts.oauth2` token client) a backend ho jen **ověří** přes Google tokeninfo (`GoogleService.validateAccessToken`) — bez client secretu a bez výměny kódu. Jeden service-account klíč tak zase pokrývá celý Google setup (mail + login).

 - **Backend:** odstraněn code-exchange OAuth2 klient a `GOOGLE_CLIENT_SECRET`; access token se ověří a (když je znám client id) zkontroluje se jeho audience.
 - **Frontend:** `initTokenClient` / `requestAccessToken`; public client id se bere z API s výchozí hodnotou zabalenou ve frontendu, takže login nepotřebuje žádnou backendovou konfiguraci.
 - `.env.template` popisuje one-file, no-secret setup.

**2. Popup selhával potichu.** Zpevnění popup flow (platí i pro nový token client):
 - GSI klient se načítá jednou a dopředu (eager v konstruktoru), aby `requestAccessToken()` běžel v rámci user gesture a prohlížeč popup nezablokoval.
 - Přidán `error_callback` — zablokovaný / zavřený popup, odmítnutý souhlas i neregistrovaný origin teď vedou na srozumitelnou chybu místo tichého zamrznutí.
 - Skutečná příčina se loguje v `LoginService`.
 - Odstraněn deprecated a nepoužívaný `apis.google.com/js/platform.js` (přepisoval `window.google`) a mrtvá `gapi` konfigurace.

## Nasazení
 - Do `keys/` stačí jeden `google.json` (service account) — jako dřív. Žádný client secret.
 - Pokud deployment používá jiný Google OAuth client než výchozí, nastav `GOOGLE_CLIENT_ID` (public, není secret).
 - V Google Cloud musí mít Web OAuth client v **Authorized JavaScript origins** doménu `https://next.interni.bosan.cz`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
    - Klik na „Přihlásit přes Bošánovský mail" otevře Google popup (není zablokovaný).
    - Po výběru účtu proběhne přihlášení a přesměrování do aplikace.
    - Při zavření popupu / odmítnutí se objeví hláška o nezdaru a v konzoli je konkrétní příčina.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)