### PR TITLE
Připojit se k Mongo až při spuštění příkazu mongo-import

### DIFF
--- a/backend/src/mongo-import/mongo-import.module.ts
+++ b/backend/src/mongo-import/mongo-import.module.ts
@@ -1,10 +1,8 @@
 import { Module } from "@nestjs/common";
-import { MongooseModule } from "@nestjs/mongoose";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { AuthModule } from "src/auth/auth.module";
-import { Config } from "src/config";
-import { AlbumsModelModule } from "src/models/albums/albums-model.module";
 import { Album } from "src/models/albums/entities/album.entity";
+import { AlbumsModelModule } from "src/models/albums/albums-model.module";
 import { Photo } from "src/models/albums/entities/photo.entity";
 import { Event } from "src/models/events/entities/event.entity";
 import { EventsModelModule } from "src/models/events/events-model.module";
@@ -13,26 +11,14 @@ import { MembersModelModule } from "src/models/members/members-model.module";
 import { User } from "src/models/users/entities/user.entity";
 import { UsersModelModule } from "src/models/users/users-model.module";
 import { StartImportCommand } from "./commands/import-mongo-data.command";
-import { MongoAlbum, MongoAlbumSchema } from "./models/album";
-import { MongoEvent, MongoEventSchema } from "./models/event";
-import { MongoMember, MongoMemberSchema } from "./models/member";
-import { MongoPhoto, MongoPhotoSchema } from "./models/photo";
-import { MongoUser, MongoUserSchema } from "./models/user";
 import { MongoImportService } from "./services/mongo-import.service";
 
 @Module({
 	imports: [
-		MongooseModule.forFeature([
-			{ name: MongoAlbum.name, schema: MongoAlbumSchema },
-			{ name: MongoPhoto.name, schema: MongoPhotoSchema },
-			{ name: MongoEvent.name, schema: MongoEventSchema },
-			{ name: MongoMember.name, schema: MongoMemberSchema },
-			{ name: MongoUser.name, schema: MongoUserSchema },
-		]),
-		MongooseModule.forRootAsync({
-			inject: [Config],
-			useFactory: (config: Config) => ({ uri: config.mongoDb.uri, connectTimeoutMS: 1000 }),
-		}),
+		// The Mongo connection is intentionally NOT established here: MongooseModule.forRootAsync
+		// would connect at module init, which happens on every CLI startup regardless of the
+		// command being run. MongoImportService opens (and closes) the connection lazily, so Mongo
+		// is only contacted when the `mongo-import` command actually runs.
 		TypeOrmModule.forFeature([Album, Photo, Event, Member, User]),
 
 		AuthModule,

--- a/backend/src/mongo-import/services/mongo-import.service.ts
+++ b/backend/src/mongo-import/services/mongo-import.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { InjectModel } from "@nestjs/mongoose";
 import { DateTime } from "luxon";
-import { Model } from "mongoose";
+import mongoose, { Model } from "mongoose";
 import { Config } from "src/config";
 import { Album } from "src/models/albums/entities/album.entity";
 import { Photo } from "src/models/albums/entities/photo.entity";
@@ -14,11 +13,11 @@ import { Member, MemberRanks, MemberRoles, MembershipStates } from "src/models/m
 import { User, UserRoles } from "src/models/users/entities/user.entity";
 import { EntityManager, EntityTarget, ObjectLiteral } from "typeorm";
 import { MongoMemberGroups } from "../data/member-groups";
-import { MongoAlbum } from "../models/album";
-import { MongoEvent } from "../models/event";
-import { MongoMember } from "../models/member";
-import { MongoPhoto } from "../models/photo";
-import { MongoUser } from "../models/user";
+import { MongoAlbum, MongoAlbumSchema } from "../models/album";
+import { MongoEvent, MongoEventSchema } from "../models/event";
+import { MongoMember, MongoMemberSchema } from "../models/member";
+import { MongoPhoto, MongoPhotoSchema } from "../models/photo";
+import { MongoUser, MongoUserSchema } from "../models/user";
 
 @Injectable()
 export class MongoImportService {
@@ -26,12 +25,15 @@ export class MongoImportService {
 
 	private readonly groupsIndex = new Map<string, number>();
 
+	// Assigned lazily in importData() once the Mongo connection is established, so that no
+	// connection is opened just by constructing this service at CLI startup.
+	private albumsModel!: Model<MongoAlbum>;
+	private photosModel!: Model<MongoPhoto>;
+	private eventsModel!: Model<MongoEvent>;
+	private membersModel!: Model<MongoMember>;
+	private usersModel!: Model<MongoUser>;
+
 	constructor(
-		@InjectModel(MongoAlbum.name) private albumsModel: Model<MongoAlbum>,
-		@InjectModel(MongoPhoto.name) private photosModel: Model<MongoPhoto>,
-		@InjectModel(MongoEvent.name) private eventsModel: Model<MongoEvent>,
-		@InjectModel(MongoMember.name) private membersModel: Model<MongoMember>,
-		@InjectModel(MongoUser.name) private usersModel: Model<MongoUser>,
 		private entityManager: EntityManager,
 		private config: Config,
 	) {}
@@ -39,17 +41,32 @@ export class MongoImportService {
 	async importData() {
 		this.logger.log(`Starting mongo import from ${this.config.mongoDb.uri}...`);
 
-		await this.entityManager.transaction(async (t) => {
-			await this.init(t);
+		// Connect to Mongo only now, when the import actually runs — not at module/CLI startup.
+		const connection = await mongoose
+			.createConnection(this.config.mongoDb.uri, { connectTimeoutMS: 1000 })
+			.asPromise();
 
-			const memberIds = await this.importMembers(t);
+		this.albumsModel = connection.model(MongoAlbum.name, MongoAlbumSchema);
+		this.photosModel = connection.model(MongoPhoto.name, MongoPhotoSchema);
+		this.eventsModel = connection.model(MongoEvent.name, MongoEventSchema);
+		this.membersModel = connection.model(MongoMember.name, MongoMemberSchema);
+		this.usersModel = connection.model(MongoUser.name, MongoUserSchema);
 
-			const userIds = await this.importUsers(t, memberIds);
+		try {
+			await this.entityManager.transaction(async (t) => {
+				await this.init(t);
 
-			const eventIds = await this.importEvents(t, memberIds);
+				const memberIds = await this.importMembers(t);
 
-			await this.importAlbums(t, userIds, eventIds);
-		});
+				const userIds = await this.importUsers(t, memberIds);
+
+				const eventIds = await this.importEvents(t, memberIds);
+
+				await this.importAlbums(t, userIds, eventIds);
+			});
+		} finally {
+			await connection.close();
+		}
 
 		this.logger.log(`Mongo import finished.`);
 	}


### PR DESCRIPTION
# Změny

 - `MongooseModule.forRootAsync` otevíral spojení s Mongo už při inicializaci modulu, což proběhne při **každém** startu CLI bez ohledu na to, který příkaz se spouští (a padalo/čekalo na timeout, když Mongo nebylo dostupné).
 - Spojení se nyní vytváří **líně** až v `MongoImportService.importData()`, tedy jen když skutečně běží příkaz `mongo-import`. Modely se vytvářejí nad tímto spojením a po dokončení importu se spojení zavře (`connection.close()` v `finally`).
 - Z `MongoImportModule` odstraněny `MongooseModule.forFeature` i `forRootAsync`; modely už nejsou injektovány přes `@InjectModel`.

# Testovací scénář

1. Spusť CLI příkaz, který **není** `mongo-import` (nebo jen nastartuj CLI) — nesmí se objevit žádný pokus o připojení k Mongo ani timeout.
2. Spusť příkaz `mongo-import` s dostupnou Mongo databází — import proběhne stejně jako dříve a po dokončení se spojení korektně zavře.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GQRVx3kEaMkV8sQsbKHiD

---
_Generated by [Claude Code](https://claude.ai/code/session_017GQRVx3kEaMkV8sQsbKHiD)_