### PR TITLE
fix(pwa): make install banner legible and on-brand in dark mode

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -54,6 +54,7 @@ export class AppComponent implements OnInit {
 	private async showInstallBanner() {
 		const toast = await this.toastService.toast("Nainstalovat aplikaci na plochu tohoto zařízení?", {
 			icon: downloadOutline,
+			cssClass: "install-toast",
 			duration: 0,
 			position: "bottom",
 			buttons: [

--- a/frontend/src/app/features/account/components/account-app/account-app.component.scss
+++ b/frontend/src/app/features/account/components/account-app/account-app.component.scss
@@ -38,6 +38,15 @@
 
 ion-button {
 	--border-radius: var(--bo-radius-btn);
+	/* Drive the button off the app's own theme-aware brand tokens instead of Ionic's
+	   default primary: deep brand blue on the light card, the light periwinkle brand
+	   accent on the dark card. The label tracks --bo-paper so it always contrasts the
+	   accent — otherwise the default primary renders dark-navy-on-near-black in dark mode. */
+	--background: var(--bo-heading);
+	--background-hover: var(--bo-heading);
+	--background-focused: var(--bo-heading);
+	--background-activated: var(--bo-heading);
+	--color: var(--bo-paper);
 	text-transform: none;
 	letter-spacing: 0;
 	font-weight: 700;

--- a/frontend/src/styles/ionic.scss
+++ b/frontend/src/styles/ionic.scss
@@ -115,6 +115,34 @@ ion-button {
 	font-weight: 600;
 }
 
+/* PWA install banner — brand identity ("žlutá na modré").
+   The default toast leaves its action in --ion-color-primary (deep brand blue),
+   which is invisible on the dark toast surface. Give it the brand blue surface
+   with the yellow accent so the message, icon and buttons stay legible in both
+   the light and dark themes. */
+ion-toast.install-toast {
+	--background: var(--san-blue);
+	--color: #fff;
+	--border-radius: var(--bo-radius-card);
+	--box-shadow: var(--bo-shadow-hero-blue);
+
+	&::part(icon) {
+		color: var(--san-yellow);
+	}
+
+	/* primary action ("Nainstalovat") in the brand yellow so it reads as the CTA */
+	&::part(button) {
+		color: var(--san-yellow);
+		font-weight: 700;
+	}
+
+	/* dismiss ("Teď ne") stays a quiet white so it doesn't compete with the CTA */
+	&::part(button cancel) {
+		color: rgba(255, 255, 255, 0.85);
+		font-weight: 600;
+	}
+}
+
 ion-searchbar {
 	--border-radius: var(--bo-radius-pill) !important;
 }


### PR DESCRIPTION
# Změny

- PWA install toast (banner „Nainstalovat aplikaci na plochu tohoto zařízení?") dostal značkovou identitu „žlutá na modré": modrý podklad, žlutá ikona a hlavní akce **Nainstalovat**, tlumené bílé **Teď ne**. Ve výchozím stavu se akce toastu vykreslovala v `--ion-color-primary` (tmavě modrá) na tmavém podkladu a byla prakticky neviditelná v tmavém režimu.
- Toto se řeší novou globální třídou `install-toast` (v `styles/ionic.scss`) + nastavením `cssClass` na toast v `app.component.ts`.
- Zároveň jsem ošetřil tlačítko **Nainstalovat** na stránce účtu, které mělo stejný problém s výchozí `primary` barvou — nyní se řídí značkovými, na motiv reagujícími tokeny (`--bo-heading` / `--bo-paper`), takže vždy kontrastuje s kartou v obou motivech.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
    - V **tmavém** režimu je install banner modrý, ikona i tlačítko **Nainstalovat** jsou dobře čitelné (žluté) a **Teď ne** je tlumeně bílé.
    - Ve **světlém** režimu vypadá banner stejně (modrý podklad, žlutá akce).
    - Na stránce **Můj účet → Aplikace** je tlačítko **Nainstalovat** čitelné v obou motivech.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gz8qaD4WPErYZxNzm57km

---
_Generated by [Claude Code](https://claude.ai/code/session_015gz8qaD4WPErYZxNzm57km)_