### PR TITLE
Nahlašování chyb také jako GitHub issues

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,8 @@
         "@nestjs/serve-static": "^5.0.4",
         "@nestjs/swagger": "^11.2.3",
         "@nestjs/typeorm": "^11.0.0",
+        "@octokit/auth-app": "^7.2.2",
+        "@octokit/rest": "^21.1.1",
         "archiver": "^7.0.1",
         "bcryptjs": "^3.0.3",
         "change-case": "^5.4.4",
@@ -2960,6 +2962,280 @@
         "npm": ">=5.10.0"
       }
     },
+    "node_modules/@octokit/auth-app": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-7.2.2.tgz",
+      "integrity": "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^8.1.4",
+        "@octokit/auth-oauth-user": "^5.1.4",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-8.1.4.tgz",
+      "integrity": "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^7.1.5",
+        "@octokit/auth-oauth-user": "^5.1.4",
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-7.1.5.tgz",
+      "integrity": "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^5.1.5",
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.6.tgz",
+      "integrity": "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^7.1.5",
+        "@octokit/oauth-methods": "^5.1.5",
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
+      "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.6.tgz",
+      "integrity": "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.2.2",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
+      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
+      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.2.3",
+        "@octokit/types": "^14.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-7.1.1.tgz",
+      "integrity": "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-5.1.5.tgz",
+      "integrity": "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^7.0.0",
+        "@octokit/request": "^9.2.3",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.6.0.tgz",
+      "integrity": "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.5.0.tgz",
+      "integrity": "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.10.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.4.tgz",
+      "integrity": "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.1.4",
+        "@octokit/request-error": "^6.1.8",
+        "@octokit/types": "^14.0.0",
+        "fast-content-type-parse": "^2.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
+      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^14.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.1.1.tgz",
+      "integrity": "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.4",
+        "@octokit/plugin-paginate-rest": "^11.4.2",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.3.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^25.1.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -4876,6 +5152,12 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -6496,6 +6778,22 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
+      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -9308,6 +9606,67 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
@@ -9563,6 +9922,28 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-int64": {
@@ -11561,6 +11942,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -11587,6 +11977,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -12157,6 +12555,18 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -12360,6 +12770,14 @@
       "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
       "license": "Apache-2.0"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/webpack": {
       "version": "5.103.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.103.0.tgz",
@@ -12512,6 +12930,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,8 @@
     "@nestjs/serve-static": "^5.0.4",
     "@nestjs/swagger": "^11.2.3",
     "@nestjs/typeorm": "^11.0.0",
+    "@octokit/auth-app": "^7.2.2",
+    "@octokit/rest": "^21.1.1",
     "archiver": "^7.0.1",
     "bcryptjs": "^3.0.3",
     "change-case": "^5.4.4",

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req } from "@nestjs/common";
+import { Body, Controller, InternalServerErrorException, Post, Req } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { AcController } from "src/access-control/access-control-lib";
@@ -22,10 +22,16 @@ export class FeedbackController {
 
 		const report = await this.feedback.buildBugReport(authUser.userId, body);
 
-		// File the issue first: it is best-effort and never throws, so it is filed even when
-		// the email send below fails. The email is sent last so its failure still surfaces to
-		// the client (the primary channel), without discarding the already-filed issue.
-		await this.feedback.fileBugReportIssue(report);
-		await this.feedback.sendBugReportEmail(report);
+		// Deliver on both channels independently — neither throws on its own failure. The
+		// report succeeds as long as at least one channel got through; only a total failure
+		// (email and GitHub both down) surfaces as an error to the client.
+		const [emailed, filed] = await Promise.all([
+			this.feedback.sendBugReportEmail(report),
+			this.feedback.fileBugReportIssue(report),
+		]);
+
+		if (!emailed && !filed) {
+			throw new InternalServerErrorException("Bug report could not be delivered by email or GitHub.");
+		}
 	}
 }

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -72,7 +72,7 @@ export class FeedbackController {
 				.join("\n");
 
 			const issue = await this.github.createIssue(this.config.github.bugReportRepo, {
-				title: this.issueTitle(params.description),
+				title: this.issueTitle(params.description, this.config.app.environmentTitle),
 				body: issueBody,
 				labels: [this.config.github.bugReportLabel],
 			});
@@ -83,10 +83,15 @@ export class FeedbackController {
 		}
 	}
 
