### PR TITLE
Serve legacy event registration PDFs by Mongo ObjectId

### DIFF
--- a/backend/src/api/events/controllers/events-registrations.controller.ts
+++ b/backend/src/api/events/controllers/events-registrations.controller.ts
@@ -51,15 +51,33 @@ export class EventsRegistrationsController {
 		@InjectRepository(Event) private eventsRepository: Repository<Event>,
 	) {}
 
+	/**
+	 * On-disk folder holding the event's registration PDF. Events imported from the old server keep
+	 * their legacy Mongo ObjectId in `srcId`, and their files live in a folder keyed by that ObjectId
+	 * (named `registration.pdf`); natively-created events use the numeric-id folder (with a
+	 * `prihlaska_<name>.pdf` file). Coalescing on `srcId` lets both resolve without moving files —
+	 * mirrors how Photo.srcId is used to serve legacy images. See getEventRegistration for the
+	 * matching legacy vs. new filename handling.
+	 */
+	private registrationFolder(event: Event): string {
+		return path.join(this.config.fs.eventsDir, event.srcId ?? event.id.toString());
+	}
+
+	/** Removes any existing registration PDF (new `prihlaska*` or legacy `registration*`) for the event. */
+	private async deleteRegistrationFiles(registrationFolder: string): Promise<void> {
+		await this.fileService.deleteFilesByPrefix(registrationFolder, "prihlaska");
+		await this.fileService.deleteFilesByPrefix(registrationFolder, "registration");
+	}
+
 	/** Replaces any existing "prihlaska" file for the event with the given PDF and flags the event. */
 	private async storeRegistration(event: Event, data: Buffer): Promise<void> {
-		const registrationFolder = path.join(this.config.fs.eventsDir, event.id.toString());
+		const registrationFolder = this.registrationFolder(event);
 		const registrationFileName = "prihlaska_" + sanitizeFilename(event.name) + ".pdf";
 		const registrationPath = path.join(registrationFolder, registrationFileName);
 
 		try {
 			await this.fileService.ensureDir(registrationFolder);
-			await this.fileService.deleteFilesByPrefix(registrationFolder, "prihlaska");
+			await this.deleteRegistrationFiles(registrationFolder);
 			await this.fileService.saveFile(registrationPath, data);
 		} catch (err) {
 			throw new InternalServerErrorException("Failed to save registration");
@@ -79,11 +97,16 @@ export class EventsRegistrationsController {
 		if (!event) throw new NotFoundException();
 		EventRegistrationReadPermission.canOrThrow(req, event);
 
-		const registrationFolder = path.join(this.config.fs.eventsDir, event.id.toString());
+		const registrationFolder = this.registrationFolder(event);
 
 		let matchingFiles: string[];
 		try {
+			// New uploads/generations are named `prihlaska_<name>.pdf`; legacy imported events keep the
+			// old `registration.pdf`. Prefer the new file, fall back to the legacy one.
 			matchingFiles = await this.fileService.getFilesByPrefx(registrationFolder, "prihlaska");
+			if (matchingFiles.length === 0) {
+				matchingFiles = await this.fileService.getFilesByPrefx(registrationFolder, "registration");
+			}
 		} catch {
 			throw new NotFoundException("Registration not found");
 		}
@@ -182,9 +205,9 @@ export class EventsRegistrationsController {
 		const event = await this.events.getEvent(id);
 		if (!event) throw new NotFoundException();
 		EventRegistrationDeletePermission.canOrThrow(req, event);
-		const registrationFolder = path.join(this.config.fs.eventsDir, event.id.toString())
-						
-		await this.fileService.deleteFilesByPrefix(registrationFolder, "prihlaska")
+		const registrationFolder = this.registrationFolder(event);
+
+		await this.deleteRegistrationFiles(registrationFolder);
 		event.hasRegistration = false;
 		await this.eventsRepository.update(event.id, { hasRegistration: false });
 

--- a/backend/src/api/events/dto/event.dto.ts
+++ b/backend/src/api/events/dto/event.dto.ts
@@ -12,7 +12,9 @@ import { Member } from "src/models/members/entities/member.entity";
 import { EventAttendeeResponse } from "./event-attendee.dto";
 import { EventExpenseResponse } from "./event-expense.dto";
 
-export class EventResponse implements Omit<Event, "setLeaders"> {
+// srcId is the legacy Mongo ObjectId used only for backend file resolution (registration PDFs of
+// imported events); like PhotoResponse omits Photo.srcId/srcAlbumId, it is not exposed in the API.
+export class EventResponse implements Omit<Event, "setLeaders" | "srcId"> {
 	id!: number;
 	name!: string;
 	@ApiProperty({ enum: EventStates, enumName: "EventStatesEnum" }) status!: EventStates;

--- a/backend/src/database/migrations/1784910021969-event-legacy-src-id.ts
+++ b/backend/src/database/migrations/1784910021969-event-legacy-src-id.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class eventLegacySrcId1784910021969 implements MigrationInterface {
+	name = "eventLegacySrcId1784910021969";
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "events" ADD "src_id" character varying`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "events" DROP COLUMN "src_id"`);
+	}
+}

--- a/backend/src/models/events/entities/event.entity.ts
+++ b/backend/src/models/events/entities/event.entity.ts
@@ -76,6 +76,12 @@ export class Event {
 	@Column({ type: "boolean", nullable: false, default: false }) hasRegistration!: boolean;
 	@Column({ type: "varchar", nullable: true }) report!: string | null;
 
+	// Legacy Mongo ObjectId of the event, set only for events imported from the old server
+	// (mongo-import). When present, the registration PDF lives in the legacy on-disk layout
+	// (folder keyed by this ObjectId, file named registration.pdf) rather than the numeric-id
+	// layout; see EventsRegistrationsController.registrationFolder.
+	@Column({ type: "varchar", nullable: true }) srcId!: string | null;
+
 	@DeleteDateColumn() deletedAt?: Date | null;
 
 	leaders?: Member[];

--- a/backend/src/mongo-import/services/mongo-import.service.ts
+++ b/backend/src/mongo-import/services/mongo-import.service.ts
@@ -252,8 +252,12 @@ export class MongoImportService {
 				waterKm: null,
 				river: null,
 				leadersEvent: mongoEvent.groups?.includes("V") || false,
-				hasRegistration: false, // TODO: migrate registration
+				// The legacy registration PDF is not moved or copied; keep the original Mongo ObjectId
+				// (srcId) so the backend can serve it straight from the legacy on-disk layout, and flag
+				// the event when the old record referenced a registration file.
+				hasRegistration: !!mongoEvent.registration,
 				report: null,
+				srcId: mongoEvent._id.toString(),
 				groups,
 			};
 

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -890,6 +890,12 @@ export namespace SDK {
          * @type {string}
          * @memberof Event
          */
+        'srcId': string | null;
+        /**
+         * 
+         * @type {string}
+         * @memberof Event
+         */
         'deletedAt'?: string | null;
         /**
          * 


### PR DESCRIPTION
# Změny

Přenáší mechanismus `Photo.srcId` na PDF přihlášky u akcí, aby soubory importované ze starého Mongo serveru šly stále dohledat (stejně jako to už funguje u fotek).

 - Přidán sloupec `Event.srcId` (původní Mongo ObjectId), který se plní během `mongo-import`. `hasRegistration` se nově nastavuje podle starého pole `registration` místo dřívějšího natvrdo `false` (`// TODO: migrate registration`).
 - Cesta ke složce s přihláškou se určuje přes `srcId ?? id` a při čtení/ukládání/mazání se kromě nového názvu `prihlaska_*.pdf` matchuje i starý název `registration.pdf`.
 - `EventResponse` sloupec `srcId` vynechává (stejně jako `PhotoResponse` nevystavuje legacy id fotek). Surové entitní schéma `Event` ho ale v OpenAPI vystavuje — stejně jako u `Photo` — takže SDK (`frontend/src/sdk/api.ts`) přibylo pole `Event.srcId`. Jde o náhodný string, jeho „únik“ je neškodný.
 - Migrace `1784910021969-event-legacy-src-id.ts` přidává sloupec `events.src_id` (tvarem odpovídá existující `photosLegacySrcIds` migraci).

> **Pozn. pro reviewera:** Migrace i změny entit byly ověřeny proti reálné PostgreSQL 16 + PostGIS: `migrations:run` / `migrations:revert` / opětovné `run` projdou, a následné `migrations:generate` hlásí „No changes in database schema were found“ (tj. migrace přesně odpovídá diffu entit). `tsc --noEmit` na backendu prochází. SDK bylo přegenerováno přes `generate:sdk`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. U akce **importované ze starého serveru**, která měla přihlášku, zkontroluj, že se PDF přihlášky správně zobrazí ke stažení (dřív se u importovaných akcí přihláška vůbec nenabízela).
3. U **nově vytvořené** akce nahraj/vygeneruj přihlášku a zkontroluj, že se uloží, zobrazí i smaže jako dosud.
4. U importované akce s přihláškou zkus přihlášku znovu nahrát a poté smazat — ověř, že se starý soubor `registration.pdf` i nový `prihlaska_*.pdf` korektně nahradí/odstraní.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqXUgoqMuK96PnLiZ8W93B