### PR TITLE
Skip stat-per-photo in album ZIP download

### DIFF
--- a/backend/src/api/public/services/public.service.ts
+++ b/backend/src/api/public/services/public.service.ts
@@ -61,14 +61,17 @@ export class PublicService {
 
 	/**
 	 * Collects the original image files of a published album for a ZIP download.
-	 * Missing files on disk are skipped; unique names are enforced so photos sharing
-	 * an original filename don't overwrite each other inside the archive.
+	 * Files are not stat-ed here — archiver skips missing ones on its own (emitting an
+	 * ENOENT warning the controller logs), which avoids a serial round-trip per photo
+	 * that scales badly on slow/networked storage. Unique names are enforced so photos
+	 * sharing an original filename don't overwrite each other inside the archive.
 	 */
 	async getAlbumDownload(albumId: number): Promise<{ filename: string; files: { path: string; name: string }[] }> {
 		const album = await this.albums.getAlbum(albumId);
 		if (!album || album.status !== AlbumStatus.public) throw new NotFoundException();
 
 		const photos = await this.photos.getPhotos({ album: album.id });
+		if (!photos.length) throw new NotFoundException("Album has no downloadable photos.");
 
 		const files: { path: string; name: string }[] = [];
 		const usedNames = new Set<string>();
@@ -77,20 +80,12 @@ export class PublicService {
 			const ext = extname(photo.name);
 			const path = this.photosFiles.getPhotoImagePath(photo, PhotoSizes.original);
 
-			try {
-				await this.photosFiles.fileExists(path);
-			} catch {
-				continue;
-			}
-
 			let name = sanitizeFilename(photo.name) || `${photo.id}${ext}`;
 			if (usedNames.has(name)) name = `${photo.id}_${name}`;
 			usedNames.add(name);
 
 			files.push({ path, name });
 		}
-
-		if (!files.length) throw new NotFoundException("Album has no downloadable photos.");
 
 		const albumName = sanitizeFilename(album.name) || String(album.id);
 		return { filename: `${albumName}.zip`, files };


### PR DESCRIPTION
# Změny

 - Album ZIP download (`getAlbumDownload` v `public.service.ts`) už neověřuje existenci každé fotky na disku sériově před začátkem streamu. Dřív to znamenalo jeden `stat` (round-trip do úložiště) na každou fotku, což špatně škáluje na pomalém/síťovém úložišti (např. `photosDir` na NASu).
 - Chybějící soubory teď přeskakuje sám archiver – při ENOENT vyvolá `warning`, které controller už loguje – takže se stream nezastaví.
 - Kontrola prázdného alba (404 „Album has no downloadable photos.“) se nově řídí seznamem fotek místo přítomnosti souborů na disku.

Prohlížení galerie se to nijak netýká – náhledy se servírují z `thumbnailsDir`. Změna se dotýká jen stažení ZIP originálů.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že u veřejného alba na bosan.cz funguje stažení celého alba jako ZIP a stažený archiv obsahuje originály fotek.
3. Zkontroluj, že album bez fotek stále vrací 404 (žádné stahování).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwsTfcT1CerDiWbYeesDVH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwsTfcT1CerDiWbYeesDVH)_