-	/** Build a concise issue title from the free-text description (first line, truncated). */
-	private issueTitle(description: string): string {
+	/**
+	 * Build a concise issue title from the free-text description (first line, truncated).
+	 * Non-production environments (ENV_TITLE set, e.g. "TEST") are prefixed so a report from
+	 * the testing environment is recognizable straight from the issue list.
+	 */
+	private issueTitle(description: string, environmentTitle: string): string {
 		const firstLine = description.trim().split("\n")[0].trim();
 		const summary = firstLine.length > 80 ? `${firstLine.slice(0, 77)}…` : firstLine;
-		return `Nahlášená chyba: ${summary}`;
+		const prefix = environmentTitle ? `[${environmentTitle}] ` : "";
+		return `${prefix}Nahlášená chyba: ${summary}`;
 	}
 }

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req } from "@nestjs/common";
+import { Body, Controller, Logger, Post, Req } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { AcController } from "src/access-control/access-control-lib";
@@ -6,6 +6,7 @@ import { AuthUser } from "src/auth/decorators/auth-user.decorator";
 import { Authenticated } from "src/auth/decorators/authenticated.decorator";
 import { SessionUser } from "src/auth/schema/user-token";
 import { Config } from "src/config";
+import { GithubService } from "src/models/github/services/github.service";
 import { MailService } from "src/models/mail/services/mail.service";
 import { UsersRepository } from "src/models/users/repositories/users.repository";
 import { SendBugReportPermission } from "../acl/feedback.acl";
@@ -17,8 +18,11 @@ import { BugReportMailTemplate } from "../mail-templates/bug-report/bug-report.m
 @ApiTags("Feedback")
 @AcController()
 export class FeedbackController {
+	private readonly logger = new Logger(FeedbackController.name);
+
 	constructor(
 		private readonly mailService: MailService,
+		private readonly github: GithubService,
 		private readonly users: UsersRepository,
 		private readonly config: Config,
 	) {}
@@ -30,14 +34,59 @@ export class FeedbackController {
 		const user = await this.users.getUser(authUser.userId, { includeMember: true });
 
 		const reporter = [user?.member?.nickname, user?.login && `<${user.login}>`].filter(Boolean).join(" ") || "neznámý";
+		const environment = this.config.app.environmentTitle || this.config.environment;
 
 		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
 			reporter,
-			environment: this.config.app.environmentTitle || this.config.environment,
+			environment,
 			url: body.url,
 			description: body.description,
 		});
 
 		await this.mailService.sendMail(mail);
+
+		// Also file the report as a GitHub issue. This is best-effort: a misconfigured or
+		// unreachable GitHub must not fail the report, which has already been delivered by mail.
+		await this.fileGithubIssue({ reporter, environment, url: body.url, description: body.description });
+	}
+
+	private async fileGithubIssue(params: {
+		reporter: string;
+		environment: string;
+		url?: string;
+		description: string;
+	}): Promise<void> {
+		if (!this.github.isConfigured) return;
+
+		try {
+			const issueBody = [
+				`**Nahlásil:** ${params.reporter}`,
+				`**Prostředí:** ${params.environment}`,
+				params.url ? `**URL:** ${params.url}` : null,
+				"",
+				"---",
+				"",
+				params.description,
+			]
+				.filter((line) => line !== null)
+				.join("\n");
+
+			const issue = await this.github.createIssue(this.config.github.bugReportRepo, {
+				title: this.issueTitle(params.description),
+				body: issueBody,
+				labels: [this.config.github.bugReportLabel],
+			});
+
+			this.logger.log(`Bug report filed as GitHub issue #${issue.number} (${issue.url}).`);
+		} catch (err) {
+			this.logger.error(`Failed to file bug report as a GitHub issue: ${(err as Error).message}`);
+		}
+	}
+
+	/** Build a concise issue title from the free-text description (first line, truncated). */
+	private issueTitle(description: string): string {
+		const firstLine = description.trim().split("\n")[0].trim();
+		const summary = firstLine.length > 80 ? `${firstLine.slice(0, 77)}…` : firstLine;
+		return `Nahlášená chyba: ${summary}`;
 	}
 }

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -22,7 +22,10 @@ export class FeedbackController {
 
 		const report = await this.feedback.buildBugReport(authUser.userId, body);
 
-		await this.feedback.sendBugReportEmail(report);
+		// File the issue first: it is best-effort and never throws, so it is filed even when
+		// the email send below fails. The email is sent last so its failure still surfaces to
+		// the client (the primary channel), without discarding the already-filed issue.
 		await this.feedback.fileBugReportIssue(report);
+		await this.feedback.sendBugReportEmail(report);
 	}
 }

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -1,98 +1,28 @@
-import { Body, Controller, Logger, Post, Req } from "@nestjs/common";
+import { Body, Controller, Post, Req } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { AcController } from "src/access-control/access-control-lib";
 import { AuthUser } from "src/auth/decorators/auth-user.decorator";
 import { Authenticated } from "src/auth/decorators/authenticated.decorator";
 import { SessionUser } from "src/auth/schema/user-token";
