### PR TITLE
Znovu aplikovat miscelaneous fixes (kratší názvy stránek, ACL tlačítka v databázi)

### DIFF
--- a/frontend/src/app/features/events/pages/event-view/event-view.component.html
+++ b/frontend/src/app/features/events/pages/event-view/event-view.component.html
@@ -16,9 +16,9 @@
 		<div class="d-none d-lg-block" style="min-width: 200px">
 			<bo-vertical-menu defaultTab="info" (change)="view.set($any($event))">
 				<bo-vertical-menu-item name="info" label="Info" icon="calendar"></bo-vertical-menu-item>
-				<bo-vertical-menu-item name="attendees" label="Účastníci" icon="people-outline"></bo-vertical-menu-item>
-				<bo-vertical-menu-item name="problems" label="Problémy" icon="medkit-outline"></bo-vertical-menu-item>
-				<bo-vertical-menu-item name="accounting" label="Účtování" icon="cash-outline"></bo-vertical-menu-item>
+				<bo-vertical-menu-item name="attendees" label="Lidé" icon="people-outline"></bo-vertical-menu-item>
+				<bo-vertical-menu-item name="problems" label="Potíže" icon="medkit-outline"></bo-vertical-menu-item>
+				<bo-vertical-menu-item name="accounting" label="Výdaje" icon="cash-outline"></bo-vertical-menu-item>
 				<bo-vertical-menu-item name="report" label="Report" icon="document-outline"></bo-vertical-menu-item>
 			</bo-vertical-menu>
 		</div>
@@ -66,9 +66,9 @@
 <bo-page-footer class="d-lg-none">
 	<bo-tabs defaultTab="info" (change)="view.set($any($event))">
 		<bo-tab name="info" label="Info" icon="calendar"></bo-tab>
-		<bo-tab name="attendees" label="Účastníci" icon="people-outline"></bo-tab>
-		<bo-tab name="problems" label="Problémy" icon="medkit-outline"></bo-tab>
-		<bo-tab name="accounting" label="Účtování" icon="cash-outline"></bo-tab>
+		<bo-tab name="attendees" label="Lidé" icon="people-outline"></bo-tab>
+		<bo-tab name="problems" label="Potíže" icon="medkit-outline"></bo-tab>
+		<bo-tab name="accounting" label="Výdaje" icon="cash-outline"></bo-tab>
 		<bo-tab name="report" label="Report" icon="document-outline"></bo-tab>
 	</bo-tabs>
 </bo-page-footer>

--- a/frontend/src/app/features/members/components/member-create-modal/member-create-modal.component.ts
+++ b/frontend/src/app/features/members/components/member-create-modal/member-create-modal.component.ts
@@ -1,5 +1,5 @@
 import { KeyValuePipe } from "@angular/common";
-import { Component, signal } from "@angular/core";
+import { Component, Input, OnInit, signal } from "@angular/core";
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from "@angular/forms";
 import {
 	IonButton,
@@ -38,7 +38,10 @@ import { SDK } from "src/sdk";
 		GroupsSelectComponent,
 	],
 })
