### PR TITLE
Při přidávání vedoucího akce nenabízet děti

### DIFF
--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
@@ -17,6 +17,9 @@ import { EventAgeHistogramComponent } from "../event-age-histogram/event-age-his
 import { EventAttendeesListComponent } from "../event-attendees-list/event-attendees-list.component";
 import { EventBirthdayListComponent } from "../event-birthday-list/event-birthday-list.component";
 
+// vedoucím akce může být jen instruktor nebo vedoucí, ne dítě
+const LEADER_ROLES: SDK.MemberRolesEnum[] = [SDK.MemberRolesEnum.Instruktor, SDK.MemberRolesEnum.Vedouci];
+
 @UntilDestroy()
 @Component({
 	selector: "bo-event-attendees",
@@ -126,6 +129,7 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 
 		await this.modalService.componentModal(MemberSelectorModalComponent, {
 			keepOpenAfterSelect: true,
+			roles: type === "leader" ? LEADER_ROLES : undefined,
 			onSelect: (member: SDK.MemberResponse) => void addSelectedMember(member),
 		});
 	}

--- a/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.ts
+++ b/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.ts
@@ -44,6 +44,8 @@ export class MemberSelectorModalComponent
 {
 	members = input<SDK.MemberResponse[]>([]);
 	keepOpenAfterSelect = false;
+	// omezení výběru na dané role, ostatní členy modal vůbec nenabídne
+	roles?: SDK.MemberRolesEnum[];
 	onSelect?: (member: SDK.MemberResponse) => void;
 
 	membersIndex: string[] = [];
@@ -64,11 +66,13 @@ export class MemberSelectorModalComponent
 		this.loadMembers();
 	}
 	private async loadMembers() {
+		const roles = this.roles;
+
 		const inputMembers = this.members();
 		if (inputMembers && inputMembers.length === 0) {
-			this._members = await this.api.MembersApi.listMembers({ limit: 1000 }).then((res) => res.data);
+			this._members = await this.api.MembersApi.listMembers({ limit: 1000, roles }).then((res) => res.data);
 		} else {
-			this._members = inputMembers || [];
+			this._members = (inputMembers || []).filter((member) => !roles || roles.includes(member.role));
 		}
 
 		this.sortMembers();


### PR DESCRIPTION
# Změny

 - Modal pro výběr člena (`bo-member-selector-modal`) umí nově omezit nabídku na zadané role – filtruje se přímo v dotazu na `/api/members` (`roles`), u předaného seznamu členů lokálně.
 - Tlačítko „Přidat vedoucí“ v záložce účastníků akce nabídne jen členy s rolí instruktor nebo vedoucí. Přidávání účastníků zůstává bez omezení.

Closes #284

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři libovolnou akci a přepni na záložku s účastníky.
3. Klikni na **Přidat vedoucí** – zkontroluj, že v seznamu (i po vyhledání jména) jsou pouze instruktoři a vedoucí, žádné děti.
4. Vyber vedoucího a zkontroluj, že se přidal do seznamu vedoucích.
5. Klikni na **Přidat účastníka** – zkontroluj, že se tady nabízejí všichni členové včetně dětí.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wfZfzJxoYAAy8MAW38i8u

---
_Generated by [Claude Code](https://claude.ai/code/session_013wfZfzJxoYAAy8MAW38i8u)_