-import { Config } from "src/config";
-import { GithubService } from "src/models/github/services/github.service";
-import { MailService } from "src/models/mail/services/mail.service";
-import { UsersRepository } from "src/models/users/repositories/users.repository";
 import { SendBugReportPermission } from "../acl/feedback.acl";
 import { BugReportBody } from "../dto/bug-report-body.dto";
-import { BugReportMailTemplate } from "../mail-templates/bug-report/bug-report.mail-template";
+import { FeedbackService } from "../services/feedback.service";
 
 @Controller("feedback")
 @Authenticated()
 @ApiTags("Feedback")
 @AcController()
 export class FeedbackController {
-	private readonly logger = new Logger(FeedbackController.name);
-
-	constructor(
-		private readonly mailService: MailService,
-		private readonly github: GithubService,
-		private readonly users: UsersRepository,
-		private readonly config: Config,
-	) {}
+	constructor(private readonly feedback: FeedbackService) {}
 
 	@Post("bug")
 	async sendBugReport(@Req() req: Request, @AuthUser() authUser: SessionUser, @Body() body: BugReportBody) {
 		SendBugReportPermission.canOrThrow(req);
 
-		const user = await this.users.getUser(authUser.userId, { includeMember: true });
+		const report = await this.feedback.buildBugReport(authUser.userId, body);
 
-		const reporter = [user?.member?.nickname, user?.login && `<${user.login}>`].filter(Boolean).join(" ") || "neznámý";
-		const environment = this.config.app.environmentTitle || this.config.environment;
-
-		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
-			reporter,
-			environment,
-			url: body.url,
-			description: body.description,
-		});
-
-		await this.mailService.sendMail(mail);
-		this.logger.verbose("Bug report email sent");
-
-		// Also file the report as a GitHub issue. This is best-effort: a misconfigured or
-		// unreachable GitHub must not fail the report, which has already been delivered by mail.
-		await this.fileGithubIssue({ reporter, environment, url: body.url, description: body.description });
-	}
-
-	private async fileGithubIssue(params: {
-		reporter: string;
-		environment: string;
-		url?: string;
-		description: string;
-	}): Promise<void> {
-		if (!this.github.isConfigured) return;
-
-		try {
-			const issueBody = [
-				`**Nahlásil:** ${params.reporter}`,
-				`**Prostředí:** ${params.environment}`,
-				params.url ? `**URL:** ${params.url}` : null,
-				"",
-				"---",
-				"",
-				params.description,
-			]
-				.filter((line) => line !== null)
-				.join("\n");
-
-			const issue = await this.github.createIssue(this.config.github.bugReportRepo, {
-				title: this.issueTitle(params.description, this.config.app.environmentTitle),
-				body: issueBody,
-				labels: [this.config.github.bugReportLabel],
-			});
-
-			this.logger.verbose(`Bug report filed as GitHub issue #${issue.number} (${issue.url}).`);
-		} catch (err) {
-			this.logger.error(`Failed to file bug report as a GitHub issue: ${(err as Error).message}`);
-		}
-	}
-
-	/**
-	 * Build a concise issue title from the free-text description (first line, truncated).
-	 * Non-production environments (ENV_TITLE set, e.g. "TEST") are prefixed so a report from
-	 * the testing environment is recognizable straight from the issue list.
-	 */
-	private issueTitle(description: string, environmentTitle: string): string {
-		const firstLine = description.trim().split("\n")[0].trim();
-		const summary = firstLine.length > 80 ? `${firstLine.slice(0, 77)}…` : firstLine;
-		const prefix = environmentTitle ? `[${environmentTitle}] ` : "";
-		return `${prefix}Nahlášená chyba: ${summary}`;
+		await this.feedback.sendBugReportEmail(report);
+		await this.feedback.fileBugReportIssue(report);
 	}
 }

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -43,7 +43,9 @@ export class FeedbackController {
 			description: body.description,
 		});
 
