### PR TITLE
chore(mcp): přidat Angular CLI MCP server do konfigurace repozitáře

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"angular-cli": {
+			"command": "npx",
+			"args": ["-y", "@angular/cli", "mcp"]
+		}
+	}
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@
   - Lockfiles are committed and `npm ci` works in `frontend/` and `backend/`. Do **not** use the root `npm ci` / `npm run install`: it runs `scripts/install.sh`, which also builds the backend and runs migrations, so it needs a database. `npm install` in a sandbox adds platform-specific optional deps to the lockfile — don't commit that churn.
   - A **frontend-only** change needs no database: `cd frontend && npm ci && npm run dev`, then read the Angular compile output.
   - For a **backend** change, or the full root `npm run dev` (the thing that produces `dev.log`), bring up Postgres first — see below.
+- **`.mcp.json` registers the Angular CLI MCP server** (`npx -y @angular/cli mcp`) — Angular docs/best-practices lookups plus workspace tools. It runs from the repo root and finds `frontend/angular.json` by itself, but needs Node 24 like every other `ng` command; its `devserver_start` tool starts a dev server, so the one-warm-server rule above applies to it too.
 
 ## Frontend SDK
 


### PR DESCRIPTION
# Změny

 - Přidán `.mcp.json` v kořeni repozitáře, který registruje Angular CLI MCP server (`npx -y @angular/cli mcp`) — dokumentace, best practices a nástroje nad Angular workspace.
 - Poznámka v `CLAUDE.md`: server běží z kořene repozitáře a `frontend/angular.json` si najde sám, potřebuje Node 24 a jeho `devserver_start` spadá pod pravidlo o jednom běžícím dev serveru.

Nejde o změnu aplikace — pouze konfigurace nástrojů pro vývoj.

# Testovací scénář

Změna se neprojeví na test.bosan.cz, testuje se lokálně:

1. Stáhni si větev a spusť v ní Claude Code (nebo jiného MCP klienta) z kořene repozitáře.
2. Potvrď dotaz na povolení serveru z `.mcp.json` a zkontroluj, že se `angular-cli` v `/mcp` připojí (status `connected`).
3. Zkontroluj, že nástroj `list_projects` najde workspace `frontend/angular.json` s projektem `bosancz`.

Ověřeno lokálně na Node 24 — server nastartuje z kořene repozitáře a `list_projects` vrátí `frontend/angular.json` (projekt `bosancz`, Angular 22).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtEuEPvmoDLuREwuFofg9r)_