### PR TITLE
Fix avatar initials for nicknames starting with a diacritic

### DIFF
--- a/frontend/src/app/shared/pipes/member.pipe.ts
+++ b/frontend/src/app/shared/pipes/member.pipe.ts
@@ -49,6 +49,6 @@ export class MemberPipe implements PipeTransform {
 	}
 
 	getFirstLetterLocal(value: string): string {
-		return value.match(/^(Ch|\w)/)?.[0] || "";
+		return value.match(/^(Ch|[\p{L}\p{N}_])/u)?.[0] || "";
 	}
 }

--- a/frontend/src/app/shared/pipes/member.pipe.ts
+++ b/frontend/src/app/shared/pipes/member.pipe.ts
@@ -49,6 +49,6 @@ export class MemberPipe implements PipeTransform {
 	}
 
 	getFirstLetterLocal(value: string): string {
-		return value.match(/^(Ch|[\p{L}\p{N}_])/u)?.[0] || "";
+		return value.match(/^(Ch|[\p{L}\p{N}])/u)?.[0] || "";
 	}
 }


### PR DESCRIPTION
# Změny

 - Oprava iniciály v avataru pro přezdívky začínající písmenem s diakritikou (např. „Číča"). Pipe `member` odvozoval první písmeno pomocí `/^(Ch|\w)/`, ale `\w` bez Unicode flagu matchuje jen `[A-Za-z0-9_]`, takže úvodní písmeno s diakritikou (`Č`, `Ž`, `ř`, …) neodpovídalo ani jedné větvi a avatar zůstal prázdný. Nově se používá Unicode-aware `/^(Ch|[\p{L}\p{N}_])/u`, které zachytí libovolné písmeno či číslici a zároveň ponechá speciální případ českého digrafu „Ch".

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že u člena s přezdívkou začínající písmenem s diakritikou (např. „Číča") se v avataru (účet, menu účtu, profil člena) zobrazí správné úvodní písmeno (`Č`) místo prázdného avataru.
3. Zkontroluj, že přezdívka „Chalupa" stále zobrazuje digraf „Ch".

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEZ7A1H88sXaiCqdrDGLAM)_