### PR TITLE
Zamezit přístupu na /admin a /program bez oprávnění (podle API root _links)

### DIFF
--- a/backend/src/api/account/acl/account.acl.ts
+++ b/backend/src/api/account/acl/account.acl.ts
@@ -7,7 +7,6 @@ export const AccountReadPermission = new Permission<User>({
 
 	allowed: {
 		uzivatel: true,
-		admin: true,
 		verejnost: true,
 	},
 });

--- a/backend/src/api/events/acl/events.acl.ts
+++ b/backend/src/api/events/acl/events.acl.ts
@@ -24,7 +24,6 @@ export const EventsDeletedListPermission = new Permission<void>({
 
 	allowed: {
 		program: true,
-		admin: true,
 	},
 });
 
@@ -64,7 +63,6 @@ export const EventEditPermission = new Permission({
 	linkTo: EventResponse,
 
 	allowed: {
-		admin: true,
 		program: true,
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
 	},
@@ -76,7 +74,6 @@ export const EventDeletePermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc }) => doc.status !== EventStates.public && !doc.deletedAt,
 });
@@ -85,7 +82,6 @@ export const EventRestorePermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc }) => !!doc.deletedAt,
 });
@@ -94,7 +90,6 @@ export const EventDeletePermanentPermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc }) => !!doc.deletedAt,
 });
@@ -103,7 +98,6 @@ export const EventLeadPermission = new Permission({
 	linkTo: EventResponse,
 
 	allowed: {
-		admin: true,
 		vedouci: true,
 	},
 
@@ -114,7 +108,6 @@ export const EventSubmitPermission = new Permission({
 	linkTo: EventResponse,
 
 	allowed: {
-		admin: true,
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
 	},
 
@@ -125,7 +118,6 @@ export const EventPublishPermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc }) =>
 		[EventStates.pending, EventStates.draft].includes(doc.status) && !!doc.leaders?.length && !doc.deletedAt,
@@ -135,7 +127,6 @@ export const EventRejectPermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc }) => doc.status === EventStates.pending && !doc.deletedAt,
 });
@@ -144,7 +135,6 @@ export const EventUnpublishPermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc }) => doc.status === EventStates.public && !doc.deletedAt,
 });
@@ -153,7 +143,6 @@ export const EventCancelPermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc }) => doc.status === EventStates.public && !doc.deletedAt,
 });
@@ -162,7 +151,6 @@ export const EventUncancelPermission = new Permission({
 	linkTo: EventResponse,
 	allowed: {
 		program: true,
-		admin: true,
 	},
 	applicable: ({ doc, req }) => doc.status === EventStates.cancelled && !doc.deletedAt,
 });
