### PR TITLE
fix(public): stáhnutí přihlášky u veřejného programu (legacy akce)

### DIFF
--- a/backend/src/api/public/services/public.service.ts
+++ b/backend/src/api/public/services/public.service.ts
@@ -46,11 +46,18 @@ export class PublicService {
 		const event = await this.events.getEvent(eventId);
 		if (!event || !this.isPubliclyVisible(event) || !event.hasRegistration) throw new NotFoundException();
 
-		const folder = join(this.config.fs.eventsDir, String(event.id));
+		// Mirror EventsRegistrationsController: events imported from the old server keep their legacy
+		// Mongo ObjectId in `srcId` and store the PDF in a folder keyed by that ObjectId (named
+		// `registration.pdf`); natively-created events use the numeric-id folder (`prihlaska_<name>.pdf`).
+		const folder = join(this.config.fs.eventsDir, event.srcId ?? String(event.id));
 
 		let matches: string[];
 		try {
+			// Prefer the new `prihlaska*` file, fall back to the legacy `registration*` one.
 			matches = await this.files.getFilesByPrefx(folder, "prihlaska");
+			if (matches.length === 0) {
+				matches = await this.files.getFilesByPrefx(folder, "registration");
+			}
 		} catch {
 			throw new NotFoundException("Registration not found");
 		}


### PR DESCRIPTION
# Změny

 - Veřejný endpoint pro stažení přihlášky (`GET /api/public/program/:id/registration`) vracel u naimportovaných (legacy) akcí 404.
 - Endpoint hledal soubor `prihlaska*` vždy ve složce podle číselného `id` akce. Legacy akce ale mají PDF uložené ve složce pojmenované podle původního Mongo ObjectId (`srcId`) a soubor se jmenuje `registration.pdf`.
 - Oprava zrcadlí chování interního `EventsRegistrationsController`: složka se určuje podle `srcId ?? id` a hledání souboru padá zpět z prefixu `prihlaska` na legacy prefix `registration`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že u veřejné (legacy naimportované) akce, která má přihlášku, funguje odkaz na stažení přihlášky — např. `https://test.bosan.cz/api/public/program/5421/registration` stáhne PDF a nevrací 404.
3. Zkontroluj, že u nativně vytvořené akce s přihláškou (`prihlaska_*.pdf`) stažení přihlášky funguje i nadále.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiUAx6bg69r4dYePTzXNex

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiUAx6bg69r4dYePTzXNex)_