### PR TITLE
feat(albums): zobrazit filtr štítků i u alba bez štítků

### DIFF
--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.html
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.html
@@ -49,8 +49,9 @@
 	</div>
 }
 
-@if (view() === 'gallery' && allTags().length) {
-	<!-- filter the gallery by tag, mirroring the public site's tag buttons -->
+@if (view() === 'gallery' && photos()?.length) {
+	<!-- filter the gallery by tag, mirroring the public site's tag buttons; shown even without
+	     any tags yet, so the hint below tells people where tags come from -->
 	<div class="tag-filter" role="group" aria-label="Filtrovat podle štítku">
 		<ion-chip
 			role="button"
@@ -77,6 +78,9 @@
 			>
 				#{{ tag }}
 			</ion-chip>
+		}
+		@if (!allTags().length) {
+			<span class="tag-hint">Štítky přidáte po kliknutí na fotku.</span>
 		}
 	</div>
 }

--- a/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.scss
+++ b/frontend/src/app/features/albums/components/album-gallery/album-gallery.component.scss
@@ -46,6 +46,12 @@
 		outline: 2px solid var(--ion-color-primary);
 		outline-offset: 2px;
 	}
+
+	.tag-hint {
+		margin-left: 0.5rem;
+		font-size: 0.85rem;
+		color: var(--ion-color-medium);
+	}
 }
 
 // without a label the buttons are icons only, so drop the padding the label took


### PR DESCRIPTION
> [!NOTE]
> Zadání bylo stručné, tak popisuju, jak jsem ho pochopil: lišta se štítky (s chipem „Všechny fotky“) se v galerii alba nově ukáže i u alba, které zatím žádné štítky nemá, a je u ní poznámka, že se štítky přidávají v detailu fotky. Pokud jsi myslel/a poznámku přímo uvnitř modalu s fotkou, klidně to přesunu.

# Změny

- Lišta filtru štítků v galerii alba se zobrazí vždy, když album obsahuje fotky — dřív byla schovaná, dokud nějaký štítek neexistoval, takže se o štítcích nedalo dozvědět.
- Když album zatím nemá žádný štítek, je vedle chipu „Všechny fotky“ nenápadná poznámka „Štítky přidáte po kliknutí na fotku.“ (styl `.tag-hint`).
- Chování filtru samotného se nemění, v režimu úprav se lišta stále nezobrazuje.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
   - Windows: `CTRL + F5`
   - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři album s fotkami, které nemá žádné štítky. Zkontroluj, že se nad galerií zobrazí chip „Všechny fotky“ a vedle něj poznámka „Štítky přidáte po kliknutí na fotku.“
3. Klikni na fotku, přidej jí ve spodní liště štítek a zavři detail. Zkontroluj, že poznámka zmizela a přibyl chip s novým štítkem, kterým jde filtrovat.
4. Zkontroluj, že u prázdného alba (bez fotek) se lišta štítků nezobrazuje a že v režimu „Upravit“ taky ne.

Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdQZbsQzpUihddGMasqX9t)_