### PR TITLE
feat(albums): ukládat metadata.json do složky s fotkami alba

### DIFF
--- a/backend/src/models/albums/repositories/albums.repository.ts
+++ b/backend/src/models/albums/repositories/albums.repository.ts
@@ -4,6 +4,7 @@ import { PaginationOptions } from "src/helpers/pagination";
 import { applySort } from "src/helpers/sort";
 import { Brackets, FindOptionsRelations, Repository } from "typeorm";
 import { Album } from "../entities/album.entity";
+import { AlbumsMetadataService } from "../services/albums-metadata.service";
 import { PhotosRepository } from "./photos.repository";
 
 export interface GetAlbumsOptions extends PaginationOptions {
@@ -16,6 +17,7 @@ export interface GetAlbumsOptions extends PaginationOptions {
 export class AlbumsRepository {
 	constructor(
 		private photosService: PhotosRepository,
+		private albumsMetadata: AlbumsMetadataService,
 		@InjectRepository(Album) private repository: Repository<Album>,
 	) {}
 
@@ -115,11 +117,17 @@ export class AlbumsRepository {
 	}
 
 	async createAlbum(album: Partial<Album>) {
-		return this.repository.save(album);
+		const saved = await this.repository.save(album);
+		// Mirror the album's metadata into its photos directory as a DB-independent backup.
+		await this.albumsMetadata.writeAlbumMetadataById(saved.id);
+		return saved;
 	}
 
 	async updateAlbum(id: Album["id"], album: Partial<Album>) {
-		return this.repository.save({ ...album, id });
+		const saved = await this.repository.save({ ...album, id });
+		// Keep the on-disk metadata.json in sync with the album's persisted state.
+		await this.albumsMetadata.writeAlbumMetadataById(id);
+		return saved;
 	}
 
 	async deleteAlbum(id: Album["id"]) {

--- a/backend/src/models/albums/services/albums-metadata.service.ts
+++ b/backend/src/models/albums/services/albums-metadata.service.ts
@@ -1,8 +1,85 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { join } from "path";
+import { Config } from "src/config";
+import { FilesService } from "src/models/files/services/files.service";
+import { IsNull, Repository } from "typeorm";
+import { Album } from "../entities/album.entity";
+
+/**
+ * Shape of the `metadata.json` written next to an album's photos. It captures the album's
+ * human-meaningful fields so the gallery could be reconstructed from the photo files alone
+ * if the database were ever lost.
+ */
+export interface AlbumMetadata {
+	id: number;
+	name: string;
+	description: string | null;
+	dateFrom: string | null;
+	dateTill: string | null;
+	datePublished: Date | string | null;
+}
 
 @Injectable()
 export class AlbumsMetadataService {
-	async writeAlbumsMetadata() {
-		throw new Error("Not implemented.");
+	private logger = new Logger(AlbumsMetadataService.name);
+
+	constructor(
+		private config: Config,
+		private files: FilesService,
+		@InjectRepository(Album) private repository: Repository<Album>,
+	) {}
+
+	/** Path to an album's `metadata.json`, inside its photos directory. */
+	private getMetadataPath(albumId: number): string {
+		return join(this.config.fs.photosDir, String(albumId), "metadata.json");
+	}
+
+	private buildMetadata(album: Album): AlbumMetadata {
+		return {
+			id: album.id,
+			name: album.name,
+			description: album.description,
+			dateFrom: album.dateFrom,
+			dateTill: album.dateTill,
+			datePublished: album.datePublished,
+		};
+	}
+
+	/**
+	 * Write `metadata.json` for a single album into its photos directory. Best-effort: a failure
+	 * here (e.g. disk error) is logged but never propagated, so it can't break the album
+	 * create/update request that triggered it — the metadata file is a backup, not the source of
+	 * truth. Pass a freshly loaded album so the file reflects the persisted state.
+	 */
+	async writeAlbumMetadata(album: Album): Promise<void> {
+		const path = this.getMetadataPath(album.id);
+
+		try {
+			await this.files.saveFile(path, JSON.stringify(this.buildMetadata(album), null, "\t"));
+		} catch (err) {
+			this.logger.error(`Failed to write album metadata to ${path}: ${err}`);
+		}
+	}
+
+	/** Load an album by id and (re)write its metadata file. Missing albums are skipped. */
+	async writeAlbumMetadataById(albumId: number): Promise<void> {
+		const album = await this.repository.findOne({ where: { id: albumId } });
+		if (!album) return;
+
+		await this.writeAlbumMetadata(album);
+	}
+
+	/** Backfill `metadata.json` for every (non-deleted) album. Backs the CLI command. */
+	async writeAlbumsMetadata(): Promise<void> {
+		const albums = await this.repository.find({ where: { deletedAt: IsNull() } });
+
+		this.logger.log(`Writing metadata for ${albums.length} albums.`);
+
+		for (const album of albums) {
+			await this.writeAlbumMetadata(album);
+		}
+
+		this.logger.log("Finished writing album metadata.");
 	}
 }


### PR DESCRIPTION
# Změny

 - Backend nově ukládá soubor `metadata.json` do složky s fotkami každého alba (`<photosDir>/<albumId>/metadata.json`). Soubor obsahuje `name`, `description` a data alba (`dateFrom`, `dateTill`, `datePublished`) — plus `id`.
 - Cílem je záloha nezávislá na databázi: kdyby databáze spadla, galerii lze zrekonstruovat ze samotných souborů fotek.
 - Metadata se zapisují pokaždé, když se album **vytvoří** nebo **upraví** (spouští se z `AlbumsRepository.createAlbum` / `updateAlbum`, takže pokrývá i publikování/zrušení publikování).
 - Doimplementována dosud jen naznačená `AlbumsMetadataService` (dřív `throw "Not implemented."`) včetně hromadného doplnění metadat pro všechna alba, které využívá stávající CLI příkaz `write-album-metadata`.
 - Zápis je „best-effort“ — případná chyba (např. problém s diskem) se jen zaloguje a nikdy nespadne požadavek na vytvoření/úpravu alba. Záloha nesmí rozbít funkci, kterou má chránit.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
    - Po vytvoření nového alba vznikne v jeho složce s fotkami soubor `metadata.json` se správným názvem, popisem a daty.
    - Po úpravě alba (včetně publikování / zrušení publikování) se obsah `metadata.json` aktualizuje.
    - Pro doplnění metadat u všech stávajících alb lze spustit CLI příkaz `write-album-metadata`.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141uSThHr44dfXC8iawBrcL)_