### PR TITLE
feat(feedback): odkaz na GitHub issue v e-mailu o nahlášené chybě

### DIFF
--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -22,11 +22,6 @@ export class FeedbackController {
 
 		const report = await this.feedback.buildBugReport(authUser.userId, body);
 
-		// The GitHub issue is the report itself: if it cannot be filed, the request fails and
-		// the user knows to report the bug some other way. The email is only a notification on
-		// top of it — it links to the issue and its own delivery failure is logged, not
-		// surfaced. (With the GitHub App unconfigured the issue is skipped without error and
-		// the email carries the report alone.)
 		const issue = await this.feedback.fileBugReportIssue(report);
 
 		await this.feedback.sendBugReportEmail(report, issue);

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, InternalServerErrorException, Post, Req } from "@nestjs/common";
+import { Body, Controller, Post, Req } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { AcController } from "src/access-control/access-control-lib";
@@ -22,15 +22,13 @@ export class FeedbackController {
 
 		const report = await this.feedback.buildBugReport(authUser.userId, body);
 
-		// File the issue first so the email can link to it, then send the email regardless of
-		// whether that succeeded — neither channel throws on its own failure. The report
-		// succeeds as long as at least one channel got through; only a total failure (email
-		// and GitHub both down) surfaces as an error to the client.
+		// The GitHub issue is the report itself: if it cannot be filed, the request fails and
+		// the user knows to report the bug some other way. The email is only a notification on
+		// top of it — it links to the issue and its own delivery failure is logged, not
+		// surfaced. (With the GitHub App unconfigured the issue is skipped without error and
+		// the email carries the report alone.)
 		const issue = await this.feedback.fileBugReportIssue(report);
-		const emailed = await this.feedback.sendBugReportEmail(report, issue);
 
-		if (!emailed && !issue) {
-			throw new InternalServerErrorException("Bug report could not be delivered by email or GitHub.");
-		}
+		await this.feedback.sendBugReportEmail(report, issue);
 	}
 }

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -22,15 +22,14 @@ export class FeedbackController {
 
 		const report = await this.feedback.buildBugReport(authUser.userId, body);
 
-		// Deliver on both channels independently — neither throws on its own failure. The
-		// report succeeds as long as at least one channel got through; only a total failure
-		// (email and GitHub both down) surfaces as an error to the client.
-		const [emailed, filed] = await Promise.all([
-			this.feedback.sendBugReportEmail(report),
-			this.feedback.fileBugReportIssue(report),
-		]);
+		// File the issue first so the email can link to it, then send the email regardless of
+		// whether that succeeded — neither channel throws on its own failure. The report
+		// succeeds as long as at least one channel got through; only a total failure (email
+		// and GitHub both down) surfaces as an error to the client.
+		const issue = await this.feedback.fileBugReportIssue(report);
+		const emailed = await this.feedback.sendBugReportEmail(report, issue);
 
-		if (!emailed && !filed) {
+		if (!emailed && !issue) {
 			throw new InternalServerErrorException("Bug report could not be delivered by email or GitHub.");
 		}
 	}

--- a/backend/src/api/feedback/controllers/feedback.controller.ts
+++ b/backend/src/api/feedback/controllers/feedback.controller.ts
@@ -24,6 +24,6 @@ export class FeedbackController {
 
 		const issue = await this.feedback.fileBugReportIssue(report);
 
-		await this.feedback.sendBugReportEmail(report, issue);
+		await this.feedback.sendBugReportEmail(report, issue).catch(() => undefined);
 	}
 }

--- a/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.hbs
+++ b/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.hbs
@@ -10,6 +10,10 @@
 	<p><strong>Stránka:</strong> <a href="{{url}}">{{url}}</a></p>
 {{/if}}
 
