### PR TITLE
feat(changelog): ikona GitHubu, nadpis v záhlaví a výběr textu v seznamu změn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-# Seznam změn
-
 Přehled novinek a oprav v jednotlivých verzích aplikace.
 
 ## v4.3.1 — 2026-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-Přehled novinek a oprav v jednotlivých verzích aplikace.
-
 ## v4.3.1 — 2026-07-28
 
 - ✨ [Gitmoji u položek a odkazy na commity v seznamu změn](https://github.com/bosancz/interni-sekce/commit/8b5dfaebc800461a73d3e50649a6df8049f06181)

--- a/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.html
+++ b/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.html
@@ -1,4 +1,15 @@
 <bo-modal-layout>
+	<a
+		slot="title"
+		class="github-link"
+		[href]="repositoryUrl"
+		target="_blank"
+		rel="noopener"
+		aria-label="Zobrazit repozitář na GitHubu"
+	>
+		<ion-icon name="logo-github"></ion-icon>
+	</a>
+
 	@if (content() === undefined) {
 		<p class="muted">Načítání…</p>
 	} @else if (content()) {

--- a/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.html
+++ b/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.html
@@ -1,14 +1,17 @@
 <bo-modal-layout>
-	<a
-		slot="title"
-		class="github-link"
-		[href]="repositoryUrl"
-		target="_blank"
-		rel="noopener"
-		aria-label="Zobrazit repozitář na GitHubu"
-	>
-		<ion-icon name="logo-github"></ion-icon>
-	</a>
+	<div slot="title" class="changelog-header">
+		<h1>Seznam změn</h1>
+
+		<a
+			class="github-link"
+			[href]="repositoryUrl"
+			target="_blank"
+			rel="noopener"
+			aria-label="Zobrazit repozitář na GitHubu"
+		>
+			<ion-icon name="logo-github"></ion-icon>
+		</a>
+	</div>
 
 	@if (content() === undefined) {
 		<p class="muted">Načítání…</p>

--- a/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.scss
+++ b/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.scss
@@ -4,6 +4,9 @@
 	overflow-y: auto;
 	// the modal layout's content slot has no padding of its own, so the changelog supplies it
 	padding: 16px;
+	// Ionic sets user-select:none app-wide for a native feel; the changelog is prose meant to be
+	// read and copied, so opt its text back into selection.
+	user-select: text !important;
 
 	// the markdown is injected with [innerHTML], so it carries no view-encapsulation attribute —
 	// without ::ng-deep none of these rules would reach it

--- a/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.scss
+++ b/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.scss
@@ -2,20 +2,12 @@
 	// Long changelogs scroll within the dialog body rather than growing the modal.
 	max-height: 60vh;
 	overflow-y: auto;
-	// the modal layout's content slot has no padding of its own, and the changelog brings its own
-	// heading, so the layout's title slot is left empty (and collapses)
+	// the modal layout's content slot has no padding of its own, so the changelog supplies it
 	padding: 16px;
 
 	// the markdown is injected with [innerHTML], so it carries no view-encapsulation attribute —
 	// without ::ng-deep none of these rules would reach it
 	::ng-deep {
-		// "Seznam změn" — serves as the modal title
-		h1 {
-			font-size: 1.5rem;
-			font-weight: bold;
-			margin: 0 0 0.5rem;
-		}
-
 		h2 {
 			font-size: 1.1rem;
 			margin: 2.5rem 0 1rem;
@@ -80,10 +72,23 @@
 	}
 }
 
-// GitHub odkaz v záhlaví — zarovnaný vpravo nahoru, aby nezasahoval do nadpisu changelogu
-.github-link {
+// Záhlaví modalu: nadpis vlevo, odkaz na GitHub vpravo
+.changelog-header {
 	display: flex;
-	justify-content: flex-end;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+
+	// inherit the modal-layout .title sizing (1.5em bold) instead of the UA h1 defaults
+	h1 {
+		margin: 0;
+		font-size: inherit;
+	}
+}
+
+.github-link {
+	display: inline-flex;
+	align-items: center;
 	color: inherit;
 
 	ion-icon {

--- a/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.scss
+++ b/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.scss
@@ -80,6 +80,21 @@
 	}
 }
 
+// GitHub odkaz v záhlaví — zarovnaný vpravo nahoru, aby nezasahoval do nadpisu changelogu
+.github-link {
+	display: flex;
+	justify-content: flex-end;
+	color: inherit;
+
+	ion-icon {
+		font-size: 1.75rem;
+	}
+
+	&:hover {
+		color: var(--ion-color-primary);
+	}
+}
+
 .muted {
 	color: var(--ion-color-medium);
 	padding: 16px;

--- a/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.ts
+++ b/frontend/src/app/shared/components/changelog-modal/changelog-modal.component.ts
@@ -1,6 +1,8 @@
 import { Component, inject } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { IonButton, IonButtons, ModalController } from "@ionic/angular/standalone";
+import { IonButton, IonButtons, IonIcon, ModalController } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import { logoGithub } from "ionicons/icons";
 import { ApiService } from "src/app/core/services/api.service";
 import { InputModalComponent } from "src/app/core/services/modal.service";
 import { ChangelogLinksPipe } from "src/app/shared/pipes/changelog-links.pipe";
@@ -11,15 +13,19 @@ import { ModalLayoutComponent } from "../modal-layout/modal-layout.component";
 	selector: "bo-changelog-modal",
 	templateUrl: "./changelog-modal.component.html",
 	styleUrl: "./changelog-modal.component.scss",
-	imports: [ModalLayoutComponent, IonButtons, IonButton, MarkdownPipe, ChangelogLinksPipe],
+	imports: [ModalLayoutComponent, IonButtons, IonButton, IonIcon, MarkdownPipe, ChangelogLinksPipe],
 })
 export class ChangelogModalComponent extends InputModalComponent<void> {
 	private readonly api = inject(ApiService);
+
+	/** Odkaz na zdrojový repozitář, otevřený z ikony v záhlaví changelogu. */
+	readonly repositoryUrl = "https://github.com/bosancz/interni-sekce";
 
 	/** `undefined` while loading, the markdown once loaded (may be "" if the file is missing). */
 	content = toSignal(this.api.changelog);
 
 	constructor() {
 		super(inject(ModalController));
+		addIcons({ logoGithub });
 	}
 }

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -162,24 +162,27 @@ function renderSection(version, date, buckets, repoUrl) {
 	return lines.join("\n");
 }
 
-// No "# Seznam změn" heading — the changelog modal renders that as its own title, so the file
-// carries only the intro paragraph above the version sections.
-const DEFAULT_HEADER = ["Přehled novinek a oprav v jednotlivých verzích aplikace.", ""].join("\n");
+// The changelog modal renders its own title and intro, so the file carries no header text at all —
+// it starts straight with the newest "## <version>" section.
+const DEFAULT_HEADER = "";
 
 function prepend(file, section) {
 	let content = existsSync(file) ? readFileSync(file, "utf8") : "";
-	if (!content.trim()) content = DEFAULT_HEADER + "\n";
+	if (!content.trim()) content = DEFAULT_HEADER;
 
-	const marker = content.indexOf("\n## ");
+	// Split the file into any header text and the version sections, so the new section goes on top
+	// of the list. The header may be empty — the file can start straight with "## <version>".
+	const marker = content.startsWith("## ") ? 0 : content.indexOf("\n## ");
 	if (marker === -1) {
-		// No version sections yet — append after the header, keeping one blank line.
-		const trimmed = content.replace(/\s*$/, "");
-		return `${trimmed}\n\n${section}\n`;
+		// No version sections yet — append after whatever header exists.
+		const header = content.replace(/\s*$/, "");
+		return header ? `${header}\n\n${section}\n` : `${section}\n`;
 	}
 
-	const header = content.slice(0, marker + 1); // include the newline before "## "
-	const rest = content.slice(marker + 1);
-	return `${header.replace(/\s*$/, "")}\n\n${section}\n${rest}`;
+	const splitAt = marker === 0 ? 0 : marker + 1; // keep the newline before "## " with the header
+	const header = content.slice(0, splitAt).replace(/\s*$/, "");
+	const rest = content.slice(splitAt);
+	return header ? `${header}\n\n${section}\n${rest}` : `${section}\n${rest}`;
 }
 
 function main() {

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -162,7 +162,9 @@ function renderSection(version, date, buckets, repoUrl) {
 	return lines.join("\n");
 }
 
-const DEFAULT_HEADER = ["# Seznam změn", "", "Přehled novinek a oprav v jednotlivých verzích aplikace.", ""].join("\n");
+// No "# Seznam změn" heading — the changelog modal renders that as its own title, so the file
+// carries only the intro paragraph above the version sections.
+const DEFAULT_HEADER = ["Přehled novinek a oprav v jednotlivých verzích aplikace.", ""].join("\n");
 
 function prepend(file, section) {
 	let content = existsSync(file) ? readFileSync(file, "utf8") : "";


### PR DESCRIPTION
# Změny

 - **Ikona GitHubu v záhlaví changelogu** – vpravo nahoře v modálním okně seznamu změn (`bo-changelog-modal`) je ikona odkazující na repozitář <https://github.com/bosancz/interni-sekce>, otevíraná v nové kartě (`target="_blank"`, `rel="noopener"`).
 - **Nadpis „Seznam změn" přesunut do záhlaví modalu** – nadpis se nyní vykresluje jako titulek modalu (`slot="title"`) vedle ikony GitHubu, místo aby přicházel z prvního řádku `CHANGELOG.md`. Nadpis `# Seznam změn` byl proto odstraněn z `CHANGELOG.md` a generátor (`scripts/generate-changelog.mjs`) ho už do souboru nevkládá (zůstává jen úvodní odstavec nad verzemi).
 - **Výběr a kopírování textu v seznamu změn** – Ionic globálně vypíná výběr textu (`user-select: none`); obsah changelogu je ale text určený ke čtení a kopírování, tak se pro něj výběr znovu povoluje.

Ikona i nadpis sedí ve fixním záhlaví `bo-modal-layout`, takže zůstávají na místě i při rolování obsahu changelogu.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. V menu klikni na verzi – otevře se modal se seznamem změn.
3. Zkontroluj, že v záhlaví modalu je vlevo nadpis „Seznam změn" a vpravo ikona GitHubu.
4. Klikni na ikonu – v nové kartě se otevře <https://github.com/bosancz/interni-sekce>.
5. Zkus myší označit (vybrat) text některé z položek changelogu a zkopírovat ho – výběr musí fungovat.
6. Zkontroluj, že nadpis i ikona zůstávají v záhlaví i při rolování dlouhého changelogu.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)