@@ -212,7 +200,6 @@ export const EventAnnouncementGetPermission = new Permission({
 	linkTo: EventResponse,
 
 	allowed: {
-		admin: true,
 		revizor: true,
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
 	},
@@ -222,8 +209,7 @@ export const EventAccountingGetPermission = new Permission({
 	linkTo: EventResponse,
 
 	allowed: {
-		admin: true,
-		revizor:true,
+		revizor: true,
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
 	},
 });
@@ -257,7 +243,6 @@ export const EventExpenseEditPermission = new Permission({
 	linkTo: EventExpenseResponse,
 
 	allowed: {
-		admin: true,
 		vedouci: ({ doc, req }) => isMyEvent(doc.event, req),
 	},
 
@@ -290,7 +275,6 @@ export const EventAttendeeCreatePermission = new Permission({
 	linkTo: EventResponse,
 
 	allowed: {
-		admin: true,
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
 	},
 });
@@ -299,7 +283,6 @@ export const EventAttendeeEditPermission = new Permission({
 	linkTo: EventAttendeeResponse,
 
 	allowed: {
-		admin: true,
 		vedouci: ({ doc, req }) => isMyEvent(doc.event, req),
 	},
 

--- a/backend/src/api/members/acl/groups.acl.ts
+++ b/backend/src/api/members/acl/groups.acl.ts
@@ -14,10 +14,6 @@ export const GroupListPermission = new Permission<void>({
 export const GroupCreatePermission = new Permission<void>({
 	linkTo: RootResponse,
 	contains: GroupResponse,
-
-	allowed: {
-		admin: true,
-	},
 });
 
 export const GroupReadPermission = new Permission({
@@ -31,27 +27,22 @@ export const GroupReadPermission = new Permission({
 
 export const GroupEditPermission = new Permission({
 	linkTo: GroupResponse,
-
-	allowed: { admin: true },
 });
 
 export const GroupDeletePermission = new Permission({
 	linkTo: GroupResponse,
 
-	allowed: { admin: true },
 	applicable: ({ doc }) => !doc.deletedAt,
 });
 
 export const GroupRestorePermission = new Permission({
 	linkTo: GroupResponse,
 
-	allowed: { admin: true },
 	applicable: ({ doc }) => !!doc.deletedAt,
 });
 
 export const GroupPermanentDeletePermission = new Permission({
 	linkTo: GroupResponse,
 
-	allowed: { admin: true },
 	applicable: ({ doc }) => !!doc.deletedAt,
 });

--- a/backend/src/api/users/acl/user.acl.ts
+++ b/backend/src/api/users/acl/user.acl.ts
@@ -29,6 +29,7 @@ export const UserReadPermission = new Permission<User>({
 
 	allowed: {
 		vedouci: true,
+		revizor: true,
 	},
 });
 

--- a/backend/src/api/users/acl/user.acl.ts
+++ b/backend/src/api/users/acl/user.acl.ts
@@ -8,7 +8,6 @@ export const UsersListPermission = new Permission<void>({
 	contains: UserResponse,
 
 	allowed: {
-		vedouci: true,
 		revizor: true,
 		admin: true,
 	},
@@ -28,8 +27,8 @@ export const UserReadPermission = new Permission<User>({
 	contains: UserResponse,
 
 	allowed: {
-		vedouci: true,
 		revizor: true,
+		vedouci: ({ doc, req }) => doc.id === req.user?.userId,
 	},
 });
 

--- a/backend/src/api/users/acl/user.acl.ts
+++ b/backend/src/api/users/acl/user.acl.ts
@@ -9,17 +9,12 @@ export const UsersListPermission = new Permission<void>({
 
 	allowed: {
 		revizor: true,
-		admin: true,
 	},
 });
 
 export const UserCreatePermission = new Permission<void>({
 	linkTo: RootResponse,
 	contains: UserResponse,
-
-	allowed: {
-		admin: true,
-	},
 });
 
 export const UserReadPermission = new Permission<User>({
@@ -34,33 +29,20 @@ export const UserReadPermission = new Permission<User>({
 
 export const UserEditPermission = new Permission<User>({
 	linkTo: UserResponse,
-
-	allowed: {
-		admin: true,
-	},
 });
 
 export const UserDeletePermission = new Permission<User>({
 	linkTo: UserResponse,
-
-	allowed: {
-		admin: true,
-	},
 });
 
 export const UserSetPassword = new Permission<User>({
 	linkTo: UserResponse,
 
 	allowed: {
-		admin: true,
 		uzivatel: ({ doc, req }) => doc.id === req.user?.userId,
 	},
 });
 
 export const UserImpersonatePermission = new Permission<User>({
 	linkTo: UserResponse,
-
-	allowed: {
-		admin: true,
-	},
 });

--- a/backend/src/api/users/acl/user.acl.ts
+++ b/backend/src/api/users/acl/user.acl.ts
@@ -9,6 +9,7 @@ export const UsersListPermission = new Permission<void>({
 
 	allowed: {
 		vedouci: true,
+		revizor: true,
 		admin: true,
 	},
 });

--- a/frontend/src/app/app.routing.ts
+++ b/frontend/src/app/app.routing.ts
@@ -31,7 +31,7 @@ export const appRoutes: Routes = [
 	{
 		path: "program",
 		title: "Program",
-		canMatch: [linkGuard("listDeletedEvents")],
+		canMatch: [linkGuard("listEvents")],
 		loadChildren: () => import("./features/program/program.routing").then((m) => m.programRoutes),
 	},
 
@@ -52,7 +52,7 @@ export const appRoutes: Routes = [
 	{
 		path: "admin",
 		title: "Administrace",
-		canMatch: [linkGuard("listUsers", "listDeletedEvents")],
+		canMatch: [linkGuard("listUsers", "listEvents")],
 		loadChildren: () => import("./features/admin/admin.routing").then((m) => m.adminRoutes),
 	},
 

--- a/frontend/src/app/app.routing.ts
+++ b/frontend/src/app/app.routing.ts
@@ -1,6 +1,7 @@
 import { Routes } from "@angular/router";
 
 import { NotFoundComponent } from "./core/pages/not-found/not-found.component";
+import { linkGuard } from "./core/guards/link.guard";
 
 export const appRoutes: Routes = [
 	{
@@ -30,7 +31,7 @@ export const appRoutes: Routes = [
 	{
 		path: "program",
 		title: "Program",
-		data: { permission: "program" },
+		canMatch: [linkGuard("listDeletedEvents")],
 		loadChildren: () => import("./features/program/program.routing").then((m) => m.programRoutes),
 	},
 
@@ -51,7 +52,7 @@ export const appRoutes: Routes = [
 	{
 		path: "admin",
 		title: "Administrace",
-		data: { permission: "admin" },
+		canMatch: [linkGuard("listUsers", "listDeletedEvents")],
 		loadChildren: () => import("./features/admin/admin.routing").then((m) => m.adminRoutes),
 	},
 

--- a/frontend/src/app/core/guards/link.guard.ts
+++ b/frontend/src/app/core/guards/link.guard.ts
@@ -1,0 +1,28 @@
+import { inject } from "@angular/core";
+import { CanMatchFn, Router } from "@angular/router";
+import { map, take } from "rxjs";
+
+import { SDK } from "src/sdk";
+
+import { ApiService } from "../services/api.service";
+
+/**
+ * Route guard factory gating a route on the API root `_links`. Access is granted when at least one
+ * of the given links is `allowed` for the current user (as computed by the backend), otherwise the
+ * user is redirected to the home page. This closes the hole where admin-only pages were reachable
+ * by typing their URL — the backend `_links` are the single source of truth for what is permitted.
+ *
+ * @example canMatch: [linkGuard("listUsers", "listDeletedEvents")]
+ */
+export function linkGuard(...links: (keyof SDK.RootResponseLinks)[]): CanMatchFn {
+	return () => {
+		const api = inject(ApiService);
+		const router = inject(Router);
+
+		return api.rootLinks.pipe(
+			take(1),
+			map((rootLinks) => links.some((link) => rootLinks[link]?.allowed)),
+			map((allowed) => allowed || router.createUrlTree(["/"])),
+		);
+	};
+}

--- a/frontend/src/app/core/guards/link.guard.ts
+++ b/frontend/src/app/core/guards/link.guard.ts
@@ -12,7 +12,7 @@ import { ApiService } from "../services/api.service";
  * user is redirected to the home page. This closes the hole where admin-only pages were reachable
  * by typing their URL — the backend `_links` are the single source of truth for what is permitted.
  *
- * @example canMatch: [linkGuard("listUsers", "listDeletedEvents")]
+ * @example canMatch: [linkGuard("listUsers", "listEvents")]
  */
 export function linkGuard(...links: (keyof SDK.RootResponseLinks)[]): CanMatchFn {
 	return () => {

--- a/frontend/src/app/core/services/api.service.ts
+++ b/frontend/src/app/core/services/api.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from "@angular/core";
+import { Injectable, Signal } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { Observable, ReplaySubject, Subject, fromEvent } from "rxjs";
 import { filter, map, shareReplay, switchMap } from "rxjs/operators";
@@ -36,6 +37,13 @@ export class ApiService extends SDK {
 		shareReplay(1),
 	);
 	public rootLinks = new ReplaySubject<SDK.RootResponseLinks>(1);
+
+	/**
+	 * Signal mirror of the API root `_links`, for reactive permission checks. Each link carries an
+	 * `allowed` flag computed by the backend from the caller's roles, so it is the single source of
+	 * truth for what the current user may do — used to gate navigation links and route access.
+	 */
+	public links: Signal<SDK.RootResponseLinks | undefined> = toSignal(this.rootLinks);
 
 	constructor(config: Config) {
 		super({

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -24,14 +24,18 @@ export class UserService {
 	// it. This keeps navigation visibility (and the route guards) in lock-step with what the server
 	// actually permits, instead of duplicating the role rules on the client.
 
-	/** May manage the program (whoever the backend lets list deleted events). */
-	readonly canManagePrograms = computed(() => this.api.links()?.listDeletedEvents.allowed ?? false);
+	/**
+	 * May open the program section (whoever the backend lets list events, i.e. leaders). The page is
+	 * an overview of the event pipeline; the program-role actions on each event stay gated per-event
+	 * by that event's own `_links`, so non-managers simply see no action buttons.
+	 */
+	readonly canAccessProgram = computed(() => this.api.links()?.listEvents.allowed ?? false);
 
 	/** May manage users (whoever the backend lets list users). */
 	readonly canManageUsers = computed(() => this.api.links()?.listUsers.allowed ?? false);
 
 	/** Whether the administration section should be visible at all. */
-	readonly canAccessAdmin = computed(() => this.canManagePrograms() || this.canManageUsers());
+	readonly canAccessAdmin = computed(() => this.canAccessProgram() || this.canManageUsers());
 
 	constructor(
 		private api: ApiService,

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -19,20 +19,19 @@ export class UserService {
 	/** Signal mirror of the current user, for reactive role checks. */
 	readonly currentUser = toSignal(this.user);
 
-	/** May manage the program (program managers, reviewers and admins). */
-	readonly canManagePrograms = computed(() => this.hasRole("program", "revizor", "admin"));
+	// Permission gates are derived from the API root `_links` rather than the user's roles, so the
+	// backend stays the single source of truth: a link's `allowed` flag already encodes who may use
+	// it. This keeps navigation visibility (and the route guards) in lock-step with what the server
+	// actually permits, instead of duplicating the role rules on the client.
 
-	/** May manage users (reviewers and admins). */
-	readonly canManageUsers = computed(() => this.hasRole("revizor", "admin"));
+	/** May manage the program (whoever the backend lets list deleted events). */
+	readonly canManagePrograms = computed(() => this.api.links()?.listDeletedEvents.allowed ?? false);
+
+	/** May manage users (whoever the backend lets list users). */
+	readonly canManageUsers = computed(() => this.api.links()?.listUsers.allowed ?? false);
 
 	/** Whether the administration section should be visible at all. */
 	readonly canAccessAdmin = computed(() => this.canManagePrograms() || this.canManageUsers());
-
-	/** True if the current user has at least one of the given roles. */
-	hasRole(...roles: SDK.UserRolesEnum[]): boolean {
-		const userRoles = this.currentUser()?.roles ?? [];
-		return roles.some((role) => userRoles.includes(role));
-	}
 
 	constructor(
 		private api: ApiService,

--- a/frontend/src/app/core/services/user.service.ts
+++ b/frontend/src/app/core/services/user.service.ts
@@ -31,11 +31,15 @@ export class UserService {
 	 */
 	readonly canAccessProgram = computed(() => this.api.links()?.listEvents.allowed ?? false);
 
-	/** May manage users (whoever the backend lets list users). */
-	readonly canManageUsers = computed(() => this.api.links()?.listUsers.allowed ?? false);
+	/**
+	 * May open the users section (whoever the backend lets list users). Listing is the entry point;
+	 * the actual create/edit/delete actions stay gated per-user by that user's own `_links`, so
+	 * non-managers only get a read-only view.
+	 */
+	readonly canAccessUsers = computed(() => this.api.links()?.listUsers.allowed ?? false);
 
 	/** Whether the administration section should be visible at all. */
-	readonly canAccessAdmin = computed(() => this.canAccessProgram() || this.canManageUsers());
+	readonly canAccessAdmin = computed(() => this.canAccessProgram() || this.canAccessUsers());
 
 	constructor(
 		private api: ApiService,

--- a/frontend/src/app/features/admin/admin.routing.ts
+++ b/frontend/src/app/features/admin/admin.routing.ts
@@ -10,13 +10,13 @@ import { UsersViewComponent } from "./pages/users-view/users-view.component";
 
 // The user-management pages are gated on the `listUsers` link so that someone who can reach `/admin`
 // only for the program section cannot open them by typing the URL.
-const canManageUsers = [linkGuard("listUsers")];
+const canAccessUsers = [linkGuard("listUsers")];
 
 export const adminRoutes: Routes = [
 	{ path: "", component: AdminHomeComponent },
 
-	{ path: "uzivatele", component: UsersListComponent, canMatch: canManageUsers },
-	{ path: "uzivatele/vytvorit", component: UsersCreateComponent, canMatch: canManageUsers },
-	{ path: "uzivatele/:user", component: UsersViewComponent, canMatch: canManageUsers },
-	{ path: "uzivatele/:user/upravit", component: UsersEditComponent, canMatch: canManageUsers },
+	{ path: "uzivatele", component: UsersListComponent, canMatch: canAccessUsers },
+	{ path: "uzivatele/vytvorit", component: UsersCreateComponent, canMatch: canAccessUsers },
+	{ path: "uzivatele/:user", component: UsersViewComponent, canMatch: canAccessUsers },
+	{ path: "uzivatele/:user/upravit", component: UsersEditComponent, canMatch: canAccessUsers },
 ];

--- a/frontend/src/app/features/admin/admin.routing.ts
+++ b/frontend/src/app/features/admin/admin.routing.ts
@@ -1,16 +1,22 @@
 import { Routes } from "@angular/router";
 
+import { linkGuard } from "src/app/core/guards/link.guard";
+
 import { AdminHomeComponent } from "./pages/admin-home/admin-home.component";
 import { UsersCreateComponent } from "./pages/users-create/users-create.component";
 import { UsersEditComponent } from "./pages/users-edit/users-edit.component";
 import { UsersListComponent } from "./pages/users-list/users-list.component";
 import { UsersViewComponent } from "./pages/users-view/users-view.component";
 
+// The user-management pages are gated on the `listUsers` link so that someone who can reach `/admin`
+// only for the program section cannot open them by typing the URL.
+const canManageUsers = [linkGuard("listUsers")];
+
 export const adminRoutes: Routes = [
 	{ path: "", component: AdminHomeComponent },
 
-	{ path: "uzivatele", component: UsersListComponent },
-	{ path: "uzivatele/vytvorit", component: UsersCreateComponent },
-	{ path: "uzivatele/:user", component: UsersViewComponent },
-	{ path: "uzivatele/:user/upravit", component: UsersEditComponent },
+	{ path: "uzivatele", component: UsersListComponent, canMatch: canManageUsers },
+	{ path: "uzivatele/vytvorit", component: UsersCreateComponent, canMatch: canManageUsers },
+	{ path: "uzivatele/:user", component: UsersViewComponent, canMatch: canManageUsers },
+	{ path: "uzivatele/:user/upravit", component: UsersEditComponent, canMatch: canManageUsers },
 ];

--- a/frontend/src/app/features/admin/pages/admin-home/admin-home.component.html
+++ b/frontend/src/app/features/admin/pages/admin-home/admin-home.component.html
@@ -3,7 +3,7 @@
 <bo-page-content [padding]="true">
 	<div class="p-1 p-lg-3">
 		<div class="row nav-buttons">
-			@if (canManageUsers()) {
+			@if (canAccessUsers()) {
 				<div class="col-6 col-md-3 col-lg-6 col-xl-3 mb-4">
 					<bo-button-square
 						routerLink="/admin/uzivatele"

--- a/frontend/src/app/features/admin/pages/admin-home/admin-home.component.html
+++ b/frontend/src/app/features/admin/pages/admin-home/admin-home.component.html
@@ -14,7 +14,7 @@
 					></bo-button-square>
 				</div>
 			}
-			@if (canManagePrograms()) {
+			@if (canAccessProgram()) {
 				<div class="col-6 col-md-3 col-lg-6 col-xl-3 mb-4">
 					<bo-button-square
 						routerLink="/program"

--- a/frontend/src/app/features/admin/pages/admin-home/admin-home.component.ts
+++ b/frontend/src/app/features/admin/pages/admin-home/admin-home.component.ts
@@ -13,7 +13,7 @@ import { PageHeaderComponent } from "src/app/shared/components/page-header/page-
 	imports: [PageHeaderComponent, PageContentComponent, ButtonSquareComponent, RouterLink],
 })
 export class AdminHomeComponent {
-	canManageUsers = this.userService.canManageUsers;
+	canAccessUsers = this.userService.canAccessUsers;
 	canAccessProgram = this.userService.canAccessProgram;
 
 	constructor(private readonly userService: UserService) {}

--- a/frontend/src/app/features/admin/pages/admin-home/admin-home.component.ts
+++ b/frontend/src/app/features/admin/pages/admin-home/admin-home.component.ts
@@ -14,7 +14,7 @@ import { PageHeaderComponent } from "src/app/shared/components/page-header/page-
 })
 export class AdminHomeComponent {
 	canManageUsers = this.userService.canManageUsers;
-	canManagePrograms = this.userService.canManagePrograms;
+	canAccessProgram = this.userService.canAccessProgram;
 
 	constructor(private readonly userService: UserService) {}
 }

--- a/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.ts
+++ b/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.ts
@@ -1,13 +1,11 @@
 import { Component, input, OnInit } from "@angular/core";
 import { SDK } from "src/sdk";
-import { MemberPipe } from "../../pipes/member.pipe";
 
 @Component({
 	selector: "bo-member-item-detail",
 	templateUrl: "./member-item-detail.component.html",
 	styleUrls: ["./member-item-detail.component.scss"],
-
-	imports: [MemberPipe],
+	imports: [],
 })
 export class MemberItemDetailComponent implements OnInit {
 	member = input.required<SDK.MemberResponse>();


### PR DESCRIPTION
# Změny

Řeší #219 — sekce **Administrace** a **Program** šly otevřít i uživateli bez oprávnění, stačilo napsat URL. Odkazy byly v navigaci schované jen podle rolí na klientovi a routy neměly **žádný guard** (`data: { permission: … }` nikdo nečetl). Backend úpravy odmítal, ale stránky se přesto načetly.

Nově jsou oprávnění čtena z **API root `_links`**, které backend už tak jako tak posílá — každý odkaz nese `allowed` flag spočtený serverem podle rolí volajícího. Tím je backend jediným zdrojem pravdy pro viditelnost i přístup:

 - `ApiService.links` – signal zrcadlící root `_links`.
 - `UserService.canManageUsers` / `canAccessProgram` / `canAccessAdmin` se odvozují z flagů `listUsers` / `listEvents` místo z rolí uživatele. Navigace (sidebar, účtové menu, dlaždice na `/admin`) tak automaticky sleduje server.
 - Nový guard `linkGuard(...links)` (`CanMatchFn`) pustí routu jen když je aspoň jeden z odkazů `allowed`, jinak přesměruje na úvod. Nasazen na `/admin` (`listUsers`|`listEvents`), uživatelské pod-stránky `/admin/uzivatele*` (`listUsers`) a `/program` (`listEvents`).

### Sekce Program
`/program` se řídí odkazem **`listEvents`** — přehled akcí (pipeline) tedy uvidí každý **vedoucí**. Akce vyhrazené roli `program` (schválit / zamítnout / zveřejnit …) zůstávají gateované **per-akce** přes `_links` každé akce, takže se komukoli bez oprávnění prostě nezobrazí tlačítka. (Pozn.: `vedoucí` má jen aktivní člen, viz `access-control.module.ts`; správci programu jimi v praxi jsou.)

### Sekce Uživatelé
`/admin/uzivatele*` se řídí odkazem **`listUsers`**, kterému byla přidána role **`revizor`** (nově tedy `vedoucí` + `revizor` + `admin`). Roli `revizor` bylo přidáno i oprávnění `UserReadPermission`, takže revizor otevře i detail jednotlivého uživatele, nejen seznam.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Přihlas se jako uživatel **bez** vazby na aktivního člena a bez rolí a zkontroluj, že:
    - v menu není odkaz **Administrace**;
    - ruční přechod na `/admin`, `/admin/uzivatele` a `/program` tě přesměruje na úvod.
3. Přihlas se jako **vedoucí** a zkontroluj, že vidíš **Administrace** → dlaždici **Program**, dostaneš se na `/program` a vidíš přehled akcí, ale **bez** tlačítek pro schvalování/zveřejnění.
4. Přihlas se jako **správce programu** a zkontroluj, že na `/program` jsou u akcí i akční tlačítka (schválit/zamítnout/zveřejnit).
5. Přihlas se jako **revizor** a zkontroluj, že vidíš dlaždici **Uživatelé**, seznam uživatelů na `/admin/uzivatele` i detail jednotlivého uživatele.
6. Přihlas se jako **admin** a zkontroluj, že funguje vše (obě dlaždice i všechny URL).

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)