### PR TITLE
CLI používá logging konfiguraci z config.ts

### DIFF
--- a/backend/src/main-cli.ts
+++ b/backend/src/main-cli.ts
@@ -7,10 +7,7 @@ async function bootstrap() {
 	const logger = new Logger("CLI");
 
 	await CommandFactory.run(CliModule, {
-		logger:
-			StaticConfig.environment === "development"
-				? ["log", "warn", "error", "fatal", "verbose", "debug"]
-				: ["log", "warn", "error", "fatal"],
+		logger: StaticConfig.logging.level,
 		serviceErrorHandler: (error) => {
 			logger.error(error);
 			console.error(error);


### PR DESCRIPTION
# Změny

 - CLI (`main-cli.ts`) nyní odvozuje NestJS log úrovně z `StaticConfig.logging.level`, tedy z proměnných `LOG_LEVEL` a `LOG_DEBUG` — stejně jako `main.ts`. Dříve úrovně natvrdo záviselY pouze na tom, zda běží v `development`.

# Testovací scénář

1. Spusť CLI příkaz s `LOG_DEBUG=1` a ověř, že se zobrazují `debug`/`verbose` logy.
2. Spusť CLI příkaz bez `LOG_DEBUG`/`LOG_LEVEL` a ověř, že se zobrazují jen `log`/`warn`/`error`/`fatal`.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W81FMukk93cKvUJPairn42)_