+		this.logger.debug(`Sending email to ${this.config.feedback.bugReportRecipient}`);
 		await this.mailService.sendMail(mail);
+		this.logger.verbose("Bug report email sent");
 
 		// Also file the report as a GitHub issue. This is best-effort: a misconfigured or
 		// unreachable GitHub must not fail the report, which has already been delivered by mail.
@@ -77,7 +79,7 @@ export class FeedbackController {
 				labels: [this.config.github.bugReportLabel],
 			});
 
-			this.logger.log(`Bug report filed as GitHub issue #${issue.number} (${issue.url}).`);
+			this.logger.verbose(`Bug report filed as GitHub issue #${issue.number} (${issue.url}).`);
 		} catch (err) {
 			this.logger.error(`Failed to file bug report as a GitHub issue: ${(err as Error).message}`);
 		}

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -43,7 +43,6 @@ export class FeedbackController {
 			description: body.description,
 		});
 
-		this.logger.debug(`Sending email to ${this.config.feedback.bugReportRecipient}`);
 		await this.mailService.sendMail(mail);
 		this.logger.verbose("Bug report email sent");
 

--- a/backend/src/api/feedback/feedback.module.ts
+++ b/backend/src/api/feedback/feedback.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { GithubModelModule } from "src/models/github/github-model.module";
 import { MailModelModule } from "src/models/mail/mail-model.module";
 import { UsersModelModule } from "src/models/users/users-model.module";
 import { FeedbackController } from "./controllers/feedback.controller";
 
 @Module({
 	controllers: [FeedbackController],
-	imports: [MailModelModule, UsersModelModule],
+	imports: [MailModelModule, UsersModelModule, GithubModelModule],
 })
 export class FeedbackModule {}

--- a/backend/src/api/feedback/feedback.module.ts
+++ b/backend/src/api/feedback/feedback.module.ts
@@ -3,9 +3,11 @@ import { GithubModelModule } from "src/models/github/github-model.module";
 import { MailModelModule } from "src/models/mail/mail-model.module";
 import { UsersModelModule } from "src/models/users/users-model.module";
 import { FeedbackController } from "./controllers/feedback.controller";
+import { FeedbackService } from "./services/feedback.service";
 
 @Module({
 	controllers: [FeedbackController],
 	imports: [MailModelModule, UsersModelModule, GithubModelModule],
+	providers: [FeedbackService],
 })
 export class FeedbackModule {}

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -43,8 +43,12 @@ export class FeedbackService {
 		};
 	}
 
-	/** Construct and send the bug-report email to the configured recipient. */
-	async sendBugReportEmail(report: BugReport): Promise<void> {
+	/**
+	 * Construct and send the bug-report email to the configured recipient.
+	 * Returns whether the email was actually sent; delivery failures are logged, not thrown,
+	 * so the caller can fall back to the other channel.
+	 */
+	async sendBugReportEmail(report: BugReport): Promise<boolean> {
 		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
 			reporter: report.reporter,
 			environment: report.environment,
@@ -52,16 +56,23 @@ export class FeedbackService {
 			description: report.description,
 		});
 
-		await this.mailService.sendMail(mail);
-		this.logger.verbose("Bug report email sent");
+		try {
+			await this.mailService.sendMail(mail);
+			this.logger.verbose("Bug report email sent");
+			return true;
+		} catch (err) {
+			this.logger.error(`Failed to send bug report email: ${(err as Error).message}`);
+			return false;
+		}
 	}
 
 	/**
-	 * Construct and file the bug report as a GitHub issue. Best-effort: a misconfigured or
-	 * unreachable GitHub must not fail the report, which is also delivered by email.
+	 * Construct and file the bug report as a GitHub issue.
+	 * Returns whether an issue was actually created — false when GitHub is not configured or
+	 * the API call fails (logged, not thrown), so the caller can fall back to the email.
 	 */