+{{#if issueUrl}}
+	<p><strong>GitHub issue:</strong> <a href="{{issueUrl}}">#{{issueNumber}}</a></p>
+{{/if}}
+
 <p><strong>Popis chyby:</strong></p>
 
 <blockquote style="white-space: pre-wrap;">{{description}}</blockquote>

--- a/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.hbs
+++ b/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.hbs
@@ -2,9 +2,7 @@
 
 <p>Uživatel nahlásil chybu v bošánovské aplikaci.</p>
 
-<p><strong>Nahlásil/a:</strong> {{reporter}}</p>
-
-<p><strong>Prostředí:</strong> {{environment}}</p>
+<p><strong>Nahlásil/a:</strong> <a href="{{reporterUrl}}">{{reporter}}</a></p>
 
 {{#if url}}
 	<p><strong>Stránka:</strong> <a href="{{url}}">{{url}}</a></p>

--- a/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.ts
+++ b/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.ts
@@ -5,6 +5,8 @@ export const BugReportMailTemplate = createMailTemplate<{
 	environment: string;
 	url?: string;
 	description: string;
+	issueNumber?: number;
+	issueUrl?: string;
 }>({
 	filePath: __dirname + "/bug-report.mail-template.hbs",
 	subject: "Nahlášení chyby v aplikaci Bošán",

--- a/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.ts
+++ b/backend/src/api/feedback/mail-templates/bug-report/bug-report.mail-template.ts
@@ -2,7 +2,7 @@ import { createMailTemplate } from "src/models/mail/functions/create-mail-templa
 
 export const BugReportMailTemplate = createMailTemplate<{
 	reporter: string;
-	environment: string;
+	reporterUrl: string;
 	url?: string;
 	description: string;
 	issueNumber?: number;

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -9,7 +9,7 @@ import { BugReportMailTemplate } from "../mail-templates/bug-report/bug-report.m
 /** A bug report resolved into everything the email and issue need. */
 export interface BugReport {
 	reporter: string;
-	environment: string;
+	reporterUrl: string;
 	url?: string;
 	description: string;
 }
@@ -36,17 +36,17 @@ export class FeedbackService {
 
 	/**
 	 * Resolve a submitted bug report into the context the email and issue share: the
-	 * reporter's identity (from the authenticated user) and the current environment.
+	 * reporter's identity (from the authenticated user) and what they wrote.
 	 */
 	async buildBugReport(userId: number, body: BugReportBody): Promise<BugReport> {
 		const user = await this.users.getUser(userId, { includeMember: true });
 
 		const reporter =
-			[user?.member?.nickname, user?.login && `<${user.login}>`].filter(Boolean).join(" ") || "neznámý";
+			[user?.member?.nickname, user?.login && `(${user.login})`].filter(Boolean).join(" ") || "neznámý";
 
 		return {
 			reporter,
-			environment: this.config.app.environmentTitle || this.config.environment,
+			reporterUrl: `${this.config.app.baseUrl}/admin/uzivatele/${userId}`,
 			url: body.url,
 			description: body.description,
 		};
@@ -61,7 +61,7 @@ export class FeedbackService {
 	async sendBugReportEmail(report: BugReport, issue?: BugReportIssue | null): Promise<boolean> {
 		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
 			reporter: report.reporter,
-			environment: report.environment,
+			reporterUrl: report.reporterUrl,
 			url: report.url,
 			description: report.description,
 			issueNumber: issue?.number,
@@ -110,8 +110,7 @@ export class FeedbackService {
 			description ? "" : null,
 			description ? "---" : null,
 			description ? "" : null,
-			`**Nahlásil:** ${report.reporter}`,
-			`**Prostředí:** ${report.environment}`,
+			`**Nahlásil:** [${report.reporter}](${report.reporterUrl})`,
 			report.url ? `**URL:** ${report.url}` : null,
 		]
 			.filter((line) => line !== null)

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -105,13 +105,13 @@ export class FeedbackService {
 
 	private issueBody(report: BugReport, description: string): string {
 		return [
-			`**Nahlásil:** ${report.reporter}`,
-			`**Prostředí:** ${report.environment}`,
-			report.url ? `**URL:** ${report.url}` : null,
+			description || null,
 			description ? "" : null,
 			description ? "---" : null,
 			description ? "" : null,
-			description || null,
+			`**Nahlásil:** ${report.reporter}`,
+			`**Prostředí:** ${report.environment}`,
+			report.url ? `**URL:** ${report.url}` : null,
 		]
 			.filter((line) => line !== null)
 			.join("\n");

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, InternalServerErrorException, Logger } from "@nestjs/common";
 import { Config } from "src/config";
 import { GithubService } from "src/models/github/services/github.service";
 import { MailService } from "src/models/mail/services/mail.service";
@@ -55,8 +55,8 @@ export class FeedbackService {
 	/**
 	 * Construct and send the bug-report email to the configured recipient. When the report was
 	 * already filed as a GitHub issue, the email links to it.
-	 * Returns whether the email was actually sent; delivery failures are logged, not thrown,
-	 * so the caller can fall back to the other channel.
+	 * The email is a notification on top of the issue, so delivery failures are only logged,
+	 * never thrown; the returned flag says whether it actually went out.
 	 */
 	async sendBugReportEmail(report: BugReport, issue?: BugReportIssue | null): Promise<boolean> {
 		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
@@ -80,8 +80,9 @@ export class FeedbackService {
 
 	/**
 	 * Construct and file the bug report as a GitHub issue.
-	 * Returns the created issue, or null when GitHub is not configured or the API call fails
-	 * (logged, not thrown), so the caller can fall back to the email alone.
+	 * Throws when the issue could not be created, so the user is told their report did not
+	 * land. Returns null only when the GitHub App is not configured at all — the integration
+	 * is then deliberately disabled and the email carries the report on its own.
 	 */
 	async fileBugReportIssue(report: BugReport): Promise<BugReportIssue | null> {
 		if (!this.github.isConfigured) return null;
@@ -99,7 +100,7 @@ export class FeedbackService {
 			return issue;
 		} catch (err) {
 			this.logger.error(`Failed to file bug report as a GitHub issue: ${(err as Error).message}`);
-			return null;
+			throw new InternalServerErrorException("Bug report could not be filed as a GitHub issue.");
 		}
 	}
 

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -46,7 +46,7 @@ export class FeedbackService {
 		};
 	}
 
-	async sendBugReportEmail(report: BugReport, issue?: BugReportIssue | null): Promise<boolean> {
+	async sendBugReportEmail(report: BugReport, issue?: BugReportIssue | null): Promise<void> {
 		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
 			reporter: report.reporter,
 			reporterUrl: report.reporterUrl,
@@ -59,10 +59,9 @@ export class FeedbackService {
 		try {
 			await this.mailService.sendMail(mail);
 			this.logger.verbose("Bug report email sent");
-			return true;
 		} catch (err) {
 			this.logger.error(`Failed to send bug report email: ${(err as Error).message}`);
-			return false;
+			throw err;
 		}
 	}
 

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -14,13 +14,11 @@ export interface BugReport {
 	description: string;
 }
 
-/** The GitHub issue a bug report was filed as. */
 export interface BugReportIssue {
 	number: number;
 	url: string;
 }
 
-/** Longest issue title built from the report; the rest of the line continues in the body. */
 const ISSUE_TITLE_MAX_LENGTH = 80;
 
 @Injectable()
@@ -34,10 +32,6 @@ export class FeedbackService {
 		private readonly config: Config,
 	) {}
 
-	/**
-	 * Resolve a submitted bug report into the context the email and issue share: the
-	 * reporter's identity (from the authenticated user) and what they wrote.
-	 */
 	async buildBugReport(userId: number, body: BugReportBody): Promise<BugReport> {
 		const user = await this.users.getUser(userId, { includeMember: true });
 
@@ -52,12 +46,6 @@ export class FeedbackService {
 		};
 	}
 
-	/**
-	 * Construct and send the bug-report email to the configured recipient. When the report was
-	 * already filed as a GitHub issue, the email links to it.
-	 * The email is a notification on top of the issue, so delivery failures are only logged,
-	 * never thrown; the returned flag says whether it actually went out.
-	 */
 	async sendBugReportEmail(report: BugReport, issue?: BugReportIssue | null): Promise<boolean> {
 		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
 			reporter: report.reporter,
@@ -78,12 +66,6 @@ export class FeedbackService {
 		}
 	}
 
-	/**
-	 * Construct and file the bug report as a GitHub issue.
-	 * Throws when the issue could not be created, so the user is told their report did not
-	 * land. Returns null only when the GitHub App is not configured at all — the integration
-	 * is then deliberately disabled and the email carries the report on its own.
-	 */
 	async fileBugReportIssue(report: BugReport): Promise<BugReportIssue | null> {
 		if (!this.github.isConfigured) return null;
 
@@ -117,12 +99,6 @@ export class FeedbackService {
 			.join("\n");
 	}
 
-	/**
-	 * Split the free-text description into the issue title and the issue body: the first line
-	 * becomes the title, every following line stays in the body. A first line too long for a
-	 * title is cut at the last word that fits, ends with a horizontal ellipsis and continues
-	 * (ellipsis-prefixed) at the top of the body, so nothing the user wrote is lost.
-	 */
 	private splitDescription(description: string): { title: string; body: string } {
 		const text = description.replace(/\r\n/g, "\n").trim();
 		const breakIndex = text.indexOf("\n");

--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -14,6 +14,15 @@ export interface BugReport {
 	description: string;
 }
 
+/** The GitHub issue a bug report was filed as. */
+export interface BugReportIssue {
+	number: number;
+	url: string;
+}
+
+/** Longest issue title built from the report; the rest of the line continues in the body. */
+const ISSUE_TITLE_MAX_LENGTH = 80;
+
 @Injectable()
 export class FeedbackService {
 	private readonly logger = new Logger(FeedbackService.name);
@@ -44,16 +53,19 @@ export class FeedbackService {
 	}
 
 	/**
-	 * Construct and send the bug-report email to the configured recipient.
+	 * Construct and send the bug-report email to the configured recipient. When the report was
+	 * already filed as a GitHub issue, the email links to it.
 	 * Returns whether the email was actually sent; delivery failures are logged, not thrown,
 	 * so the caller can fall back to the other channel.
 	 */
-	async sendBugReportEmail(report: BugReport): Promise<boolean> {
+	async sendBugReportEmail(report: BugReport, issue?: BugReportIssue | null): Promise<boolean> {
 		const mail = BugReportMailTemplate(this.config.feedback.bugReportRecipient, {
 			reporter: report.reporter,
 			environment: report.environment,
 			url: report.url,
 			description: report.description,
+			issueNumber: issue?.number,
+			issueUrl: issue?.url,
 		});
 
 		try {
@@ -68,50 +80,73 @@ export class FeedbackService {
 
 	/**
 	 * Construct and file the bug report as a GitHub issue.
-	 * Returns whether an issue was actually created — false when GitHub is not configured or
-	 * the API call fails (logged, not thrown), so the caller can fall back to the email.
+	 * Returns the created issue, or null when GitHub is not configured or the API call fails
+	 * (logged, not thrown), so the caller can fall back to the email alone.
 	 */
-	async fileBugReportIssue(report: BugReport): Promise<boolean> {
-		if (!this.github.isConfigured) return false;
+	async fileBugReportIssue(report: BugReport): Promise<BugReportIssue | null> {
+		if (!this.github.isConfigured) return null;
+
+		const { title, body } = this.splitDescription(report.description);
 
 		try {
 			const issue = await this.github.createIssue(this.config.github.bugReportRepo, {
-				title: this.issueTitle(report.description, this.config.app.environmentTitle),
-				body: this.issueBody(report),
+				title: this.issueTitle(title, this.config.app.environmentTitle),
+				body: this.issueBody(report, body),
 				labels: [this.config.github.bugReportLabel],
 			});
 
 			this.logger.verbose(`Bug report filed as GitHub issue #${issue.number} (${issue.url}).`);
-			return true;
+			return issue;
 		} catch (err) {
 			this.logger.error(`Failed to file bug report as a GitHub issue: ${(err as Error).message}`);
-			return false;
+			return null;
 		}
 	}
 
-	private issueBody(report: BugReport): string {
+	private issueBody(report: BugReport, description: string): string {
 		return [
 			`**Nahlásil:** ${report.reporter}`,
 			`**Prostředí:** ${report.environment}`,
 			report.url ? `**URL:** ${report.url}` : null,
-			"",
-			"---",
-			"",
-			report.description,
+			description ? "" : null,
+			description ? "---" : null,
+			description ? "" : null,
+			description || null,
 		]
 			.filter((line) => line !== null)
 			.join("\n");
 	}
 
 	/**
-	 * Build a concise issue title from the free-text description (first line, truncated).
+	 * Split the free-text description into the issue title and the issue body: the first line
+	 * becomes the title, every following line stays in the body. A first line too long for a
+	 * title is cut at the last word that fits, ends with a horizontal ellipsis and continues
+	 * (ellipsis-prefixed) at the top of the body, so nothing the user wrote is lost.
+	 */
+	private splitDescription(description: string): { title: string; body: string } {
+		const text = description.replace(/\r\n/g, "\n").trim();
+		const breakIndex = text.indexOf("\n");
+
+		const firstLine = (breakIndex === -1 ? text : text.slice(0, breakIndex)).trim();
+		const otherLines = breakIndex === -1 ? "" : text.slice(breakIndex + 1).trim();
+
+		if (firstLine.length <= ISSUE_TITLE_MAX_LENGTH) return { title: firstLine, body: otherLines };
+
+		const lastSpace = firstLine.lastIndexOf(" ", ISSUE_TITLE_MAX_LENGTH - 1);
+		const cut = lastSpace > ISSUE_TITLE_MAX_LENGTH / 2 ? lastSpace : ISSUE_TITLE_MAX_LENGTH - 1;
+
+		return {
+			title: `${firstLine.slice(0, cut).trimEnd()}…`,
+			body: [`…${firstLine.slice(cut).trim()}`, otherLines].filter(Boolean).join("\n"),
+		};
+	}
+
+	/**
 	 * Non-production environments (ENV_TITLE set, e.g. "TEST") are prefixed so a report from
 	 * the testing environment is recognizable straight from the issue list.
 	 */
-	private issueTitle(description: string, environmentTitle: string): string {
-		const firstLine = description.trim().split("\n")[0].trim();
-		const summary = firstLine.length > 80 ? `${firstLine.slice(0, 77)}…` : firstLine;
+	private issueTitle(title: string, environmentTitle: string): string {
 		const prefix = environmentTitle ? `[${environmentTitle}] ` : "";
-		return `${prefix}Nahlášená chyba: ${summary}`;
+		return `${prefix}${title || "Nahlášená chyba"}`;
 	}
 }


### PR DESCRIPTION
# Změny

 - Nahlášená chyba se nejdřív zakládá jako GitHub issue a teprve potom se posílá e-mail — pokud se issue povedlo založit, e-mail na něj obsahuje odkaz (`#číslo`). Dřív oba kanály běžely paralelně, takže e-mail o issue nic nevěděl.
 - **Issue je samotné nahlášení, e-mail je jen upozornění navíc:** když se issue nepodaří založit, request skončí chybou 500 a uživatel se dozví, že nahlášení neprošlo. Selhání odeslání e-mailu se naopak jen zaloguje a uživateli se nijak neprojeví. Když GitHub App není nakonfigurovaná (typicky lokální vývoj), zakládání issue se přeskočí bez chyby a nahlášení nese jen e-mail.
 - Titulek issue tvoří **první řádek** popisu (bez dřívější předpony `Nahlášená chyba:`; předpona prostředí `[TEST]` zůstává). Je-li první řádek delší než 80 znaků, zkrátí se na hranici posledního slova, ukončí se výpustkou `…` a jeho zbytek pokračuje — také uvozený `…` — na začátku popisu issue, takže se nic z napsaného textu neztratí.
 - **Ostatní řádky jsou vždy popis** issue; první řádek se v popisu už neopakuje. V těle issue je nejdřív popis chyby, pod ním `---` a až potom technické údaje (nahlásil / URL). Když po odebrání titulku nezbyde žádný text, oddělovač se vynechá a v těle jsou jen technické údaje.
 - Prázdný popis (jen bílé znaky) má fallback titulek `Nahlášená chyba`.
 - **Nahlašující je odkaz na svou stránku uživatele** (`<BASE_URL>/admin/uzivatele/<id>`) — v issue jako markdown odkaz, v e-mailu jako `<a>`. Login se zobrazuje v kulatých závorkách místo špičatých: `Kopec (kopec)` — GitHub by `<kopec>` vzal jako HTML tag a zahodil ho.
 - **Údaj o prostředí zmizel** z těla issue i z e-mailu. V titulku issue zůstává předpona `[TEST]`, aby šla nahlášení z testu poznat rovnou v seznamu issues — pokud má zmizet i ta, řekni.
 - E-mail dál obsahuje celý text popisu včetně prvního řádku, přibyl jen řádek s odkazem na issue.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. V menu účtu nahlas chybu s krátkým jednořádkovým popisem. Zkontroluj, že vzniklo issue s titulkem `[TEST] <ten řádek>` a že v těle issue jsou jen technické údaje (nahlásil / URL), bez zopakovaného titulku a bez oddělovače.
3. Zkontroluj, že „Nahlásil“ je odkaz a vede na tvou stránku uživatele.
4. Nahlas chybu s víceřádkovým popisem. Zkontroluj, že titulek je první řádek a v těle issue jsou nejdřív ostatní řádky, pak `---` a pak technické údaje.
5. Nahlas chybu, jejíž první řádek je hodně dlouhý (víc než 80 znaků). Zkontroluj, že titulek končí `…` na hranici slova a že zbytek toho řádku je na začátku popisu issue uvozený `…`.
6. Zkontroluj doručený e-mail — měl by obsahovat řádek `GitHub issue: #<číslo>` odkazující na právě založené issue a odkaz na nahlašujícího.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)