### PR TITLE
feat(frontend): zobrazovat verzi zapečenou při buildu místo verze z API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM node:24-alpine AS build-frontend
 
 ARG NG_CONFIGURATION=production
+ARG VERSION
 
 WORKDIR /app/frontend
 
@@ -12,6 +13,7 @@ RUN npm ci
 
 # build
 COPY ./frontend .
+ENV VERSION=$VERSION
 RUN npm run build
 
 

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -29,6 +29,9 @@
 							}
 						],
 						"scripts": [],
+						"define": {
+							"APP_VERSION": "'DEV'"
+						},
 						"browser": "src/main.ts",
 						"stylePreprocessorOptions": {
 							"includePaths": ["."]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
 	"description": "Bošán",
 	"private": true,
 	"scripts": {
-		"build": "ng build --configuration production",
+		"build": "ng build --configuration production --define APP_VERSION=\"'${VERSION:-DEV}'\"",
 		"dev": "ng serve",
 		"dev:test-server": "ng serve --configuration=test-server",
 		"generate:sdk": "openapi-sdk -i http://127.0.0.1:3000/api/openapi-json -o src/sdk"

--- a/frontend/src/app/shared/components/version/version.component.html
+++ b/frontend/src/app/shared/components/version/version.component.html
@@ -1,5 +1,5 @@
 <p class="version">
-	<a (click)="openChangelog()" class="clickable">Verze {{ version() }}</a>
+	<a (click)="openChangelog()" class="clickable">Verze {{ version }}</a>
 </p>
 
 @if (updateAvailable()) {

--- a/frontend/src/app/shared/components/version/version.component.ts
+++ b/frontend/src/app/shared/components/version/version.component.ts
@@ -1,11 +1,11 @@
 import { Component, signal } from "@angular/core";
-import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { SwUpdate } from "@angular/service-worker";
 import { IonSpinner } from "@ionic/angular/standalone";
-import { filter, map } from "rxjs";
-import { ApiService } from "src/app/core/services/api.service";
+import { filter } from "rxjs";
 import { ModalService } from "src/app/core/services/modal.service";
 import { ChangelogModalComponent } from "src/app/shared/components/changelog-modal/changelog-modal.component";
+import { Config } from "src/config";
 import { Logger } from "src/logger";
 
 @Component({
@@ -17,14 +17,14 @@ import { Logger } from "src/logger";
 export class VersionComponent {
 	private readonly logger = new Logger("VersionComponent");
 
-	version = toSignal(this.api.info.pipe(map((info) => info.version.replace(/^v(?=\d)/, ""))));
+	version = this.config.version.replace(/^v(?=\d)/, "");
 	updateAvailable = signal(false);
 	updating = signal(false);
 
 	private updateCheck?: Promise<boolean>;
 
 	constructor(
-		private readonly api: ApiService,
+		private readonly config: Config,
 		private readonly swUpdate: SwUpdate,
 		private readonly modal: ModalService,
 	) {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,6 +1,8 @@
 export class Config {
 	production = true;
 
+	version = APP_VERSION;
+
 	apiRoot = "/";
 
 	jwtDomains = ["bosan.cz"];

--- a/frontend/src/typings.d.ts
+++ b/frontend/src/typings.d.ts
@@ -3,3 +3,5 @@ declare var module: NodeModule;
 interface NodeModule {
 	id: string;
 }
+
+declare const APP_VERSION: string;


### PR DESCRIPTION
# Změny

- Verze v UI se dosud brala z backendu (`GET /api` → `ApiService.info`), takže starý načtený frontend (otevřená záložka přes deploy, ještě neaktivovaný service worker) hlásil už novou verzi — číslo na obrazovce nepopisovalo běžící kód.
- `Dockerfile`: `ARG VERSION` + `ENV VERSION=$VERSION` nově i ve fázi `build-frontend` (runner fázi to zůstává beze změny pro backend).
- `frontend/package.json`: build předává verzi Angularu přes `--define APP_VERSION="'${VERSION:-DEV}'"`, takže se zapeče do bundlu.
- `frontend/angular.json`: `define` s výchozí hodnotou `'DEV'` — pokrývá `ng serve`, CLI hodnota má přednost.
- `frontend/src/typings.d.ts`: `declare const APP_VERSION: string;`
- `frontend/src/config.ts`: nové pole `version` (vedle ostatních build-time konstant).
- `VersionComponent` bere verzi z `Config` místo z API; odstranění úvodního `v` (`v4.4.0` → `4.4.0`) zůstává, stejně jako celý service-worker update flow a otevírání changelogu.

Workflows měnit netřeba — `build.yml` už `VERSION` jako build-arg posílá a ten dorazí do každé fáze, která si ho deklaruje (`vN.N.N` z PROD, `NEXT-<sha>` z NEXT). Backend si `VERSION` drží dál (logy, CLI, OpenAPI) a `RootResponse.version` v API zůstává.

Ověřeno lokálně (Node 24): `npm run build` zapeče `this.version="DEV"`, `VERSION=v9.9.9 npm run build` zapeče `this.version="v9.9.9"` do `dist/browser/main-*.js`.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že v levém menu (a na mobilu v účtovém menu) je pořád vidět `Verze …` a odpovídá nasazenému buildu.
3. Klikni na verzi a zkontroluj, že se otevře changelog.
4. Nech záložku otevřenou přes nasazení další verze — zobrazené číslo se nesmí změnit dřív, než se přes „Aktualizovat" načte nový frontend.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BntBWKggNt16Umi9uF3peY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BntBWKggNt16Umi9uF3peY)_