-export class MemberCreateModalComponent extends InputModalComponent<SDK.MemberCreateBody> {
+export class MemberCreateModalComponent extends InputModalComponent<SDK.MemberCreateBody> implements OnInit {
+	// Preselects the group when opened from within a group's page; the user can still change it.
+	@Input() defaultGroupId?: number | null;
+
 	roles = MemberRoles;
 
 	showValidationErrors = signal(false);
@@ -53,6 +56,10 @@ export class MemberCreateModalComponent extends InputModalComponent<SDK.MemberCr
 
 	constructor(modalController: ModalController) {
 		super(modalController);
+	}
+
+	ngOnInit() {
+		if (this.defaultGroupId != null) this.form.controls.groupId.setValue(this.defaultGroupId);
 	}
 
 	createMember() {

--- a/frontend/src/app/features/members/pages/group-view/group-view.component.ts
+++ b/frontend/src/app/features/members/pages/group-view/group-view.component.ts
@@ -3,8 +3,9 @@ import { ActivatedRoute } from "@angular/router";
 import { AlertController, NavController } from "@ionic/angular/standalone";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { addIcons } from "ionicons";
-import { create, informationCircleOutline, peopleOutline, trash } from "ionicons/icons";
+import { addOutline, create, downloadOutline, informationCircleOutline, peopleOutline, trash } from "ionicons/icons";
 import { ApiService } from "src/app/core/services/api.service";
+import { ModalService } from "src/app/core/services/modal.service";
 import { ToastService } from "src/app/core/services/toast.service";
 import { Action } from "src/app/shared/components/action-buttons/action-buttons.component";
 import { PageContentComponent } from "src/app/shared/components/page-content/page-content.component";
@@ -17,6 +18,7 @@ import { VerticalMenuComponent } from "src/app/shared/components/vertical-menu/v
 import { SDK } from "src/sdk";
 import { GroupInfoComponent } from "../../components/group-info/group-info.component";
 import { GroupMembersComponent } from "../../components/group-members/group-members.component";
+import { MemberCreateModalComponent } from "../../components/member-create-modal/member-create-modal.component";
 import { GroupsService } from "../../services/groups.service";
 
 @UntilDestroy()
@@ -41,29 +43,46 @@ export class GroupViewComponent implements OnInit {
 
 	view = signal<"info" | "clenove">("clenove");
 
-	// actions that do not apply to the group are hidden,
-	// actions that apply but the user is not permitted to use are shown disabled
+	// actions the user is not permitted to use are hidden entirely (not shown disabled)
 	actions = computed<Action[]>(() => {
 		const links = this.group()?._links;
 
-		return [
+		const actions: Action[] = [
 			{
 				text: "Upravit",
 				icon: "create",
 				pinned: true,
-				hidden: !links?.updateGroup.applicable,
-				disabled: !links?.updateGroup.allowed,
+				hidden: !links?.updateGroup.applicable || !links?.updateGroup.allowed,
 				handler: () => this.navController.navigateForward(`/databaze/oddily/${this.group()?.id}/upravit`),
 			},
 			{
 				text: "Smazat",
 				icon: "trash",
 				color: "danger",
-				hidden: !links?.deleteGroup.applicable,
-				disabled: !links?.deleteGroup.allowed,
+				hidden: !links?.deleteGroup.applicable || !links?.deleteGroup.allowed,
 				handler: () => this.deleteGroup(),
 			},
 		];
+
+		// member-list actions only make sense while looking at the Členové tab
+		if (this.view() === "clenove") {
+			actions.push(
+				{
+					text: "Nový člen",
+					icon: "add-outline",
+					pinned: true,
+
+					handler: () => this.createMember(),
+				},
+				{
+					text: "Export do XLSX",
+					icon: "download-outline",
+					handler: () => this.exportMembers(),
+				},
+			);
+		}
+
+		return actions;
 	});
 
 	constructor(
@@ -73,8 +92,9 @@ export class GroupViewComponent implements OnInit {
 		private groupsService: GroupsService,
 		private alertController: AlertController,
 		private toastService: ToastService,
+		private modalService: ModalService,
 	) {
-		addIcons({ informationCircleOutline, peopleOutline, create, trash });
+		addIcons({ informationCircleOutline, peopleOutline, create, trash, addOutline, downloadOutline });
 	}
 
 	ngOnInit(): void {
@@ -113,5 +133,39 @@ export class GroupViewComponent implements OnInit {
 		await this.toastService.toast(`${group.name ?? "Oddíl " + group.id} smazán.`);
 
 		this.navController.navigateBack("/databaze");
+	}
+
+	private async createMember() {
+		const group = this.group();
+		if (!group) return;
+
+		const memberData = await this.modalService.componentModal(MemberCreateModalComponent, {
+			defaultGroupId: group.id,
+		});
+		if (!memberData) return;
+
+		await this.api.MembersApi.createMember(memberData);
+		await this.toastService.toast("Člen uložen.");
+
+		// re-fetch the group so bo-group-members (subscribed to currentGroup) reloads its list
+		this.groupsService.loadGroup(group.id);
+	}
+
+	private async exportMembers() {
+		const group = this.group();
+		if (!group) return;
+
+		const res = await this.api.MembersApi.exportMembersXlsx({ groups: [group.id], active: true }, { responseType: "blob" });
+
+		const blob = new Blob([res.data], {
+			type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		});
+
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = `${group.shortName ?? "oddil-" + group.id}.xlsx`;
+		a.click();
+		URL.revokeObjectURL(url);
 	}
 }

--- a/frontend/src/app/features/members/pages/groups-list/groups-list.component.ts
+++ b/frontend/src/app/features/members/pages/groups-list/groups-list.component.ts
@@ -68,8 +68,7 @@ export class GroupsListComponent implements ViewWillEnter, ViewWillLeave {
 				text: "Nový oddíl",
 				icon: "add-outline",
 				pinned: true,
-				disabled: !links?.createGroup.allowed,
-				hidden: !links?.createGroup.applicable,
+				hidden: !links?.createGroup.applicable || !links?.createGroup.allowed,
 				handler: () => this.createGroup(),
 			},
 		]);

--- a/frontend/src/app/features/members/pages/members-list/members-list.component.html
+++ b/frontend/src/app/features/members/pages/members-list/members-list.component.html
@@ -1,4 +1,4 @@
-<bo-page-header title="Členská databáze" [actions]="actions()" />
+<bo-page-header title="Databáze" [actions]="actions()" />
 
 <bo-filter [search]="true" [showButtonMobileOnly]="true" [immediateFilter]="true">
 	@if (isDesktop()) {
@@ -260,7 +260,7 @@
 
 	@if (!members()) {
 		<p class="ion-padding">
-			Členská databáze je prázdná. Chceš <a class="clickable" (click)="create()">přidat prvního člena</a>?
+			Databáze je prázdná. Chceš <a class="clickable" (click)="create()">přidat prvního člena</a>?
 		</p>
 	}
 


### PR DESCRIPTION
# Změny

Znovu aplikuje změny z branche `miscelaneous-fixes`, které se do masteru nedostaly. Původně byly smergované v #280, poté revertované v #281, a opětovný merge v #282 už je nevrátil — commity z `miscelaneous-fixes` jsou v masteru předkem, takže Git je pokládá za smergované a revert zůstal v platnosti. Proto tato branch nese **cherry-pick** tří původních commitů nad aktuální master:

- `fix too long bar solved by shorter names of pages` — v detailu akce se záložky přejmenovaly na kratší: **Účastníci → Lidé**, **Problémy → Potíže**, **Účtování → Výdaje** (desktopové vertikální menu i mobilní taby).
- `buttons in database acl` — na stránce oddílu (`/databaze/oddily/:id`) přibyla akce **Nový člen** (přes `MemberCreateModalComponent` s novým `@Input() defaultGroupId`, který předvybere oddíl) a **Export do XLSX**; obě se zobrazují jen na záložce Členové. Zároveň se akce, na které uživatel nemá právo, nyní **skrývají** místo toho, aby se zobrazovaly zašedlé — v detailu oddílu i v seznamu oddílů.
- `shorten the database name` — titulek seznamu členů **Členská databáze → Databáze** (včetně textu pro prázdný seznam).

## Co se záměrně nevrací

- Commit `fix-errors-durnig-npm-run` (změny v `backend/package.json`, `backend/package-lock.json`, `frontend/tsconfig.json`, `app.config.ts`, `event-attendees-list.component.html`) **není** součástí — byl revertován samostatně na samotné branchi (`bdd439c`, smergováno v #282), takže jeho vynechání je zamýšlený stav.
- Přímý diff `master`↔`miscelaneous-fixes` obsahuje i změny v `events-list`, ale ty jsou jen důsledek toho, že branch je v tomto souboru starší než master — jejich převzetí by revertovalo #279 (skrývání hover náhledu při otevření akce). Cherry-pick se jich proto nedotýká; `frontend/src/app/features/events/pages/events-list/` je vůči masteru bitově shodný.

Výsledný diff se týká 5 souborů a jejich obsah je shodný s branchí `miscelaneous-fixes`. Ověřeno, že API, které nový kód volá, v aktuálním masteru existuje ve stejné podobě (`ModalService.componentModal(component, componentProps)`, `MembersApi.exportMembersXlsx(queryParams, options)`), takže není potřeba regenerovat SDK ani měnit backend.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že v **detailu akce** mají záložky kratší názvy — **Lidé**, **Potíže**, **Výdaje** — a že se lišta vejde na jeden řádek. Ověř na desktopu (vertikální menu) i na mobilu (spodní taby).
3. Zkontroluj, že seznam členů (`/databaze`) má titulek **Databáze** místo *Členská databáze*.
4. Otevři detail oddílu (`/databaze/oddily/:id`), záložka **Členové**:
    - jsou vidět akce **Nový člen** a **Export do XLSX**,
    - **Nový člen** otevře modal s **předvybraným oddílem** (a jde přepnout na jiný); po uložení se seznam členů oddílu obnoví,
    - **Export do XLSX** stáhne soubor pojmenovaný podle zkratky oddílu,
    - po přepnutí na záložku **Info** obě tyto akce zmizí.
5. Zkontroluj, že akce, na které nemáš práva (Upravit / Smazat u oddílu, Nový oddíl v seznamu oddílů), se **nezobrazují vůbec** místo zašedlé varianty.
6. Zkontroluj, že v přehledu akcí dál funguje náhledová kartička a že se schová při otevření akce (regrese vůči #279).

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CuxzxQbmnKADF8fMDG3en3)_