### PR TITLE
Fix NaN integer error on event registration routes

### DIFF
--- a/backend/src/api/events/controllers/events-registrations.controller.ts
+++ b/backend/src/api/events/controllers/events-registrations.controller.ts
@@ -7,6 +7,7 @@ import {
 	InternalServerErrorException,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Post,
 	Put,
 	Query,
@@ -73,7 +74,7 @@ export class EventsRegistrationsController {
 
 	@Get(":id/registration")
 	@AcLinks(EventRegistrationReadPermission)
-	async getEventRegistration(@Req() req: Request, @Param("id") id: number, @Res() res: Response): Promise<void> {
+	async getEventRegistration(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Res() res: Response): Promise<void> {
 		const event = await this.events.getEvent(id);
 		if (!event) throw new NotFoundException();
 		EventRegistrationReadPermission.canOrThrow(req, event);
@@ -118,7 +119,7 @@ export class EventsRegistrationsController {
 	})
 	async saveEventRegistration(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@UploadedFile() registration: Express.Multer.File): Promise<void> {
 			const event = await this.events.getEvent(id);
 			if (!event) throw new NotFoundException();
@@ -139,7 +140,7 @@ export class EventsRegistrationsController {
 	@Get(":id/registration/templates")
 	@AcLinks(EventRegistrationGeneratePermission)
 	@ApiResponse({ status: 200, type: [RegistrationTemplateResponse] })
-	async getEventRegistrationTemplates(@Req() req: Request, @Param("id") id: number): Promise<RegistrationTemplateResponse[]> {
+	async getEventRegistrationTemplates(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<RegistrationTemplateResponse[]> {
 		const event = await this.events.getEvent(id);
 		if (!event) throw new NotFoundException();
 
@@ -157,7 +158,7 @@ export class EventsRegistrationsController {
 	@ApiQuery({ name: "note", required: false })
 	async generateEventRegistration(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Query("template") template: string,
 		@Query("color") color: string,
 		@Query("note") note?: string,
@@ -177,7 +178,7 @@ export class EventsRegistrationsController {
 
 	@Delete(":id/registration")
 	@AcLinks(EventRegistrationDeletePermission)
-	async deleteEventRegistration(@Req() req: Request, @Param("id") id: number): Promise<void> {
+	async deleteEventRegistration(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
 		const event = await this.events.getEvent(id);
 		if (!event) throw new NotFoundException();
 		EventRegistrationDeletePermission.canOrThrow(req, event);


### PR DESCRIPTION
# Změny

 - Přidán `ParseIntPipe` na parametr `:id` u všech endpointů v `events-registrations.controller.ts`.
 - Nečíselné `:id` (např. `/events/NaN/registration`) dřív procházelo přes globální `ValidationPipe` (`enableImplicitConversion`) jako `NaN` rovnou do SQL dotazu, což vyhazovalo 500 `QueryFailedError` (`invalid input syntax for type integer: "NaN"`). Teď se takový požadavek odmítne s 400 ještě před dotazem do DB.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
    - Volání `/events/NaN/registration` (nebo jiné nečíselné id) vrátí 400 Bad Request místo 500 a v backend logu se neobjeví `QueryFailedError` s `NaN`.
    - Běžné registrační funkce nad platným číselným id (zobrazení, uložení, generování, mazání přihlášky) fungují beze změny.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DevANCvkxJLownJZGXBWgE)_