### PR TITLE
ci: only create version tag when it does not already exist

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -39,5 +39,9 @@ jobs:
       - name: Create Version Tag
         if: inputs.version
         run: |
-          git tag --force ${{ inputs.version }}
-          git push origin --force ${{ inputs.version }}
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "Tag ${{ inputs.version }} already exists, leaving it untouched."
+            exit 0
+          fi
+          git tag ${{ inputs.version }}
+          git push origin ${{ inputs.version }}


### PR DESCRIPTION
# Změny

 - Tag `PROD`/`NEXT` (pohyblivé tagy) se dál vytvářejí s `--force`, ale verzový tag (např. `v1.2.3`) se nově vytvoří **jen pokud na originu ještě neexistuje**.
 - Řeší případ `semver=none`: krok pro zjištění verze vrátí aktuální verzi a předchozí `--force` přepsal existující verzový tag na nový commit. Nyní se existující verzový tag nechá být.

# Testovací scénář

1. Spusť workflow **Release to PROD** s `semver=none` na commitu, který už má verzový tag.
    - Zkontroluj, že se existující verzový tag **nepřesune** na nový commit a v logu je hláška „Tag … already exists, leaving it untouched.“
2. Spusť **Release to PROD** s `semver=patch`.
    - Zkontroluj, že se nový verzový tag vytvoří a pushne.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_016agisCjV4bGakNMuzDGzur)_