-	async fileBugReportIssue(report: BugReport): Promise<void> {
-		if (!this.github.isConfigured) return;
+	async fileBugReportIssue(report: BugReport): Promise<boolean> {
+		if (!this.github.isConfigured) return false;
 
 		try {
 			const issue = await this.github.createIssue(this.config.github.bugReportRepo, {
@@ -71,8 +82,10 @@ export class FeedbackService {
 			});
 
 			this.logger.verbose(`Bug report filed as GitHub issue #${issue.number} (${issue.url}).`);
+			return true;
 		} catch (err) {
 			this.logger.error(`Failed to file bug report as a GitHub issue: ${(err as Error).message}`);
+			return false;
 		}
 	}
 

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Config } from "src/config";
+import { GithubService } from "src/models/github/services/github.service";
+import { MailService } from "src/models/mail/services/mail.service";
+import { UsersRepository } from "src/models/users/repositories/users.repository";
+import { BugReportBody } from "../dto/bug-report-body.dto";
+import { BugReportMailTemplate } from "../mail-templates/bug-report/bug-report.mail-template";
+
+/** A bug report resolved into everything the email and issue need. */
+export interface BugReport {
+	reporter: string;
+	environment: string;
+	url?: string;
+	description: string;
+}
+
+@Injectable()
+export class FeedbackService {
+	private readonly logger = new Logger(FeedbackService.name);
+
+	constructor(
+		private readonly mailService: MailService,
+		private readonly github: GithubService,
+		private readonly users: UsersRepository,
+		private readonly config: Config,
+	) {}
+
+	/**
+	 * Resolve a submitted bug report into the context the email and issue share: the
+	 * reporter's identity (from the authenticated user) and the current environment.
+	 */
+	async buildBugReport(userId: number, body: BugReportBody): Promise<BugReport> {
+		const user = await this.users.getUser(userId, { includeMember: true });
+
+		const reporter =
+			[user?.member?.nickname, user?.login && `<${user.login}>`].filter(Boolean).join(" ") || "neznámý";
+
+		return {
+			reporter,
+			environment: this.config.app.environmentTitle || this.config.environment,
+			url: body.url,
+			description: body.description,
+		};
+	}
+
+	/** Construct and send the bug-report email to the configured recipient. */
+	async sendBugReportEmail(report: BugReport): Promise<void> {
+		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
+			reporter: report.reporter,
+			environment: report.environment,
+			url: report.url,
+			description: report.description,
+		});
+
+		await this.mailService.sendMail(mail);
+		this.logger.verbose("Bug report email sent");
+	}
+
+	/**
+	 * Construct and file the bug report as a GitHub issue. Best-effort: a misconfigured or
+	 * unreachable GitHub must not fail the report, which is also delivered by email.
+	 */
+	async fileBugReportIssue(report: BugReport): Promise<void> {
+		if (!this.github.isConfigured) return;
+
+		try {
+			const issue = await this.github.createIssue(this.config.github.bugReportRepo, {
+				title: this.issueTitle(report.description, this.config.app.environmentTitle),
+				body: this.issueBody(report),
+				labels: [this.config.github.bugReportLabel],
+			});
+
+			this.logger.verbose(`Bug report filed as GitHub issue #${issue.number} (${issue.url}).`);
+		} catch (err) {
+			this.logger.error(`Failed to file bug report as a GitHub issue: ${(err as Error).message}`);
+		}
+	}
+
+	private issueBody(report: BugReport): string {
+		return [
+			`**Nahlásil:** ${report.reporter}`,
+			`**Prostředí:** ${report.environment}`,
+			report.url ? `**URL:** ${report.url}` : null,
+			"",
+			"---",
+			"",
+			report.description,
+		]
+			.filter((line) => line !== null)
+			.join("\n");
+	}
+
+	/**
+	 * Build a concise issue title from the free-text description (first line, truncated).
+	 * Non-production environments (ENV_TITLE set, e.g. "TEST") are prefixed so a report from
+	 * the testing environment is recognizable straight from the issue list.
+	 */
+	private issueTitle(description: string, environmentTitle: string): string {
+		const firstLine = description.trim().split("\n")[0].trim();
+		const summary = firstLine.length > 80 ? `${firstLine.slice(0, 77)}…` : firstLine;
+		const prefix = environmentTitle ? `[${environmentTitle}] ` : "";
+		return `${prefix}Nahlášená chyba: ${summary}`;
+	}
+}

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -144,6 +144,34 @@ const feedback = {
 };
 
 /**
+ * GitHub App.
+ *
+ * In-app bug reports are additionally filed as GitHub issues (see FeedbackController /
+ * GithubService). Authentication uses a GitHub App: the App ID + private key sign a JWT
+ * that is exchanged for a short-lived installation access token (all handled by
+ * @octokit/auth-app), so issues are created as the app — no personal account or PAT.
+ *
+ * Set up: create a GitHub App with "Issues: Read & write" permission, generate a private
+ * key, and install it on the target repo. Provide the key either inline via
+ * GITHUB_APP_PRIVATE_KEY (PEM, literal `\n` escapes are accepted) or as a file mounted in
+ * the keys dir via GITHUB_APP_PRIVATE_KEY_FILE. The installation id is auto-discovered
+ * from the repo, so GITHUB_APP_INSTALLATION_ID is optional. When appId/privateKey are
+ * unset the integration is simply disabled and bug reports fall back to email only.
+ */
+const github = {
+	appId: process.env["GITHUB_APP_ID"] ?? "",
+	privateKey: (process.env["GITHUB_APP_PRIVATE_KEY"] ?? "").replace(/\\n/g, "\n"),
+	privateKeyFile: process.env["GITHUB_APP_PRIVATE_KEY_FILE"]
+		? path.resolve(fs.keysDir, process.env["GITHUB_APP_PRIVATE_KEY_FILE"])
+		: "",
+	installationId: process.env["GITHUB_APP_INSTALLATION_ID"] ?? "",
+	// Repository that in-app bug reports are filed into, as "owner/repo".
+	bugReportRepo: process.env["GITHUB_BUG_REPORT_REPO"] ?? "bosancz/interni-sekce",
+	// Label applied to every issue created from an in-app bug report.
+	bugReportLabel: process.env["GITHUB_BUG_REPORT_LABEL"] ?? "user-reported",
+};
+
+/**
  * OAuth2 identity-provider settings.
  *
  * The backend acts as an OAuth2 provider (authorization-code flow) so external
@@ -166,6 +194,7 @@ export class Config {
 	db = db;
 	environment = environment;
 	feedback = feedback;
+	github = github;
 	google = google;
 	jwt = jwt;
 	logging = logging;

--- a/backend/src/models/github/github-model.module.ts
+++ b/backend/src/models/github/github-model.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { GithubService } from "./services/github.service";
+
+@Module({
+	providers: [GithubService],
+	exports: [GithubService],
+})
+export class GithubModelModule {}

--- a/backend/src/models/github/services/github.service.ts
+++ b/backend/src/models/github/services/github.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { createAppAuth } from "@octokit/auth-app";
+import { Octokit } from "@octokit/rest";
+import { readFileSync } from "fs";
+import { Config } from "src/config";
+
+/**
+ * Thin wrapper around the GitHub REST API, authenticated as a GitHub App installation.
+ *
+ * The app's App ID + private key sign a JWT that @octokit/auth-app exchanges for a
+ * short-lived installation access token (auto-refreshed), so everything created here is
+ * authored by the app itself — no personal account or PAT. Currently used to file in-app
+ * bug reports as issues (see FeedbackController).
+ *
+ * When the app is not configured (missing App ID / private key), the service stays
+ * disabled: `isConfigured` is false and callers skip it, so bug reports fall back to
+ * email only instead of failing.
+ */
+@Injectable()
+export class GithubService {
+	private readonly logger = new Logger(GithubService.name);
+
+	private readonly appId: string;
+	private readonly privateKey: string;
+
+	/** Installation client, created lazily and cached after the first successful auth. */
+	private installationClient: Octokit | null = null;
+
+	constructor(private readonly config: Config) {
+		this.appId = this.config.github.appId;
+		this.privateKey = this.resolvePrivateKey();
+
+		if (!this.isConfigured) {
+			this.logger.warn(
+				"GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY[_FILE] missing); " +
+					"issue creation is disabled.",
+			);
+		}
+	}
+
+	/** Whether the GitHub App credentials are present and issue creation can be attempted. */
+	get isConfigured(): boolean {
+		return Boolean(this.appId && this.privateKey);
+	}
+
+	/**
+	 * Create an issue in the given "owner/repo" and return its number and html url.
+	 * Any label that does not yet exist in the repo is created automatically by GitHub.
+	 */
+	async createIssue(
+		repo: string,
+		params: { title: string; body: string; labels?: string[] },
+	): Promise<{ number: number; url: string }> {
+		const [owner, name] = repo.split("/");
+		if (!owner || !name) throw new Error(`Invalid GitHub repo "${repo}" (expected "owner/repo").`);
+
+		const client = await this.getInstallationClient(owner, name);
+
+		const res = await client.rest.issues.create({
+			owner,
+			repo: name,
+			title: params.title,
+			body: params.body,
+			labels: params.labels,
+		});
+
+		return { number: res.data.number, url: res.data.html_url };
+	}
+
+	/** Read the private key from the inline env var or the mounted key file. */
+	private resolvePrivateKey(): string {
+		if (this.config.github.privateKey) return this.config.github.privateKey;
+
+		const file = this.config.github.privateKeyFile;
+		if (!file) return "";
+
+		try {
+			return readFileSync(file, "utf8");
+		} catch (err) {
+			this.logger.error(`Failed to read GitHub App private key file "${file}": ${(err as Error).message}`);
+			return "";
+		}
+	}
+
+	/**
+	 * Build (and cache) an Octokit client scoped to the app's installation on the repo.
+	 * The installation id is taken from config when set, otherwise discovered from the repo.
+	 */
+	private async getInstallationClient(owner: string, repo: string): Promise<Octokit> {
+		if (this.installationClient) return this.installationClient;
+
+		if (!this.isConfigured) throw new Error("GitHub App is not configured.");
+
+		const auth = { appId: this.appId, privateKey: this.privateKey };
+
+		const installationId = this.config.github.installationId
+			? Number(this.config.github.installationId)
+			: (await new Octokit({ authStrategy: createAppAuth, auth }).rest.apps.getRepoInstallation({ owner, repo }))
+					.data.id;
+
+		this.installationClient = new Octokit({
+			authStrategy: createAppAuth,
+			auth: { ...auth, installationId },
+		});
+
+		return this.installationClient;
+	}
+}


