### PR TITLE
fix(api): validate numeric route params with ParseIntPipe

### DIFF
--- a/backend/src/api/albums/controllers/albums.controller.ts
+++ b/backend/src/api/albums/controllers/albums.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post, Query, Req } from "@nestjs/common";
+import { Body, Controller, Delete, Get, NotFoundException, Param, ParseIntPipe, Patch, Post, Query, Req } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { DateTime } from "luxon";
@@ -84,7 +84,7 @@ export class AlbumsController {
 	@Get(":id")
 	@AcLinks(AlbumReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(AlbumResponse) })
-	async getAlbum(@Param("id") id: number, @Req() req: Request): Promise<AlbumResponse> {
+	async getAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<AlbumResponse> {
 		const album = await this.albums.getAlbum(id, { event: true });
 		if (!album) throw new NotFoundException();
 
@@ -96,7 +96,7 @@ export class AlbumsController {
 	@Patch(":id")
 	@AcLinks(AlbumEditPermission)
 	@ApiResponse({ status: 204 })
-	async updateAlbum(@Param("id") id: number, @Req() req: Request, @Body() body: AlbumUpdateBody): Promise<void> {
+	async updateAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request, @Body() body: AlbumUpdateBody): Promise<void> {
 		const album = await this.albums.getAlbum(id);
 		if (!album) throw new NotFoundException();
 
@@ -108,7 +108,7 @@ export class AlbumsController {
 	@Delete(":id")
 	@AcLinks(AlbumDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteAlbum(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async deleteAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const album = await this.albums.getAlbum(id);
 		if (!album) throw new NotFoundException();
 
@@ -120,7 +120,7 @@ export class AlbumsController {
 	@Post(":id/restore")
 	@AcLinks(AlbumRestorePermission)
 	@ApiResponse({ status: 204 })
-	async restoreAlbum(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async restoreAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const album = await this.albums.getDeletedAlbum(id);
 		if (!album) throw new NotFoundException();
 
@@ -132,7 +132,7 @@ export class AlbumsController {
 	@Delete(":id/permanent")
 	@AcLinks(AlbumDeletePermanentPermission)
 	@ApiResponse({ status: 204 })
-	async deleteAlbumPermanent(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async deleteAlbumPermanent(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const album = await this.albums.getDeletedAlbum(id);
 		if (!album) throw new NotFoundException();
 
@@ -145,7 +145,7 @@ export class AlbumsController {
 	@Post(":id/publish")
 	@AcLinks(AlbumPublishPermission)
 	@ApiResponse({ status: 204 })
-	async publishAlbum(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async publishAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const album = await this.albums.getAlbum(id);
 		if (!album) throw new NotFoundException();
 
@@ -157,7 +157,7 @@ export class AlbumsController {
 	@Post(":id/unpublish")
 	@AcLinks(AlbumUnpublishPermission)
 	@ApiResponse({ status: 204 })
-	async unpublishAlbum(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async unpublishAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const album = await this.albums.getAlbum(id);
 		if (!album) throw new NotFoundException();
 
@@ -169,7 +169,7 @@ export class AlbumsController {
 	@Get(":id/photos")
 	@AcLinks(AlbumPhotosPermission)
 	@ApiResponse({ status: 200, type: WithLinks(PhotoResponse), isArray: true })
-	async getAlbumPhotos(@Param("id") id: number, @Req() req: Request): Promise<PhotoResponse[]> {
+	async getAlbumPhotos(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<PhotoResponse[]> {
 		const album = await this.albums.getAlbum(id);
 		if (!album) throw new NotFoundException();
 
@@ -182,7 +182,7 @@ export class AlbumsController {
 	@AcLinks(AlbumReorderPhotosPermission)
 	@ApiResponse({ status: 204 })
 	async reorderAlbumPhotos(
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Req() req: Request,
 		@Body() body: AlbumPhotosOrderBody,
 	): Promise<void> {

--- a/backend/src/api/albums/controllers/photos.controller.ts
+++ b/backend/src/api/albums/controllers/photos.controller.ts
@@ -6,6 +6,7 @@ import {
 	Get,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Patch,
 	Post,
 	Req,
@@ -74,7 +75,7 @@ export class PhotosController {
 	@Get(":id")
 	@AcLinks(PhotoReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(PhotoResponse) })
-	async getPhoto(@Param("id") id: number, @Req() req: Request) {
+	async getPhoto(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
 		const photo = await this.photos.getPhoto(id);
 		if (!photo) throw new NotFoundException();
 
@@ -86,7 +87,7 @@ export class PhotosController {
 	@Patch(":id")
 	@AcLinks(PhotoEditPermission)
 	@ApiResponse({ status: 204 })
-	async updatePhoto(@Param("id") id: number, @Req() req: Request, @Body() body: PhotoUpdateBody): Promise<void> {
+	async updatePhoto(@Param("id", ParseIntPipe) id: number, @Req() req: Request, @Body() body: PhotoUpdateBody): Promise<void> {
 		const photo = await this.photos.getPhoto(id);
 		if (!photo) throw new NotFoundException();
 
@@ -98,7 +99,7 @@ export class PhotosController {
 	@Delete(":id")
 	@AcLinks(PhotoDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deletePhoto(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async deletePhoto(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const photo = await this.photos.getPhoto(id);
 		if (!photo) throw new NotFoundException();
 
@@ -110,7 +111,7 @@ export class PhotosController {
 	@Get(":id/image/:size")
 	@AcLinks(PhotoReadFilePermission)
 	async getPhotoImage(
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Param("size") size: PhotoSizes,
 		@Req() req: Request,
 		@Res() res: Response,

--- a/backend/src/api/events/controllers/events-accounting.controller.ts
+++ b/backend/src/api/events/controllers/events-accounting.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, NotFoundException, Param, Req, Res, StreamableFile } from "@nestjs/common";
+import { Controller, Get, HttpCode, NotFoundException, Param, ParseIntPipe, Req, Res, StreamableFile } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Request, Response } from "express";
@@ -25,7 +25,7 @@ export class EventsAccountingController {
 	@ApiResponse({ status: 200 })
 	async getEventAccounting(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Res({ passthrough: true }) res: Response,
 	): Promise<StreamableFile> {
 		//const event = await this.events.getEvent(id);

--- a/backend/src/api/events/controllers/events-announcement.controller.ts
+++ b/backend/src/api/events/controllers/events-announcement.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, NotFoundException, Param, Req, Res, StreamableFile } from "@nestjs/common";
+import { Controller, Get, HttpCode, NotFoundException, Param, ParseIntPipe, Req, Res, StreamableFile } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Request, Response } from "express";
@@ -25,7 +25,7 @@ export class EventsAnnouncementController {
 	@ApiResponse({ status: 200 })
 	async getEventAnnouncement(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Res({ passthrough: true }) res: Response,
 	): Promise<StreamableFile> {
 		//const event = await this.events.getEvent(id);

--- a/backend/src/api/events/controllers/events-attendees.controller.ts
+++ b/backend/src/api/events/controllers/events-attendees.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Put, Req } from "@nestjs/common";
+import { Body, Controller, Delete, Get, NotFoundException, Param, ParseIntPipe, Patch, Put, Req } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { AcController, AcLinks, WithLinks } from "src/access-control/access-control-lib";
@@ -21,7 +21,7 @@ export class EventsAttendeesController {
 	@Get(":eventId/attendees")
 	@AcLinks(EventAttendeesListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(EventAttendeeResponse), isArray: true })
-	async listEventAttendees(@Req() req: Request, @Param("eventId") eventId: number): Promise<EventAttendeeResponse[]> {
+	async listEventAttendees(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<EventAttendeeResponse[]> {
 		const event = await this.events.getEvent(eventId);
 		if (!event) throw new NotFoundException();
 
@@ -35,8 +35,8 @@ export class EventsAttendeesController {
 	@ApiResponse({ status: 204 })
 	async addEventAttendee(
 		@Req() req: Request,
-		@Param("eventId") eventId: number,
-		@Param("memberId") memberId: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
+		@Param("memberId", ParseIntPipe) memberId: number,
 		@Body() body: EventAttendeeCreateBody,
 	) {
 		const event = await this.events.getEvent(eventId);
@@ -52,8 +52,8 @@ export class EventsAttendeesController {
 	@ApiResponse({ status: 204 })
 	async updateEventAttendee(
 		@Req() req: Request,
-		@Param("eventId") eventId: number,
-		@Param("memberId") memberId: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
+		@Param("memberId", ParseIntPipe) memberId: number,
 		@Body() body: EventAttendeeUpdateBody,
 	) {
 		const eventAttendee = await this.events.getEventAttendee(eventId, memberId);
@@ -71,8 +71,8 @@ export class EventsAttendeesController {
 	@ApiResponse({ status: 204 })
 	async deleteEventAttendee(
 		@Req() req: Request,
-		@Param("eventId") eventId: number,
-		@Param("memberId") memberId: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
+		@Param("memberId", ParseIntPipe) memberId: number,
 	) {
 		const eventAttendee = await this.events.getEventAttendee(eventId, memberId);
 		if (!eventAttendee) throw new NotFoundException();

--- a/backend/src/api/events/controllers/events-expenses.controller.ts
+++ b/backend/src/api/events/controllers/events-expenses.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, HttpCode, NotFoundException, Param, Patch, Post, Req } from "@nestjs/common";
+import { Body, Controller, Delete, Get, HttpCode, NotFoundException, Param, ParseIntPipe, Patch, Post, Req } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { AcController, AcLinks, WithLinks } from "src/access-control/access-control-lib";
@@ -20,7 +20,7 @@ export class EventsExpensesController {
 	@Get("")
 	@AcLinks(EventExpensesListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(EventExpenseResponse), isArray: true })
-	async listEventExpenses(@Req() req: Request, @Param("eventId") eventId: number): Promise<EventExpenseResponse[]> {
+	async listEventExpenses(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<EventExpenseResponse[]> {
 		const event = await this.events.getEvent(eventId);
 		if (!event) throw new NotFoundException();
 
@@ -37,7 +37,7 @@ export class EventsExpensesController {
 	@ApiResponse({ status: 201, type: WithLinks(EventExpenseResponse) })
 	async addEventExpense(
 		@Req() req: Request,
-		@Param("eventId") eventId: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Body() body: EventExpenseCreateBody,
 	) {
 		const event = await this.events.getEvent(eventId);
@@ -53,8 +53,8 @@ export class EventsExpensesController {
 	@ApiResponse({ status: 204 })
 	async updateEventExpense(
 		@Req() req: Request,
-		@Param("eventId") eventId: number,
-		@Param("expenseId") expenseId: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
+		@Param("expenseId", ParseIntPipe) expenseId: number,
 		@Body() body: EventExpenseUpdateBody,
 	) {
 		const eventExpense = await this.events.getEventExpense(eventId, expenseId);
@@ -72,8 +72,8 @@ export class EventsExpensesController {
 	@ApiResponse({ status: 204 })
 	async deleteEventExpense(
 		@Req() req: Request,
-		@Param("eventId") eventId: number,
-		@Param("expenseId") expenseId: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
+		@Param("expenseId", ParseIntPipe) expenseId: number,
 	) {
 		const eventExpense = await this.events.getEventExpense(eventId, expenseId);
 		if (!eventExpense) throw new NotFoundException();

--- a/backend/src/api/events/controllers/events-reports.controller.ts
+++ b/backend/src/api/events/controllers/events-reports.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpCode, NotFoundException, Param, Req } from "@nestjs/common";
+import { Controller, Get, HttpCode, NotFoundException, Param, ParseIntPipe, Req } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Request } from "express";
@@ -21,7 +21,7 @@ export class EventsReportsController {
 	@HttpCode(204)
 	@AcLinks(EventReportReadPermission)
 	@ApiResponse({ status: 204 })
-	async getEventReport(@Req() req: Request, @Param("id") id: number): Promise<void> {
+	async getEventReport(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
 		const event = await this.events.getEvent(id);
 		if (!event) throw new NotFoundException();
 

--- a/backend/src/api/events/controllers/events.controller.ts
+++ b/backend/src/api/events/controllers/events.controller.ts
@@ -8,6 +8,7 @@ import {
 	Logger,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Patch,
 	Post,
 	Query,
@@ -122,7 +123,7 @@ export class EventsController {
 	@Get(":id")
 	@AcLinks(EventReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(EventResponse) })
-	async getEvent(@Req() req: Request, @Param("id") id: number): Promise<EventResponse> {
+	async getEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<EventResponse> {
 		const event = await this.events.getEvent(id, { leaders: true });
 		if (!event) throw new NotFoundException();
 
@@ -135,7 +136,7 @@ export class EventsController {
 	@HttpCode(204)
 	@AcLinks(EventEditPermission)
 	@ApiResponse({ status: 204 })
-	async updateEvent(@Req() req: Request, @Param("id") id: number, @Body() body: EventUpdateBody): Promise<void> {
+	async updateEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Body() body: EventUpdateBody): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
 		if (!event) throw new NotFoundException();
 
@@ -159,7 +160,7 @@ export class EventsController {
 	@HttpCode(204)
 	@AcLinks(EventDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteEvent(@Req() req: Request, @Param("id") id: number): Promise<void> {
+	async deleteEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
 		if (!event) throw new NotFoundException();
 
@@ -172,7 +173,7 @@ export class EventsController {
 	@HttpCode(204)
 	@AcLinks(EventRestorePermission)
 	@ApiResponse({ status: 204 })
-	async restoreEvent(@Req() req: Request, @Param("id") id: number): Promise<void> {
+	async restoreEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
 		if (!event) throw new NotFoundException();
 
@@ -185,7 +186,7 @@ export class EventsController {
 	@HttpCode(204)
 	@AcLinks(EventDeletePermanentPermission)
 	@ApiResponse({ status: 204 })
-	async deleteEventPermanent(@Req() req: Request, @Param("id") id: number): Promise<void> {
+	async deleteEventPermanent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
 		if (!event) throw new NotFoundException();
 
@@ -198,7 +199,7 @@ export class EventsController {
 	@HttpCode(204)
 	@AcLinks(EventLeadPermission)
 	@ApiResponse({ status: 204 })
-	async leadEvent(@Req() req: Request, @Param("id") id: number, @AuthUser() authUser: SessionUser): Promise<void> {
+	async leadEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @AuthUser() authUser: SessionUser): Promise<void> {
 		if (authUser.memberId === undefined) throw new ConflictException("User is not linked to a member.");
 
 		const event = await this.events.getEvent(id, { leaders: true });
@@ -215,7 +216,7 @@ export class EventsController {
 	@ApiResponse({ status: 204 })
 	async submitEvent(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
@@ -232,7 +233,7 @@ export class EventsController {
 	@ApiResponse({ status: 204 })
 	async rejectEvent(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
@@ -249,7 +250,7 @@ export class EventsController {
 	@ApiResponse({ status: 204 })
 	async publishEvent(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
@@ -266,7 +267,7 @@ export class EventsController {
 	@ApiResponse({ status: 204 })
 	async unpublishEvent(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
@@ -283,7 +284,7 @@ export class EventsController {
 	@ApiResponse({ status: 204 })
 	async cancelEvent(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });
@@ -300,7 +301,7 @@ export class EventsController {
 	@ApiResponse({ status: 204 })
 	async uncancelEvent(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
 		const event = await this.events.getEvent(id, { leaders: true });

--- a/backend/src/api/members/controllers/groups.controller.ts
+++ b/backend/src/api/members/controllers/groups.controller.ts
@@ -8,6 +8,7 @@ import {
 	HttpStatus,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Patch,
 	Post,
 	Query,
@@ -58,7 +59,7 @@ export class GroupsController {
 	@Get(":id")
 	@AcLinks(GroupReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(GroupResponse) })
-	async getGroup(@Param("id") id: number, @Req() req: Request) {
+	async getGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
 		const group = await this.groups.getGroup(id);
 		if (!group) throw new NotFoundException();
 
@@ -70,7 +71,7 @@ export class GroupsController {
 	@Patch(":id")
 	@AcLinks(GroupEditPermission)
 	@ApiResponse({ status: HttpStatus.OK })
-	async updateGroup(@Param("id") id: number, @Req() req: Request, @Body() body: UpdateGroupBody) {
+	async updateGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request, @Body() body: UpdateGroupBody) {
 		const group = await this.groups.getGroup(id);
 		if (!group) throw new NotFoundException();
 
@@ -81,7 +82,7 @@ export class GroupsController {
 
 	@Delete(":id")
 	@AcLinks(GroupDeletePermission)
-	async deleteGroup(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async deleteGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const group = await this.groups.getGroup(id);
 		if (!group) throw new NotFoundException();
 
@@ -94,7 +95,7 @@ export class GroupsController {
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@AcLinks(GroupRestorePermission)
 	@ApiResponse({ status: HttpStatus.NO_CONTENT })
-	async restoreGroup(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async restoreGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const group = await this.groups.getGroup(id, { withDeleted: true });
 		if (!group) throw new NotFoundException();
 
@@ -105,7 +106,7 @@ export class GroupsController {
 
 	@Delete(":id/permanent")
 	@AcLinks(GroupPermanentDeletePermission)
-	async permanentlyDeleteGroup(@Param("id") id: number, @Req() req: Request): Promise<void> {
+	async permanentlyDeleteGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
 		const group = await this.groups.getGroup(id, { withDeleted: true });
 		if (!group) throw new NotFoundException();
 

--- a/backend/src/api/members/controllers/member-contacts.controller.ts
+++ b/backend/src/api/members/controllers/member-contacts.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, NotFoundException, Param, Patch, Post, Req, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, NotFoundException, Param, ParseIntPipe, Patch, Post, Req, UseGuards } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { AcController, AcLinks, WithLinks } from "src/access-control/access-control-lib";
@@ -21,7 +21,7 @@ export class MemberContactsController {
 	@Get()
 	@AcLinks(MemberContactsListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(MemberContactResponse), isArray: true })
-	async listContacts(@Req() req: Request, @Param("id") memberId: number): Promise<MemberContactResponse[]> {
+	async listContacts(@Req() req: Request, @Param("id", ParseIntPipe) memberId: number): Promise<MemberContactResponse[]> {
 		const member = await this.membersRepository.getMember(memberId, { relations: { contacts: true } });
 		if (!member) throw new NotFoundException();
 
@@ -35,7 +35,7 @@ export class MemberContactsController {
 	@ApiResponse({ type: WithLinks(MemberContactResponse) })
 	async createContact(
 		@Req() req: Request,
-		@Param("id") memberId: number,
+		@Param("id", ParseIntPipe) memberId: number,
 		@Body() body: CreateContactBody,
 	): Promise<MemberContactResponse> {
 		const member = await this.membersRepository.getMember(memberId);
@@ -51,8 +51,8 @@ export class MemberContactsController {
 	@ApiResponse({ type: WithLinks(MemberContactResponse) })
 	async updateContact(
 		@Req() req: Request,
-		@Param("id") memberId: number,
-		@Param("contactId") contactId: number,
+		@Param("id", ParseIntPipe) memberId: number,
+		@Param("contactId", ParseIntPipe) contactId: number,
 		@Body() body: CreateContactBody,
 	): Promise<MemberContactResponse> {
 		const member = await this.membersRepository.getMember(memberId);
@@ -66,7 +66,7 @@ export class MemberContactsController {
 	@Delete(":contactId")
 	@AcLinks(MemberContactsDeletePermission)
 	@ApiResponse({ type: WithLinks(MemberContactResponse) })
-	async deleteContact(@Req() req: Request, @Param("id") memberId: number, @Param("contactId") contactId: number) {
+	async deleteContact(@Req() req: Request, @Param("id", ParseIntPipe) memberId: number, @Param("contactId", ParseIntPipe) contactId: number) {
 		const memberContact = await this.membersRepository.getContact(memberId, contactId);
 		if (!memberContact) throw new NotFoundException();
 

--- a/backend/src/api/members/controllers/member-insurance-card.controller.ts
+++ b/backend/src/api/members/controllers/member-insurance-card.controller.ts
@@ -9,6 +9,7 @@ import {
 	Logger,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Put,
 	Req,
 	Res,
@@ -53,7 +54,7 @@ export class MemberInsuranceCardController {
 	@Get("")
 	@AcLinks(MemberInsuranceCardReadPermission)
 	@ApiResponse({})
-	async getInsuranceCard(@Req() req: Request, @Res() res: Response, @Param("id") memberId: number) {
+	async getInsuranceCard(@Req() req: Request, @Res() res: Response, @Param("id", ParseIntPipe) memberId: number) {
 		const member = await this.membersService.getMember(memberId);
 		if (!member) throw new NotFoundException("Member not found");
 
@@ -89,7 +90,7 @@ export class MemberInsuranceCardController {
 	@ApiResponse({ status: HttpStatus.NO_CONTENT })
 	async uploadInsuranceCard(
 		@Req() req: Request,
-		@Param("id") memberId: number,
+		@Param("id", ParseIntPipe) memberId: number,
 		@UploadedFile() file: Express.Multer.File,
 	) {
 		const member = await this.membersService.getMember(memberId);
@@ -120,7 +121,7 @@ export class MemberInsuranceCardController {
 	@Delete("")
 	@AcLinks(MemberInsuranceCardDeletePermission)
 	@ApiResponse({ status: HttpStatus.NO_CONTENT })
-	async deleteInsuranceCard(@Req() req: Request, @Param("id") memberId: number) {
+	async deleteInsuranceCard(@Req() req: Request, @Param("id", ParseIntPipe) memberId: number) {
 		const member = await this.membersService.getMember(memberId);
 		if (!member) throw new NotFoundException("Member not found");
 

--- a/backend/src/api/members/controllers/members.controller.ts
+++ b/backend/src/api/members/controllers/members.controller.ts
@@ -5,6 +5,7 @@ import {
 	Get,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Patch,
 	Post,
 	Query,
@@ -83,7 +84,7 @@ export class MembersController {
 	@Get(":id")
 	@AcLinks(MemberReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(MemberResponse) })
-	async getMember(@Param("id") id: number, @Req() req: Request): Promise<MemberResponse> {
+	async getMember(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<MemberResponse> {
 		const member = await this.members.getMember(id);
 		if (!member) throw new NotFoundException();
 
@@ -95,7 +96,7 @@ export class MembersController {
 	@Patch(":id")
 	@AcLinks(MemberUpdatePermission)
 	@ApiResponse({ status: 204 })
-	async updateMember(@Req() req: Request, @Param("id") id: number, @Body() body: MemberUpdateBody) {
+	async updateMember(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Body() body: MemberUpdateBody) {
 		const member = await this.members.getMember(id);
 		if (!member) throw new NotFoundException();
 
@@ -107,7 +108,7 @@ export class MembersController {
 	@Delete(":id")
 	@AcLinks(MemberDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteMember(@Req() req: Request, @Param("id") id: number) {
+	async deleteMember(@Req() req: Request, @Param("id", ParseIntPipe) id: number) {
 		const member = await this.members.getMember(id);
 		if (!member) throw new NotFoundException();
 
@@ -119,7 +120,7 @@ export class MembersController {
 	@Post(":id/restore")
 	@AcLinks(MemberRestorePermission)
 	@ApiResponse({ status: 204 })
-	async restoreMember(@Req() req: Request, @Param("id") id: number) {
+	async restoreMember(@Req() req: Request, @Param("id", ParseIntPipe) id: number) {
 		const member = await this.members.getDeletedMember(id);
 		if (!member) throw new NotFoundException();
 
@@ -131,7 +132,7 @@ export class MembersController {
 	@Delete(":id/permanent")
 	@AcLinks(MemberDeletePermanentPermission)
 	@ApiResponse({ status: 204 })
-	async deleteMemberPermanent(@Req() req: Request, @Param("id") id: number) {
+	async deleteMemberPermanent(@Req() req: Request, @Param("id", ParseIntPipe) id: number) {
 		const member = await this.members.getDeletedMember(id);
 		if (!member) throw new NotFoundException();
 

--- a/backend/src/api/public/controllers/public.controller.ts
+++ b/backend/src/api/public/controllers/public.controller.ts
@@ -5,6 +5,7 @@ import {
 	Logger,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Query,
 	Req,
 	Res,
@@ -60,7 +61,7 @@ export class PublicController {
 	}
 
 	@Get("program/:id/registration")
-	async getProgramRegistration(@Param("id") id: number, @Res() res: Response): Promise<void> {
+	async getProgramRegistration(@Param("id", ParseIntPipe) id: number, @Res() res: Response): Promise<void> {
 		const { path, filename } = await this.publicService.getRegistrationFile(id);
 
 		res.setHeader("Content-Type", "application/pdf");
@@ -87,18 +88,18 @@ export class PublicController {
 
 	@Get("gallery/:id")
 	@AcLinks(PublicGalleryAlbumPermission)
-	async getGalleryAlbum(@Param("id") id: number) {
+	async getGalleryAlbum(@Param("id", ParseIntPipe) id: number) {
 		return this.publicService.getAlbum(id);
 	}
 
 	@Get("gallery/:id/preview")
 	@AcLinks(PublicGalleryAlbumPreviewPermission)
-	async getGalleryAlbumPreview(@Param("id") id: number) {
+	async getGalleryAlbumPreview(@Param("id", ParseIntPipe) id: number) {
 		return this.publicService.getAlbum(id, { preview: true });
 	}
 
 	@Get("gallery/:id/download")
-	async downloadAlbum(@Param("id") id: number, @Res() res: Response): Promise<void> {
+	async downloadAlbum(@Param("id", ParseIntPipe) id: number, @Res() res: Response): Promise<void> {
 		const { filename, files } = await this.publicService.getAlbumDownload(id);
 
 		const archive = archiver("zip", { store: true }); // photos are already compressed; store to save CPU
@@ -121,7 +122,7 @@ export class PublicController {
 
 	@Get("photos/:id/image/:size")
 	async getPublicPhotoImage(
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Param("size") size: PhotoSizes,
 		@Res() res: Response,
 	): Promise<void> {

--- a/backend/src/api/statistics/controllers/paddlers-statistics.controller.ts
+++ b/backend/src/api/statistics/controllers/paddlers-statistics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Req } from "@nestjs/common";
+import { Controller, Get, Param, ParseIntPipe, Req } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { PaddlersStatisticsService } from "src/models/statistics/services/paddlers-statistics.service";
@@ -21,7 +21,7 @@ export class PaddlersStatisticsController {
 
 	@Get(":year/ranking")
 	@ApiResponse({ status: 200, type: PaddlersRankingResponse, isArray: true })
-	getPaddlersRanking(@Req() req: Request, @Param("year") year: number): Promise<PaddlersRankingResponse[]> {
+	getPaddlersRanking(@Req() req: Request, @Param("year", ParseIntPipe) year: number): Promise<PaddlersRankingResponse[]> {
 		PadlersRankingPermission.canOrThrow(req);
 
 		return this.statistics.getPaddlersRanking(year);

--- a/backend/src/api/users/controllers/users.controller.ts
+++ b/backend/src/api/users/controllers/users.controller.ts
@@ -5,6 +5,7 @@ import {
 	Get,
 	NotFoundException,
 	Param,
+	ParseIntPipe,
 	Patch,
 	Post,
 	Put,
@@ -91,7 +92,7 @@ export class UsersController {
 	@ApiResponse({ status: 200, type: WithLinks(UserResponse) })
 	async getUser(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Query() query: GetUserQueryDto,
 	): Promise<UserResponse> {
 		const user = await this.userRepository.findOne({
@@ -108,7 +109,7 @@ export class UsersController {
 	@Patch(":id")
 	@AcLinks(UserEditPermission)
 	@ApiResponse({ status: 204 })
-	async updateUser(@Req() req: Request, @Param("id") id: number, @Body() body: UserUpdateBody): Promise<void> {
+	async updateUser(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Body() body: UserUpdateBody): Promise<void> {
 		const user = await this.userService.getUser(id);
 		if (!user) throw new NotFoundException();
 
@@ -120,7 +121,7 @@ export class UsersController {
 	@Delete(":id")
 	@AcLinks(UserDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteUser(@Req() req: Request, @Param("id") id: number): Promise<void> {
+	async deleteUser(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
 		const user = await this.userService.getUser(id);
 		if (!user) throw new NotFoundException();
 
@@ -134,7 +135,7 @@ export class UsersController {
 	@ApiResponse({ status: 204 })
 	async setUserPassword(
 		@Req() req: Request,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 		@Body() body: UserSetPasswordBody,
 	): Promise<void> {
 		const user = await this.userService.getUser(id);
@@ -152,7 +153,7 @@ export class UsersController {
 	async impersonateUser(
 		@Req() req: Request,
 		@Res({ passthrough: true }) res: Response,
-		@Param("id") id: number,
+		@Param("id", ParseIntPipe) id: number,
 	) {
 		const user = await this.userService.getUser(id);
 		if (!user) throw new NotFoundException();


### PR DESCRIPTION
# Změny

- Doplněn `ParseIntPipe` ke všem číselným route parametrům (`@Param(...)` typu `: number`) ve zbývajících API controllerech — stejná oprava jako v #262 (`events-registrations.controller.ts`).
- Globální `ValidationPipe` má zapnutý `enableImplicitConversion`, takže parametr typu `: number` byl převeden přes `Number()` **bez** validace. Nečíselný segment cesty (např. `GET /events/NaN/registration` nebo zbloudilé `undefined`) se stal `NaN`, propadl až do SQL dotazu a Postgres ho odmítl chybou `invalid input syntax for type integer: "NaN"` — což skončilo jako HTTP 500 `QueryFailedError`.
- `ParseIntPipe` nyní vyhodí 400 Bad Request ještě před jakýmkoli DB dotazem, což je správné chování pro klientskou chybu.
- Dotčené controllery: `albums`, `photos`, `events`, `events-accounting`, `events-announcement`, `events-reports`, `events-attendees`, `events-expenses`, `groups`, `members`, `member-contacts`, `member-insurance-card`, `users`, `public`, `paddlers-statistics`.
- Žádná změna OpenAPI specifikace → není potřeba regenerovat SDK. Pouze parametry typu `: number` byly upraveny, stringové parametry zůstaly beze změny.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že aplikace funguje jako dříve (načítání akcí, členů, alb, uživatelů, statistik).
3. Zavolej API endpoint s nečíselným ID, např. `GET /api/events/NaN` nebo `GET /api/members/undefined`, a ověř, že vrací **400 Bad Request** (dříve 500 Internal Server Error).

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_018QcSiC9CwyNoMo85xD9sef)_