### PR TITLE
feat(version): odkaz na aktualizaci na samostatném řádku pod verzí

### DIFF
--- a/frontend/src/app/shared/components/version/version.component.html
+++ b/frontend/src/app/shared/components/version/version.component.html
@@ -1,13 +1,13 @@
 <p class="version">
-	@switch (updateStatus()) {
-		@case ("checking") {
+	<a (click)="openChangelog()" class="clickable">Verze {{ version() }}</a>
+</p>
+
+@if (updateAvailable()) {
+	<p class="update">
+		@if (updating()) {
 			<ion-spinner></ion-spinner>
-		}
-		@case ("available") {
+		} @else {
 			<a (click)="doUpdate()" class="clickable">Aktualizovat</a>
 		}
-		@default {
-			<a (click)="openChangelog()" class="clickable">Verze {{ version() }}</a>
-		}
-	}
-</p>
+	</p>
+}

--- a/frontend/src/app/shared/components/version/version.component.scss
+++ b/frontend/src/app/shared/components/version/version.component.scss
@@ -10,7 +10,8 @@ p {
 }
 
 ion-spinner {
-	height: 20px;
+	height: 1rem;
+	vertical-align: middle;
 }
 
 .clickable {

--- a/frontend/src/app/shared/components/version/version.component.ts
+++ b/frontend/src/app/shared/components/version/version.component.ts
@@ -1,8 +1,8 @@
 import { Component, signal } from "@angular/core";
-import { toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { SwUpdate } from "@angular/service-worker";
 import { IonSpinner } from "@ionic/angular/standalone";
-import { map } from "rxjs";
+import { filter, map } from "rxjs";
 import { ApiService } from "src/app/core/services/api.service";
 import { ModalService } from "src/app/core/services/modal.service";
 import { ChangelogModalComponent } from "src/app/shared/components/changelog-modal/changelog-modal.component";
@@ -18,36 +18,57 @@ export class VersionComponent {
 	private readonly logger = new Logger("VersionComponent");
 
 	version = toSignal(this.api.info.pipe(map((info) => info.version)));
-	updateStatus = signal<"checking" | "available" | "unavailable" | "error">("unavailable");
+	updateAvailable = signal(false);
+	updating = signal(false);
+
+	private updateCheck?: Promise<boolean>;
 
 	constructor(
 		private readonly api: ApiService,
 		private readonly swUpdate: SwUpdate,
 		private readonly modal: ModalService,
 	) {
+		this.swUpdate.versionUpdates
+			.pipe(
+				filter((event) => event.type === "VERSION_DETECTED" || event.type === "VERSION_READY"),
+				takeUntilDestroyed(),
+			)
+			.subscribe((event) => {
+				this.logger.log("New version detected:", event.type);
+				this.updateAvailable.set(true);
+			});
+
 		this.checkForUpdates();
 	}
 
 	private async checkForUpdates(): Promise<void> {
 		if (!this.swUpdate.isEnabled) return;
 
-		this.updateStatus.set("checking");
 		this.logger.debug("Checking for updates...");
+		this.updateCheck = this.swUpdate.checkForUpdate();
 
 		try {
-			const updateAvailable = await this.swUpdate.checkForUpdate();
-			this.updateStatus.set(updateAvailable ? "available" : "unavailable");
+			const updateAvailable = await this.updateCheck;
+			if (updateAvailable) this.updateAvailable.set(true);
 			this.logger.log("Update available:", updateAvailable);
 		} catch {
-			this.updateStatus.set("error");
 			this.logger.error("Error while checking for updates");
 		} finally {
 			this.logger.debug("Update check completed");
 		}
 	}
 
-	doUpdate(): void {
-		this.swUpdate.activateUpdate().then(() => document.location.reload());
+	async doUpdate(): Promise<void> {
+		this.updating.set(true);
+
+		try {
+			await this.updateCheck;
+			await this.swUpdate.activateUpdate();
+			document.location.reload();
+		} catch {
+			this.updating.set(false);
+			this.logger.error("Error while activating the update");
+		}
 	}
 
 	openChangelog(): void {


### PR DESCRIPTION
# Změny

 - Odkaz „Aktualizovat“ už nenahrazuje číslo verze, ale zobrazuje se na samostatném řádku pod ní — verze je tak v patičce vidět pořád.
 - Odkaz se objeví hned při detekci nové verze (událost `VERSION_DETECTED` ze `SwUpdate.versionUpdates`), ne až po jejím stažení.
 - Po kliknutí se na místě odkazu točí spinner, dokud není nová verze stažená a připravená; teprve pak se aktivuje a stránka se načte znovu. Stahování samotné řídí service worker, zastavit ho a spustit až po kliknutí nejde, ale čekání na dokončení má teď viditelný indikátor.
 - Spinner při úvodní kontrole aktualizací zmizel — číslo verze se zobrazí rovnou a řádek s aktualizací přibyde, jen když je co aktualizovat.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že v patičce menu (postranní panel i modal účtu) je vidět „Verze …“ a kliknutí na ni otevře seznam změn.
3. Po nasazení nové verze (nebo při otevřené staré záložce) zkontroluj, že se pod verzí objeví řádek „Aktualizovat“ a verze zůstane vidět.
4. Klikni na „Aktualizovat“ — na jeho místě se objeví spinner a po dokončení se aplikace sama načte znovu v nové verzi.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsZj8BfJiT5tmpkdKAa96u)_