### PR TITLE
Zobrazit všechny členy oddílu v záložce Členové

### DIFF
--- a/frontend/src/app/features/members/components/group-members/group-members.component.ts
+++ b/frontend/src/app/features/members/components/group-members/group-members.component.ts
@@ -74,10 +74,6 @@ import { GroupsService } from "../../services/groups.service";
 	],
 })
 export class GroupMembersComponent implements OnInit {
-	// Upper bound for a single group's membership; used to fetch the whole group in one
-	// request instead of relying on the backend's paginated default (see loadMembers).
-	private static readonly MEMBERS_LIMIT = 1000;
-
 	members = signal<SDK.MemberResponseWithLinks[] | undefined>(undefined);
 
 	roles = MemberRoles;
@@ -226,13 +222,8 @@ export class GroupMembersComponent implements OnInit {
 			roles: this.selectedRoles() as SDK.ListMembersRolesEnum[],
 			membership: this.selectedMembership() as SDK.ListMembersMembershipEnum[],
 			groups: [this.groupId],
-			// This tab shows the whole group at once (no pagination UI). Without an explicit
-			// limit the backend caps the result at its default (25), which — combined with the
-			// default `role DESC` sort — silently drops members that sort last (e.g. children,
-			// role "dite") in any group larger than the cap. A group is inherently bounded
-			// (children + leaders of a single oddíl), so request far above any real size to
-			// load every member in a single request.
-			limit: GroupMembersComponent.MEMBERS_LIMIT,
+			// No pagination UI here — load the whole group in one request.
+			limit: 1000,
 			// default: active only; "show inactive" reveals inactive members too
 			active: this.showInactive() ? undefined : true,
 			// Fetch contacts in the same request instead of one call per member,

--- a/frontend/src/app/features/members/components/group-members/group-members.component.ts
+++ b/frontend/src/app/features/members/components/group-members/group-members.component.ts
@@ -74,6 +74,10 @@ import { GroupsService } from "../../services/groups.service";
 	],
 })
 export class GroupMembersComponent implements OnInit {
+	// Upper bound for a single group's membership; used to fetch the whole group in one
+	// request instead of relying on the backend's paginated default (see loadMembers).
+	private static readonly MEMBERS_LIMIT = 1000;
+
 	members = signal<SDK.MemberResponseWithLinks[] | undefined>(undefined);
 
 	roles = MemberRoles;
@@ -222,6 +226,13 @@ export class GroupMembersComponent implements OnInit {
 			roles: this.selectedRoles() as SDK.ListMembersRolesEnum[],
 			membership: this.selectedMembership() as SDK.ListMembersMembershipEnum[],
 			groups: [this.groupId],
+			// This tab shows the whole group at once (no pagination UI). Without an explicit
+			// limit the backend caps the result at its default (25), which — combined with the
+			// default `role DESC` sort — silently drops members that sort last (e.g. children,
+			// role "dite") in any group larger than the cap. A group is inherently bounded
+			// (children + leaders of a single oddíl), so request far above any real size to
+			// load every member in a single request.
+			limit: GroupMembersComponent.MEMBERS_LIMIT,
 			// default: active only; "show inactive" reveals inactive members too
 			active: this.showInactive() ? undefined : true,
 			// Fetch contacts in the same request instead of one call per member,


### PR DESCRIPTION
# Změny

 - Záložka **Členové** v detailu oddílu nyní načítá celý oddíl v jednom požadavku. Dříve neposílala žádný `limit`, takže backend vrátil jen výchozích 25 členů. Ve výchozím řazení podle role (`role DESC`) se PostgreSQL enum řadí `vedouci, instruktor, dite`, takže všechny **děti** (`dite`) končí na konci seznamu a v oddílech s více než ~25 členy se do limitu nevešly a chyběly (a při řazení dětí jako první naopak zmizeli vedoucí).
 - Přidán explicitní `limit` výrazně nad reálnou velikost jakéhokoli oddílu, takže se vždy zobrazí všichni členové (záložka nemá stránkování a je určena k zobrazení celého oddílu).

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že:
    - V databázi otevři oddíl s více než 25 členy a jdi na záložku **Členové**.
    - Zobrazí se **všichni** členové oddílu včetně všech dětí (role „dítě"), ne jen prvních 25.
    - Seřaď podle role sestupně i vzestupně — v obou případech jsou v seznamu jak vedoucí, tak všechny děti.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lwah9KRdhoJ6X4xnMeT6To)_