### PR TITLE
Remove hardcoded NEXT beta label from page title

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -10,7 +10,7 @@
 			content="Skupina Šán je seskupení sedmi dětských vodáckých oddílů. Domovskou loděnici máme v Podolí mezi Žlutými lázněmi a botelem Racek naproti plaveckému bazénu"
 		/>
 
-		<title>Bošán NEXT</title>
+		<title>Bošán</title>
 
 		<link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png" />
 		<link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/icon-32x32.png" />


### PR DESCRIPTION
# Změny

 - Odstraněn natvrdo zapsaný label `NEXT` z titulku stránky v `frontend/src/index.html` (`Bošán NEXT` → `Bošán`). Sloužil jako "beta" label, ale prostředí se už dynamicky nastavuje přes `environmentTitle` (viz `title.service.ts` / sidebar / home), takže statický `NEXT` v `index.html` byl přebytečný.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že titulek záložky v prohlížeči (a než se načte Angular) je `Bošán`, ne `Bošán NEXT`.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCuLb4UeecorSNnZWvUKaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCuLb4UeecorSNnZWvUKaS)_