### PR TITLE
Log app name and version on CLI bootstrap

### DIFF
--- a/backend/src/main-cli.ts
+++ b/backend/src/main-cli.ts
@@ -6,6 +6,9 @@ import { StaticConfig } from "./config";
 async function bootstrap() {
 	const logger = new Logger("CLI");
 
+	logger.log(`${StaticConfig.app.name} CLI`);
+	logger.log(`Version: ${StaticConfig.app.version}`);
+
 	await CommandFactory.run(CliModule, {
 		logger: StaticConfig.logging.level,
 		serviceErrorHandler: (error) => {


### PR DESCRIPTION
# Změny

 - `main-cli.ts` nyní loguje název aplikace (`Bošán`) a verzi před spuštěním CLI, stejně jako to dělá `main.ts` při startu serveru. Hodnoty se čtou z `StaticConfig.app.name` a `StaticConfig.app.version`.

# Testovací scénář

1. Spusť CLI (`npm run cli` v `backend/`).
2. Zkontroluj, že se v logu na začátku objeví `Bošán CLI` a `Version: <verze>` ještě před bootstrapem CLI modulu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdxrDfp6cgJGUmUHGUoNHf)_