### PR TITLE
style(frontend): odstranit předponu v u čísla verze v menu

### DIFF
--- a/frontend/src/app/shared/components/version/version.component.ts
+++ b/frontend/src/app/shared/components/version/version.component.ts
@@ -17,7 +17,7 @@ import { Logger } from "src/logger";
 export class VersionComponent {
 	private readonly logger = new Logger("VersionComponent");
 
-	version = toSignal(this.api.info.pipe(map((info) => info.version)));
+	version = toSignal(this.api.info.pipe(map((info) => info.version.replace(/^v(?=\d)/, ""))));
 	updateAvailable = signal(false);
 	updating = signal(false);
 


### PR DESCRIPTION
# Změny

 - `VersionComponent` nyní odstraňuje počáteční `v` z čísla verze, takže se v menu zobrazuje „Verze 4.4.0“ místo „Verze v4.4.0“. Odstraňuje se jen `v` následované číslicí, takže verze typu `NEXT-<sha>` a `DEV` zůstávají beze změny.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že v menu dole je u verze uvedeno číslo bez počátečního `v` (např. „Verze 4.4.0“).
3. Zkontroluj, že kliknutí na verzi stále otevře changelog.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKysZoLrL7kGTuRp3UtyZA)_