### PR DESCRIPTION
# Změny

 - Nahlášení chyby z aplikace (menu účtu / postranní panel) se nově zakládá i jako **GitHub issue** — dosud se posílalo jen e‑mailem. E‑mail zůstává, issue se přidává navíc.
 - Issue se vytvoří v konfigurovaném repozitáři (výchozí `bosancz/interni-sekce`) a dostane štítek **`user-reported`**. Titulek se odvodí z prvního řádku popisu, tělo obsahuje kdo nahlásil, prostředí, URL a popis.
 - Nový `GithubService` se autentizuje jako **GitHub App** přes `@octokit/auth-app` (App ID + privátní klíč → installation token); ID instalace se automaticky zjistí z repozitáře. Přidány závislosti `@octokit/rest` a `@octokit/auth-app`.
 - Zakládání issue je **best‑effort**: když GitHub App není nastavená nebo je nedostupná, jen se zaloguje varování a nahlášení projde e‑mailem jako dřív.
 - Konfigurace přes env proměnné: `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY` (inline) nebo `GITHUB_APP_PRIVATE_KEY_FILE` (soubor v keys adresáři), volitelně `GITHUB_APP_INSTALLATION_ID`, `GITHUB_BUG_REPORT_REPO`, `GITHUB_BUG_REPORT_LABEL`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
    - Přes menu účtu / postranní panel jde nahlásit chybu jako dosud a přijde e‑mail.
    - Ve `bosancz/interni-sekce` se zároveň založil nový issue se štítkem `user-reported`, správným titulkem a popisem (nahlašovatel, prostředí, URL, text).
    - Když GitHub App není nakonfigurovaná, nahlášení stále projde e‑mailem (v logu je jen varování, request neselže).

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQ7h97vr4pQot3iDnUw67

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTQ7h97vr4pQot3iDnUw67)_