### PR TITLE
Štítky u fotek v galerii – úprava, zobrazení a filtrování (#292)

### DIFF
--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.html
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.html
@@ -51,13 +51,29 @@
 
 @if (view() === 'gallery' && allTags().length) {
 	<!-- filter the gallery by tag, mirroring the public site's tag buttons -->
-	<div class="tag-filter">
-		<ion-chip [outline]="!!effectiveTag()" color="primary" (click)="selectTag(null)">Všechny fotky</ion-chip>
+	<div class="tag-filter" role="group" aria-label="Filtrovat podle štítku">
+		<ion-chip
+			role="button"
+			tabindex="0"
+			[attr.aria-pressed]="!effectiveTag()"
+			[outline]="!!effectiveTag()"
+			color="primary"
+			(click)="selectTag(null)"
+			(keydown.enter)="selectTag(null)"
+			(keydown.space)="$event.preventDefault(); selectTag(null)"
+		>
+			Všechny fotky
+		</ion-chip>
 		@for (tag of allTags(); track tag) {
 			<ion-chip
+				role="button"
+				tabindex="0"
+				[attr.aria-pressed]="effectiveTag() === tag"
 				[outline]="effectiveTag() !== tag"
 				color="primary"
-				(click)="selectTag(effectiveTag() === tag ? null : tag)"
+				(click)="toggleTag(tag)"
+				(keydown.enter)="toggleTag(tag)"
+				(keydown.space)="$event.preventDefault(); toggleTag(tag)"
 			>
 				#{{ tag }}
 			</ion-chip>

--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.html
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.html
@@ -49,11 +49,27 @@
 	</div>
 }
 
+@if (view() === 'gallery' && allTags().length) {
+	<!-- filter the gallery by tag, mirroring the public site's tag buttons -->
+	<div class="tag-filter">
+		<ion-chip [outline]="!!effectiveTag()" color="primary" (click)="selectTag(null)">Všechny fotky</ion-chip>
+		@for (tag of allTags(); track tag) {
+			<ion-chip
+				[outline]="effectiveTag() !== tag"
+				color="primary"
+				(click)="selectTag(effectiveTag() === tag ? null : tag)"
+			>
+				#{{ tag }}
+			</ion-chip>
+		}
+	</div>
+}
+
 <div class="gallery">
 	@if (view() === 'gallery') {
 		@if (photos()?.length) {
 			<bo-photo-gallery
-				[photos]="photos()!"
+				[photos]="displayPhotos()!"
 				[maxHeight]="320"
 				[clickable]="true"
 				(click)="photoClick.emit($event)"

--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.scss
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.scss
@@ -41,6 +41,11 @@
 	ion-chip {
 		cursor: pointer;
 	}
+
+	ion-chip:focus-visible {
+		outline: 2px solid var(--ion-color-primary);
+		outline-offset: 2px;
+	}
 }
 
 // without a label the buttons are icons only, so drop the padding the label took

--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.scss
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.scss
@@ -31,6 +31,18 @@
 	flex-wrap: wrap;
 }
 
+.tag-filter {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 2px;
+	margin: 0.5rem 0;
+
+	ion-chip {
+		cursor: pointer;
+	}
+}
+
 // without a label the buttons are icons only, so drop the padding the label took
 @media (max-width: 991.98px) {
 	.gallery-header .actions ion-button {

--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.ts
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.ts
@@ -58,6 +58,11 @@ export class AlbumGalleryComponent {
 		this.activeTag.set(tag);
 	}
 
+	// clicking the active tag again clears the filter
+	toggleTag(tag: string) {
+		this.activeTag.set(this.effectiveTag() === tag ? null : tag);
+	}
+
 	upload = output<void>();
 	viewChange = output<"gallery" | "manage">();
 	sort = output<void>();

--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.ts
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.ts
@@ -1,5 +1,5 @@
-import { Component, input, output } from "@angular/core";
-import { IonButton, IonIcon } from "@ionic/angular/standalone";
+import { Component, computed, input, output, signal } from "@angular/core";
+import { IonButton, IonChip, IonIcon } from "@ionic/angular/standalone";
 import { addIcons } from "ionicons";
 import {
 	closeOutline,
@@ -19,13 +19,44 @@ import { PhotoListComponent } from "../photo-list/photo-list.component";
 	templateUrl: "./album-gallery.component.html",
 	styleUrls: ["./album-gallery.component.scss"],
 
-	imports: [IonButton, IonIcon, PhotoGalleryComponent, PhotoListComponent],
+	imports: [IonButton, IonChip, IonIcon, PhotoGalleryComponent, PhotoListComponent],
 })
 export class AlbumGalleryComponent {
 	photos = input<SDK.PhotoResponseWithLinks[] | undefined>(undefined);
 	view = input<"gallery" | "manage">("gallery");
 	selecting = input<boolean>(false);
 	selectedPhotos = input<SDK.PhotoResponseWithLinks[]>([]);
+
+	// currently selected tag filter (null = show all photos)
+	activeTag = signal<string | null>(null);
+
+	// every distinct tag across the album's photos, in first-seen order — the filter chips
+	allTags = computed(() => {
+		const seen = new Set<string>();
+		for (const photo of this.photos() ?? []) {
+			for (const tag of photo.tags ?? []) seen.add(tag);
+		}
+		return [...seen];
+	});
+
+	// ignore a stale selection (e.g. after switching to an album without that tag)
+	effectiveTag = computed(() => {
+		const tag = this.activeTag();
+		return tag && this.allTags().includes(tag) ? tag : null;
+	});
+
+	// the photos actually shown: filtered by the active tag, but only while browsing —
+	// managing (sort/delete/reorder) always operates on the full set
+	displayPhotos = computed(() => {
+		const photos = this.photos();
+		const tag = this.effectiveTag();
+		if (!photos || this.view() !== "gallery" || !tag) return photos;
+		return photos.filter((photo) => photo.tags?.includes(tag));
+	});
+
+	selectTag(tag: string | null) {
+		this.activeTag.set(tag);
+	}
 
 	upload = output<void>();
 	viewChange = output<"gallery" | "manage">();

--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.ts
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.ts
@@ -27,6 +27,18 @@ export class AlbumGalleryComponent {
 	selecting = input<boolean>(false);
 	selectedPhotos = input<SDK.PhotoResponseWithLinks[]>([]);
 
+	upload = output<void>();
+	viewChange = output<"gallery" | "manage">();
+	sort = output<void>();
+	selectingStart = output<void>();
+	selectingCancel = output<void>();
+	deleteSelected = output<void>();
+	selectedPhotosChange = output<SDK.PhotoResponseWithLinks[]>();
+	reorder = output<SDK.PhotoResponseWithLinks[]>();
+	photoClick = output<SDK.PhotoResponseWithLinks>();
+	listClick = output<CustomEvent<SDK.PhotoResponseWithLinks | undefined>>();
+	longPress = output<SDK.PhotoResponseWithLinks>();
+
 	// currently selected tag filter (null = show all photos)
 	activeTag = signal<string | null>(null);
 
@@ -62,18 +74,6 @@ export class AlbumGalleryComponent {
 	toggleTag(tag: string) {
 		this.activeTag.set(this.effectiveTag() === tag ? null : tag);
 	}
-
-	upload = output<void>();
-	viewChange = output<"gallery" | "manage">();
-	sort = output<void>();
-	selectingStart = output<void>();
-	selectingCancel = output<void>();
-	deleteSelected = output<void>();
-	selectedPhotosChange = output<SDK.PhotoResponseWithLinks[]>();
-	reorder = output<SDK.PhotoResponseWithLinks[]>();
-	photoClick = output<SDK.PhotoResponseWithLinks>();
-	listClick = output<CustomEvent<SDK.PhotoResponseWithLinks | undefined>>();
-	longPress = output<SDK.PhotoResponseWithLinks>();
 
 	constructor() {
 		addIcons({

--- a/frontend/src/app/features/albums/components/photo-list/photo-list.component.html
+++ b/frontend/src/app/features/albums/components/photo-list/photo-list.component.html
@@ -36,6 +36,13 @@
 								</span>
 							}
 						</p>
+						@if (photo.tags?.length) {
+							<div class="tags">
+								@for (tag of photo.tags; track tag) {
+									<ion-chip class="tag" color="warning">#{{ tag }}</ion-chip>
+								}
+							</div>
+						}
 					</ion-label>
 
 					<ion-reorder slot="end"></ion-reorder>

--- a/frontend/src/app/features/albums/components/photo-list/photo-list.component.scss
+++ b/frontend/src/app/features/albums/components/photo-list/photo-list.component.scss
@@ -128,6 +128,8 @@
 		height: 22px;
 		margin: 0;
 		font-size: 0.75rem;
+		// these chips are display-only, so don't imply they're clickable
+		cursor: default;
 	}
 }
 

--- a/frontend/src/app/features/albums/components/photo-list/photo-list.component.scss
+++ b/frontend/src/app/features/albums/components/photo-list/photo-list.component.scss
@@ -118,6 +118,19 @@
 	text-overflow: ellipsis;
 }
 
+.tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 2px;
+	margin-top: 4px;
+
+	ion-chip.tag {
+		height: 22px;
+		margin: 0;
+		font-size: 0.75rem;
+	}
+}
+
 @keyframes inputShow {
 	0% {
 		opacity: 0;

--- a/frontend/src/app/features/albums/components/photo-list/photo-list.component.ts
+++ b/frontend/src/app/features/albums/components/photo-list/photo-list.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from "@angular/forms";
 import {
 	IonAvatar,
 	IonCheckbox,
+	IonChip,
 	IonItem,
 	IonLabel,
 	IonReorder,
@@ -27,6 +28,7 @@ import { SDK } from "src/sdk";
 		IonReorderGroup,
 		IonItem,
 		IonCheckbox,
+		IonChip,
 		IonAvatar,
 		IonLabel,
 		IonReorder,

--- a/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.html
+++ b/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.html
@@ -2,18 +2,33 @@
 	@for (tag of availableTags(); track tag) {
 		<ion-chip
 			class="tag"
+			role="button"
+			[attr.tabindex]="disabled() ? -1 : 0"
+			[attr.aria-pressed]="hasTag(tag)"
 			[class.active]="hasTag(tag)"
 			[outline]="!hasTag(tag)"
 			color="warning"
 			[disabled]="disabled()"
 			(click)="toggleTag(tag)"
+			(keydown.enter)="toggleTag(tag)"
+			(keydown.space)="$event.preventDefault(); toggleTag(tag)"
 		>
 			#{{ tag }}
 		</ion-chip>
 	}
 
 	@if (!disabled()) {
-		<ion-chip class="tag add" outline color="light" (click)="addTag()">
+		<ion-chip
+			class="tag add"
+			role="button"
+			tabindex="0"
+			aria-label="Přidat štítek"
+			outline
+			color="light"
+			(click)="addTag()"
+			(keydown.enter)="addTag()"
+			(keydown.space)="$event.preventDefault(); addTag()"
+		>
 			<ion-icon name="add-outline"></ion-icon>
 			Štítek
 		</ion-chip>

--- a/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.html
+++ b/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.html
@@ -1,6 +1,21 @@
-@for (tag of tags(); track tag) {
-	<span class="tag badge badge-warning" [class.active]="hasTag(tag)" (click)="toggleTag(tag)"
-		>#{{ tag }}</span
-	>
-}
-<span class="tag badge badge-warning" (click)="newTag()">+</span>
+<div class="tags">
+	@for (tag of availableTags(); track tag) {
+		<ion-chip
+			class="tag"
+			[class.active]="hasTag(tag)"
+			[outline]="!hasTag(tag)"
+			color="warning"
+			[disabled]="disabled()"
+			(click)="toggleTag(tag)"
+		>
+			#{{ tag }}
+		</ion-chip>
+	}
+
+	@if (!disabled()) {
+		<ion-chip class="tag add" outline color="light" (click)="addTag()">
+			<ion-icon name="add-outline"></ion-icon>
+			Štítek
+		</ion-chip>
+	}
+</div>

--- a/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.scss
+++ b/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.scss
@@ -1,11 +1,26 @@
-.tag {
+.tags {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 2px;
+}
+
+ion-chip.tag {
+	margin: 2px;
+	font-size: 0.85rem;
 	cursor: pointer;
-	vertical-align: middle;
-	margin: 0 5px 0 0;
+	transition: opacity 0.15s ease;
+
+	// an available-but-not-applied tag is dimmed, so the photo's own tags stand out
+	&:not(.active):not(.add) {
+		opacity: 0.55;
+	}
+	&:not(.active):not(.add):hover {
+		opacity: 0.85;
+	}
 }
-.tag:not(.active) {
-	opacity: 0.3;
-}
-.tag:not(.active):hover {
-	opacity: 0.8;
+
+ion-chip.tag.add ion-icon {
+	margin-right: 2px;
+	font-size: 1rem;
 }

--- a/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.scss
+++ b/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.scss
@@ -11,12 +11,13 @@ ion-chip.tag {
 	cursor: pointer;
 	transition: opacity 0.15s ease;
 
-	// an available-but-not-applied tag is dimmed, so the photo's own tags stand out
+	// applied vs available is carried mainly by filled-vs-outline; a light dim is only a
+	// secondary cue, kept high enough to stay readable on the modal's black background
 	&:not(.active):not(.add) {
-		opacity: 0.55;
+		opacity: 0.8;
 	}
 	&:not(.active):not(.add):hover {
-		opacity: 0.85;
+		opacity: 1;
 	}
 }
 

--- a/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.scss
+++ b/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.scss
@@ -25,3 +25,9 @@ ion-chip.tag.add ion-icon {
 	margin-right: 2px;
 	font-size: 1rem;
 }
+
+// a light focus ring reads on the modal's black background
+ion-chip.tag:focus-visible {
+	outline: 2px solid #fff;
+	outline-offset: 2px;
+}

--- a/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.ts
+++ b/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.ts
@@ -18,8 +18,9 @@ import { addOutline } from "ionicons/icons";
 	imports: [IonChip, IonIcon],
 })
 export class PhotoTagsEditorComponent {
-	// tags currently on the photo
-	tags = input<string[]>([]);
+	// tags currently on the photo (null/undefined treated as empty; nullable so callers can
+	// bind the raw value without allocating a fresh [] on every change-detection pass)
+	tags = input<string[] | null>(null);
 	// every tag used anywhere in the album, offered as ready-made toggles
 	albumTags = input<string[]>([]);
 	disabled = input<boolean>(false);
@@ -33,7 +34,7 @@ export class PhotoTagsEditorComponent {
 	availableTags = computed(() => {
 		const seen = new Set<string>();
 		const result: string[] = [];
-		for (const tag of [...this.albumTags(), ...this.tags()]) {
+		for (const tag of [...this.albumTags(), ...(this.tags() ?? [])]) {
 			if (seen.has(tag)) continue;
 			seen.add(tag);
 			result.push(tag);
@@ -46,13 +47,13 @@ export class PhotoTagsEditorComponent {
 	}
 
 	hasTag(tag: string) {
-		return this.tags().includes(tag);
+		return (this.tags() ?? []).includes(tag);
 	}
 
 	toggleTag(tag: string) {
 		if (this.disabled()) return;
 
-		const tags = this.tags();
+		const tags = this.tags() ?? [];
 		const next = tags.includes(tag) ? tags.filter((t) => t !== tag) : [...tags, tag];
 		this.tagsChange.emit(next);
 	}
@@ -85,8 +86,9 @@ export class PhotoTagsEditorComponent {
 
 		// a tag already on the photo is a no-op; one that only exists elsewhere in the
 		// album (or is brand new) gets added
-		if (this.tags().includes(tag)) return;
+		const tags = this.tags() ?? [];
+		if (tags.includes(tag)) return;
 
-		this.tagsChange.emit([...this.tags(), tag]);
+		this.tagsChange.emit([...tags, tag]);
 	}
 }

--- a/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.ts
+++ b/frontend/src/app/features/albums/components/photo-tags-editor/photo-tags-editor.component.ts
@@ -1,83 +1,92 @@
-import { Component, forwardRef, input, signal } from "@angular/core";
-import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from "@angular/forms";
+import { Component, computed, inject, input, output } from "@angular/core";
+import { AlertController, IonChip, IonIcon } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import { addOutline } from "ionicons/icons";
 
+/**
+ * Presentational editor for a single photo's tags. It offers the album's existing tag
+ * vocabulary (`albumTags`) as toggleable chips — a chip is highlighted when the photo
+ * carries that tag — plus a "+" chip that prompts for a brand-new tag. Every change is
+ * emitted through `tagsChange`; the component keeps no state of its own, so the parent
+ * owns persistence (see PhotosEditComponent.saveTags).
+ */
 @Component({
-	selector: "photo-tags-editor",
+	selector: "bo-photo-tags-editor",
 	templateUrl: "./photo-tags-editor.component.html",
 	styleUrls: ["./photo-tags-editor.component.scss"],
-	
-	imports: [FormsModule],
-	providers: [
-		{
-			provide: NG_VALUE_ACCESSOR,
-			multi: true,
-			useExisting: forwardRef(() => PhotoTagsEditorComponent),
-		},
-	],
+
+	imports: [IonChip, IonIcon],
 })
-export class PhotoTagsEditorComponent implements ControlValueAccessor {
+export class PhotoTagsEditorComponent {
+	// tags currently on the photo
 	tags = input<string[]>([]);
-	selectedTags = signal<string[]>([]);
+	// every tag used anywhere in the album, offered as ready-made toggles
+	albumTags = input<string[]>([]);
+	disabled = input<boolean>(false);
 
-	disabled: boolean = false;
+	tagsChange = output<string[]>();
 
-	onChange: any = () => {};
-	onTouched: any = () => {};
+	private alertController = inject(AlertController);
 
-	writeValue(tags: any): void {
-		this.selectedTags.set(tags || []);
-	}
-	registerOnChange(fn: any): void {
-		this.onChange = fn;
-	}
-	registerOnTouched(fn: any): void {
-		this.onTouched = fn;
-	}
-	setDisabledState(isDisabled: boolean): void {
-		this.disabled = isDisabled;
-	}
+	// the album vocabulary plus any tag already on this photo, de-duplicated and
+	// kept in a stable order so chips don't jump around as tags are toggled
+	availableTags = computed(() => {
+		const seen = new Set<string>();
+		const result: string[] = [];
+		for (const tag of [...this.albumTags(), ...this.tags()]) {
+			if (seen.has(tag)) continue;
+			seen.add(tag);
+			result.push(tag);
+		}
+		return result;
+	});
 
-	constructor() {}
+	constructor() {
+		addIcons({ addOutline });
+	}
 
 	hasTag(tag: string) {
-		return this.selectedTags().indexOf(tag) !== -1;
+		return this.tags().includes(tag);
 	}
 
 	toggleTag(tag: string) {
-		if (this.disabled) return;
+		if (this.disabled()) return;
 
-		const selected = [...this.selectedTags()];
-		let i = selected.indexOf(tag);
-		if (i === -1) {
-			selected.push(tag);
-		} else {
-			selected.splice(i, 1);
-		}
-
-		this.selectedTags.set(selected);
-		this.onChange(selected);
+		const tags = this.tags();
+		const next = tags.includes(tag) ? tags.filter((t) => t !== tag) : [...tags, tag];
+		this.tagsChange.emit(next);
 	}
 
-	newTag() {
-		if (this.disabled) return;
+	async addTag() {
+		if (this.disabled()) return;
 
-		let tag = window.prompt("Zadejte název nového tagu:");
+		const alert = await this.alertController.create({
+			header: "Nový štítek",
+			inputs: [{ name: "tag", type: "text", placeholder: "Název štítku" }],
+			buttons: [
+				{ text: "Zrušit", role: "cancel" },
+				{
+					text: "Přidat",
+					handler: (value: { tag: string }) => {
+						this.commitNewTag(value.tag);
+					},
+				},
+			],
+		});
+
+		await alert.present();
+	}
+
+	private commitNewTag(raw: string | undefined | null) {
+		// normalize: trim, drop a leading "#", collapse inner whitespace
+		let tag = (raw ?? "").trim().replace(/\s+/g, " ");
+		if (tag.startsWith("#")) tag = tag.slice(1).trim();
 		if (!tag) return;
 
-		if (tag.charAt(0) === "#") tag = tag.substring(1);
+		// a tag already on the photo is a no-op; one that only exists elsewhere in the
+		// album (or is brand new) gets added
+		if (this.tags().includes(tag)) return;
 
-		const tags = [...this.tags()];
-		if (tags.indexOf(tag) === -1) {
-			tags.push(tag);
-			// Note: tags is an input, so we can't directly modify it
-			// This would need to be handled by the parent component
-		}
-
-		const selected = [...this.selectedTags()];
-		if (selected.indexOf(tag) === -1) {
-			selected.push(tag);
-			this.selectedTags.set(selected);
-			this.onChange(selected);
-		}
+		this.tagsChange.emit([...this.tags(), tag]);
 	}
 }

--- a/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.html
+++ b/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.html
@@ -95,6 +95,13 @@
 
 	@if (photo()) {
 		<ion-toolbar class="bottom-toolbar" [class.controls-hidden]="!controlsVisible()">
+			<div class="tags-bar">
+				<bo-photo-tags-editor
+					[tags]="photo()!.tags || []"
+					[albumTags]="albumTags()"
+					(tagsChange)="saveTags($event)"
+				></bo-photo-tags-editor>
+			</div>
 			@if (!editingCaption()) {
 				<ion-item lines="none">
 					<ion-label [class.nocaption]="!photo()!.caption" (dblclick)="editCaption()">

--- a/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.html
+++ b/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.html
@@ -97,7 +97,7 @@
 		<ion-toolbar class="bottom-toolbar" [class.controls-hidden]="!controlsVisible()">
 			<div class="tags-bar">
 				<bo-photo-tags-editor
-					[tags]="photo()!.tags || []"
+					[tags]="photo()!.tags ?? null"
 					[albumTags]="albumTags()"
 					(tagsChange)="saveTags($event)"
 				></bo-photo-tags-editor>

--- a/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.scss
+++ b/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.scss
@@ -73,7 +73,7 @@ ion-toolbar {
 // scroll if the album has a lot of tags, so they never crowd out the image
 .tags-bar {
 	padding: 4px 12px 0;
-	max-height: 33vh;
+	max-height: 25vh;
 	overflow-y: auto;
 }
 

--- a/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.scss
+++ b/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.scss
@@ -69,6 +69,14 @@ ion-toolbar {
 	font-style: italic;
 }
 
+// tag chips sit just above the caption row; they wrap onto multiple lines and
+// scroll if the album has a lot of tags, so they never crowd out the image
+.tags-bar {
+	padding: 4px 12px 0;
+	max-height: 33vh;
+	overflow-y: auto;
+}
+
 .image-viewer {
 	position: absolute;
 	inset: 0;

--- a/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.ts
+++ b/frontend/src/app/features/albums/components/photos-edit/photos-edit.component.ts
@@ -32,6 +32,7 @@ import { ToastService } from "src/app/core/services/toast.service";
 import { TooltipDirective } from "src/app/shared/directives/tooltip.directive";
 import { PhotoImageUrlPipe } from "src/app/shared/pipes/photo-image-url.pipe";
 import { SDK } from "src/sdk";
+import { PhotoTagsEditorComponent } from "../photo-tags-editor/photo-tags-editor.component";
 
 @Component({
 	selector: "bo-photos-edit",
@@ -53,6 +54,7 @@ import { SDK } from "src/sdk";
 		IonIcon,
 		PhotoImageUrlPipe,
 		TooltipDirective,
+		PhotoTagsEditorComponent,
 	],
 })
 export class PhotosEditComponent implements OnInit {
@@ -60,6 +62,10 @@ export class PhotosEditComponent implements OnInit {
 	// Set via Ionic modal componentProps (Object.assign), so it must be a plain property, not a signal input
 	@Input() photos!: SDK.PhotoResponseWithLinks[];
 	@Input() startPhoto?: SDK.PhotoResponseWithLinks;
+
+	// every tag used anywhere in the album, offered as ready-made toggles in the editor;
+	// grows as new tags are created so they become reusable on the other photos too
+	albumTags = signal<string[]>([]);
 
 	// true when the current photo's image failed to load, so we show a message instead
 	imageError = signal(false);
@@ -92,12 +98,23 @@ export class PhotosEditComponent implements OnInit {
 	}
 
 	ngOnInit(): void {
+		this.rebuildAlbumTags();
+
 		// the photo to start on comes in as a prop, openPhoto then puts it in the URL —
 		// the modal owns the ?photo= param for as long as it is open (see openPhoto)
 		let index = this.photos.findIndex((item) => item.id === this.startPhoto?.id);
 		if (index === -1) index = 0;
 
 		this.openPhoto(index);
+	}
+
+	// collect the distinct tags across all photos in the album, in first-seen order
+	private rebuildAlbumTags() {
+		const seen = new Set<string>();
+		for (const photo of this.photos) {
+			for (const tag of photo.tags ?? []) seen.add(tag);
+		}
+		this.albumTags.set([...seen]);
 	}
 
 	@HostListener("document:keyup", ["$event"])
@@ -183,22 +200,54 @@ export class PhotosEditComponent implements OnInit {
 	}
 
 	async saveCaption(value: string | number | null | undefined) {
-		const photo = this.photo();
-		if (!photo) return;
+		const current = this.photo();
+		if (!current) return;
 
 		const caption = value == null || value === "" ? null : String(value);
 
 		try {
-			await this.api.PhotoGalleryApi.updatePhoto(photo.id, { caption });
+			await this.api.PhotoGalleryApi.updatePhoto(current.id, { caption });
 		} catch (e) {
 			this.toastService.toast("Nepodařilo se uložit popisek.", { color: "warning" });
 			return; // keep editing so the user can retry
 		}
 
-		// mutate the shared object in place so the parent's photo list shows the new caption too
+		// mutate the real array element (not the detached copy the signal may hold after a
+		// previous edit) so the parent's photo list — and repeated edits — stay in sync; only
+		// touch the view if this photo is still the one on screen (the user may have swiped away)
+		const photo = this.photos.find((item) => item.id === current.id) ?? current;
 		photo.caption = caption;
-		this.photo.set({ ...photo });
+		if (this.photo()?.id === photo.id) this.photo.set({ ...photo });
 		this.editingCaption.set(false);
+	}
+
+	async saveTags(tags: string[]) {
+		const current = this.photo();
+		if (!current) return;
+
+		// resolve the real array element so the parent gallery/list see the change too
+		const photo = this.photos.find((item) => item.id === current.id) ?? current;
+		const previous = photo.tags ?? null;
+		const next = tags.length ? tags : null;
+
+		// Apply optimistically and synchronously: the editor is fully controlled off the photo's
+		// tags, so a quick second toggle must derive its set from this pending value rather than
+		// the not-yet-persisted previous one (otherwise concurrent PATCHes would drop a tag). The
+		// chip also reacts instantly. Reflect it in the view only while this photo is on screen.
+		const showing = () => this.photo()?.id === photo.id;
+		photo.tags = next;
+		if (showing()) this.photo.set({ ...photo });
+		this.rebuildAlbumTags();
+
+		try {
+			await this.api.PhotoGalleryApi.updatePhoto(photo.id, { tags: next });
+		} catch (e) {
+			this.toastService.toast("Nepodařilo se uložit štítky.", { color: "warning" });
+			// roll the optimistic change back, again only touching the view if still shown
+			photo.tags = previous;
+			if (showing()) this.photo.set({ ...photo });
+			this.rebuildAlbumTags();
+		}
 	}
 
 	async close() {

--- a/frontend/src/app/features/albums/pages/albums-view-info/albums-view-info.component.ts
+++ b/frontend/src/app/features/albums/pages/albums-view-info/albums-view-info.component.ts
@@ -153,6 +153,10 @@ export class AlbumsViewInfoComponent implements OnInit, ViewWillLeave {
 			const photos = this.photos();
 			if (photos?.length !== originalCount && album) {
 				this.loadAlbum(album.id); // album must be present when closing modal
+			} else if (photos) {
+				// tag/caption edits in the modal mutate photo objects in place; refresh the
+				// signal reference so the gallery's derived tag filter reflects them
+				this.photos.set([...photos]);
 			}
 		});
 	}


### PR DESCRIPTION
# Změny

 - Znovu zavádí rozhraní pro **štítky (tagy) u fotek** v interní galerii. Fotky nesou pole `tags` už roky (z importu ze starého Mongo serveru a veřejné API je servíruje pro filtrování na bosan.cz), ale interní sekce dávno ztratila rozhraní k jejich využití.
 - **Úprava štítků u fotky:** v detailu fotky (celoobrazovkový prohlížeč) přibyl editor štítků – kliknutím se přepínají existující štítky alba a přes „+“ lze přidat nový. Ukládá se okamžitě přes `PATCH /photos/:id`. Zápisy jsou optimistické, takže rychlá po sobě jdoucí přepnutí na sebe navazují a neztrácejí se; při chybě se změna vrátí zpět.
 - **Filtrování podle štítku:** nad galerií alba je lišta se štítky (stejně jako na veřejném webu) – kliknutím se fotky vyfiltrují podle štítku, „Všechny fotky“ filtr zruší. Řazení/správa fotek pracuje vždy s celým albem.
 - **Zobrazení štítků:** ve správě fotek (seznam) se u každé fotky zobrazují její štítky jako chipy.
 - **Bez zásahu do serveru:** backend, DTO, SDK i veřejné API štítky už poskytují i ukládají. Ověřeno za běhu, že veřejné API (`/api/public/gallery/:id`) vrací `tags` (u fotky bez štítků prázdné pole `[]`, tak jak to bosan.cz očekává) a že interní `GET /albums/:id/photos` a `PATCH /photos/:id` štítky čtou i zapisují.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři **Galerie** → album, které má fotky (ideálně nějaké se štítky, např. tábor 2019 1. turnus).
3. Zkontroluj, že nad galerií je lišta se štítky a že kliknutím na štítek se fotky vyfiltrují; „Všechny fotky“ filtr zruší.
4. Otevři fotku a u spodní lišty přepni pár štítků a přes „+“ přidej nový – změna se hned uloží a projeví se i po zavření a znovuotevření (i v liště filtru nad galerií).
5. Přepni galerii na **Upravit** (seznam) a zkontroluj, že se u fotek zobrazují jejich štítky.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QekWw9CaD1DixJt37FqdX5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QekWw9CaD1DixJt37FqdX5)_