### PR TITLE
Nadpisy v markdown editoru, šablona reportu a viditelné textové pole

### DIFF
--- a/frontend/src/app/features/events/components/event-report/event-report.component.ts
+++ b/frontend/src/app/features/events/components/event-report/event-report.component.ts
@@ -15,6 +15,9 @@ import { SDK } from "src/sdk";
 import { MarkdownPipe } from "../../../../shared/pipes/markdown.pipe";
 import { AlbumSelectorModalComponent, CREATE_ALBUM } from "../album-selector-modal/album-selector-modal.component";
 
+/** Prefilled outline offered when writing a report for an event that doesn't have one yet. */
+const EVENT_REPORT_TEMPLATE = ["# Průběh akce", "", "# Problémy", "", "# Pochvaly pro členy"].join("\n");
+
 @UntilDestroy()
 @Component({
 	selector: "bo-event-report",
@@ -54,7 +57,7 @@ export class EventReportComponent {
 	async writeReport() {
 		const result = await this.modalService.componentModal(MarkdownEditorModalComponent, {
 			header: "Report",
-			value: this.event()?.report,
+			value: this.event()?.report || EVENT_REPORT_TEMPLATE,
 		});
 
 		if (result !== null) this.update.emit({ report: result });

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.html
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.html
@@ -11,6 +11,37 @@
 				color="light"
 				fill="solid"
 				size="small"
+				(click)="onAddHeading(1)"
+				aria-label="Přidat nadpis 1. úrovně"
+				boTooltip="Nadpis 1. úrovně (#)"
+			>
+				H1
+			</ion-button>
+			<ion-button
+				color="light"
+				fill="solid"
+				size="small"
+				(click)="onAddHeading(2)"
+				aria-label="Přidat nadpis 2. úrovně"
+				boTooltip="Nadpis 2. úrovně (##)"
+			>
+				H2
+			</ion-button>
+			<ion-button
+				color="light"
+				fill="solid"
+				size="small"
+				(click)="onAddHeading(3)"
+				aria-label="Přidat nadpis 3. úrovně"
+				boTooltip="Nadpis 3. úrovně (###)"
+			>
+				H3
+			</ion-button>
+			<div class="toolbar-separator"></div>
+			<ion-button
+				color="light"
+				fill="solid"
+				size="small"
 				(click)="onAddBold()"
 				aria-label="Přidat tučné formátování"
 				boTooltip="Tučné (Ctrl/Cmd + B)"
@@ -60,6 +91,7 @@
 <div class="help-pane" [hidden]="view() !== 'help'">
 	<p>Používej markdown zápis přímo v textu:</p>
 	<ul>
+		<li><strong>Nadpisy:</strong> <code>#</code>, <code>##</code>, <code>###</code> na začátku řádku</li>
 		<li><strong>Tučné:</strong> <code>**text**</code></li>
 		<li><strong>Kurzíva:</strong> <code>_text_</code></li>
 		<li><strong>Seznam:</strong> každý řádek začni <code>- </code></li>

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.html
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.html
@@ -74,6 +74,7 @@
 
 	<ion-textarea
 		autoGrow
+		fill="outline"
 		[placeholder]="placeholder()"
 		[(ngModel)]="content"
 		(keydown)="onEditorKeydown($event)"

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.html
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.html
@@ -72,13 +72,14 @@
 		</div>
 	</div>
 
-	<ion-textarea
-		autoGrow
-		fill="outline"
-		[placeholder]="placeholder()"
-		[(ngModel)]="content"
-		(keydown)="onEditorKeydown($event)"
-	></ion-textarea>
+	<div class="textarea-wrap">
+		<ion-textarea
+			autoGrow
+			[placeholder]="placeholder()"
+			[(ngModel)]="content"
+			(keydown)="onEditorKeydown($event)"
+		></ion-textarea>
+	</div>
 </div>
 
 <div class="preview-pane" [hidden]="view() !== 'preview'">

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
@@ -44,20 +44,30 @@ ion-segment {
 		}
 	}
 
+	// Border lives on a wrapper we fully control (outside Ionic's shadow DOM)
+	// so an empty field is always visibly outlined — not only once focused.
+	.textarea-wrap {
+		flex-grow: 1;
+		display: flex;
+		margin: 4px 2px 0;
+		border: 1px solid var(--ion-color-step-300);
+		border-radius: 8px;
+		background: var(--bo-light);
+		overflow: hidden;
+
+		&:focus-within {
+			border-color: var(--ion-color-primary);
+			box-shadow: 0 0 0 1px var(--ion-color-primary);
+		}
+	}
+
 	ion-textarea {
 		flex-grow: 1;
 		--padding-start: 16px;
 		--padding-end: 16px;
 		--border-radius: 8px;
-		margin: 4px 2px 0;
 		--min-height: 220px;
 		--background: var(--bo-light);
-
-		// `fill="outline"` draws the border via these vars; make it clearly
-		// visible so an empty field is distinguishable from the white background.
-		--border-width: 1px;
-		--border-color: var(--ion-color-step-300);
-		--highlight-color-focused: var(--ion-color-primary);
 	}
 }
 

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
@@ -52,13 +52,12 @@ ion-segment {
 		margin: 4px 2px 0;
 		--min-height: 220px;
 		--background: var(--bo-light);
-		border: 1px solid var(--ion-color-step-200);
-		border-radius: 8px;
 
-		&.ion-focused,
-		&:focus-within {
-			border-color: var(--ion-color-primary);
-		}
+		// `fill="outline"` draws the border via these vars; make it clearly
+		// visible so an empty field is distinguishable from the white background.
+		--border-width: 1px;
+		--border-color: var(--ion-color-step-300);
+		--highlight-color-focused: var(--ion-color-primary);
 	}
 }
 

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
@@ -33,9 +33,9 @@ ion-segment {
 		display: flex;
 		align-items: center;
 		gap: 4px;
-		border: 1px solid var(--ion-color-step-200);
+		border: 1px solid var(--bo-line);
 		border-radius: 8px;
-		background: var(--ion-color-step-50);
+		background: var(--bo-light);
 		width: fit-content;
 
 		ion-button {
@@ -46,11 +46,13 @@ ion-segment {
 
 	// Border lives on a wrapper we fully control (outside Ionic's shadow DOM)
 	// so an empty field is always visibly outlined — not only once focused.
+	// Note: `--ion-color-step-*` is only defined in the dark theme, so using it
+	// here would make the whole `border` declaration invalid in light mode.
 	.textarea-wrap {
 		flex-grow: 1;
 		display: flex;
 		margin: 4px 2px 0;
-		border: 1px solid var(--ion-color-step-300);
+		border: 1px solid color-mix(in srgb, var(--bo-muted) 45%, transparent);
 		border-radius: 8px;
 		background: var(--bo-light);
 		overflow: hidden;
@@ -109,5 +111,5 @@ ion-segment {
 .toolbar-separator {
 	width: 1px;
 	height: 20px;
-	background: var(--ion-color-step-250);
+	background: var(--bo-line);
 }

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.scss
@@ -47,10 +47,18 @@ ion-segment {
 	ion-textarea {
 		flex-grow: 1;
 		--padding-start: 16px;
-		--border-radius: 4px;
-		margin: 0 2px;
+		--padding-end: 16px;
+		--border-radius: 8px;
+		margin: 4px 2px 0;
 		--min-height: 220px;
 		--background: var(--bo-light);
+		border: 1px solid var(--ion-color-step-200);
+		border-radius: 8px;
+
+		&.ion-focused,
+		&:focus-within {
+			border-color: var(--ion-color-primary);
+		}
 	}
 }
 

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.ts
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.ts
@@ -48,6 +48,10 @@ export class MarkdownEditorComponent {
 		void this.addList();
 	}
 
+	onAddHeading(level: 1 | 2 | 3) {
+		void this.addHeading(level);
+	}
+
 	async addBold() {
 		await this.wrapSelection("**");
 	}
@@ -63,6 +67,24 @@ export class MarkdownEditorComponent {
 			return selected
 				.split("\n")
 				.map((line) => (line.length ? (line.startsWith("- ") ? line : `- ${line}`) : "- "))
+				.join("\n");
+		});
+	}
+
+	async addHeading(level: 1 | 2 | 3) {
+		const prefix = `${"#".repeat(level)} `;
+
+		await this.transformSelection((selected) => {
+			if (!selected.length) return prefix;
+
+			return selected
+				.split("\n")
+				.map((line) => {
+					// Strip any existing heading marker so switching levels
+					// replaces rather than stacks the markers.
+					const stripped = line.replace(/^#{1,6}\s+/, "");
+					return `${prefix}${stripped}`;
+				})
 				.join("\n");
 		});
 	}


### PR DESCRIPTION
# Změny

 - Přidány tlačítka **H1 / H2 / H3** do lišty markdown editoru — vloží `#`, `##`, resp. `###` na začátek vybraných řádků (a nahradí případný existující nadpisový prefix místo jeho zdvojení).
 - Report z akce se při psaní od nuly předvyplní šablonou:
   ```md
   # Průběh akce

   # Problémy

   # Pochvaly pro členy
   ```
   Když už report existuje, otevře se jeho stávající obsah beze změny.
 - Textové pole editoru dostalo viditelný rámeček (a zvýraznění při zaměření), takže prázdné pole už není bílé na bílém a je jasně poznat, kam se píše.
 - Doplněna nápověda o zápisu nadpisů.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři libovolnou akci a její Report → **Napsat report**.
    - Zkontroluj, že se editor předvyplní šablonou `# Průběh akce`, `# Problémy`, `# Pochvaly pro členy`.
    - Zkontroluj, že prázdné textové pole má viditelný rámeček.
3. V editoru napiš/označ řádek a klikni na **H1**, **H2**, **H3** — ověř, že se přidá `#`, `##`, `###` a přepínání úrovní prefix nahrazuje, nezdvojuje.
4. U akce, která už report má, otevři úpravu (tužka) a ověř, že se zobrazí původní text, ne šablona.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nhd55bBQYKLZ3U43yz6hXF)_