### PR TITLE
fix(events): formátovat markdown v "Co s sebou" ve vygenerované přihlášce

### DIFF
--- a/backend/assets/registration-templates/README.md
+++ b/backend/assets/registration-templates/README.md
@@ -29,6 +29,9 @@ Použij dvojité složené závorky. Dostupné údaje:
 | `{{arrival}}` | příjezd (datum, čas, místo dohromady) |
 | `{{dateFrom}}` / `{{dateTill}}` | datum od / do |
 | `{{{descriptionHtml}}}` | popis akce (psaný v markdownu, vloží se jako HTML – **použij trojité závorky**) |
+| `{{{itemListHtml}}}` | co s sebou (psané v markdownu, vloží se jako HTML – **použij trojité závorky**) |
+| `{{{noteHtml}}}` | poznámka zadaná při generování (markdown → HTML – **použij trojité závorky**) |
+| `{{price}}` | cena i s „Kč" |
 | `{{contactsLine}}` | vedoucí a kontakty na jednom řádku |
 | `{{#each contacts}} {{name}} {{phone}} {{email}} {{/each}}` | seznam vedoucích pro vlastní formátování |
 | `{{accent}}` | vybraná barva (hex), kterou se generuje |

--- a/backend/assets/registration-templates/sportovni/template.html
+++ b/backend/assets/registration-templates/sportovni/template.html
@@ -155,8 +155,13 @@
 			.info-box p {
 				margin: 4px 0;
 			}
-			.info-box .multiline {
-				white-space: pre-line;
+			.info-box .item-list > .label + p {
+				display: inline;
+			}
+			.info-box .item-list ul,
+			.info-box .item-list ol {
+				margin: 4px 0;
+				padding-left: 18px;
 			}
 			.description {
 				margin-bottom: 12px;
@@ -279,7 +284,7 @@
 						{{#if departure}}<p><span class="label">Sraz:</span> {{departure}}</p>{{/if}}
 						{{#if arrival}}<p><span class="label">Návrat:</span> {{arrival}}</p>{{/if}}
 						{{#if price}}<p><span class="label">Cena:</span> {{price}}</p>{{/if}}
-						{{#if itemList}}<p class="multiline"><span class="label">S sebou:</span> {{itemList}}</p>{{/if}}
+						{{#if itemListHtml}}<div class="item-list"><span class="label">S sebou:</span> {{{itemListHtml}}}</div>{{/if}}
 						{{#if contactsLine}}<p><span class="label">Kontakt:</span> {{contactsLine}}</p>{{/if}}
 					</div>
 

--- a/backend/assets/registration-templates/turisticka/template.html
+++ b/backend/assets/registration-templates/turisticka/template.html
@@ -133,8 +133,14 @@
 				margin: 4px 0;
 			}
 
-			.info-box .multiline {
-				white-space: pre-line;
+			.info-box .item-list > .label + p {
+				display: inline;
+			}
+
+			.info-box .item-list ul,
+			.info-box .item-list ol {
+				margin: 4px 0;
+				padding-left: 18px;
 			}
 
 			/* volitelný box s doplňující informací (např. platební instrukce) */
@@ -243,7 +249,7 @@
 						{{#if departure}}<p><span class="label">Odjezd:</span> {{departure}}</p>{{/if}}
 						{{#if arrival}}<p><span class="label">Příjezd:</span> {{arrival}}</p>{{/if}}
 						{{#if price}}<p><span class="label">Cena:</span> {{price}}</p>{{/if}}
-						{{#if itemList}}<p class="multiline"><span class="label">Co s sebou:</span> {{itemList}}</p>{{/if}}
+						{{#if itemListHtml}}<div class="item-list"><span class="label">Co s sebou:</span> {{{itemListHtml}}}</div>{{/if}}
 						{{#if contactsLine}}<p><span class="label">Kontakt:</span> {{contactsLine}}</p>{{/if}}
 					</div>
 

--- a/backend/assets/registration-templates/vodacka/template.html
+++ b/backend/assets/registration-templates/vodacka/template.html
@@ -157,8 +157,13 @@
 			.info-box p {
 				margin: 4px 0;
 			}
-			.info-box .multiline {
-				white-space: pre-line;
+			.info-box .item-list > .label + p {
+				display: inline;
+			}
+			.info-box .item-list ul,
+			.info-box .item-list ol {
+				margin: 4px 0;
+				padding-left: 18px;
 			}
 			.description {
 				margin-bottom: 12px;
@@ -291,7 +296,7 @@
 						{{#if departure}}<p><span class="label">Začátek:</span> {{departure}}</p>{{/if}}
 						{{#if arrival}}<p><span class="label">Konec:</span> {{arrival}}</p>{{/if}}
 						{{#if price}}<p><span class="label">Cena:</span> {{price}}</p>{{/if}}
-						{{#if itemList}}<p class="multiline"><span class="label">Co s sebou:</span> {{itemList}}</p>{{/if}}
+						{{#if itemListHtml}}<div class="item-list"><span class="label">Co s sebou:</span> {{{itemListHtml}}}</div>{{/if}}
 						{{#if contactsLine}}<p><span class="label">Kontakt:</span> {{contactsLine}}</p>{{/if}}
 					</div>
 

--- a/backend/assets/registration-templates/vytvarny/template.html
+++ b/backend/assets/registration-templates/vytvarny/template.html
@@ -128,8 +128,13 @@
 			.info-box p {
 				margin: 4px 0;
 			}
-			.info-box .multiline {
-				white-space: pre-line;
+			.info-box .item-list > .label + p {
+				display: inline;
+			}
+			.info-box .item-list ul,
+			.info-box .item-list ol {
+				margin: 4px 0;
+				padding-left: 18px;
 			}
 			.note-box {
 				margin-top: 10px;
@@ -269,7 +274,7 @@
 							{{#if departure}}<p><span class="label">Začátek:</span> {{departure}}</p>{{/if}}
 							{{#if arrival}}<p><span class="label">Konec:</span> {{arrival}}</p>{{/if}}
 							{{#if price}}<p><span class="label">Cena:</span> {{price}}</p>{{/if}}
-							{{#if itemList}}<p class="multiline"><span class="label">Co s sebou:</span> {{itemList}}</p>{{/if}}
+							{{#if itemListHtml}}<div class="item-list"><span class="label">Co s sebou:</span> {{{itemListHtml}}}</div>{{/if}}
 							{{#if contactsLine}}<p><span class="label">Kontakt:</span> {{contactsLine}}</p>{{/if}}
 						</div>
 					</div>

--- a/backend/src/models/events/services/event-registration.service.ts
+++ b/backend/src/models/events/services/event-registration.service.ts
@@ -193,12 +193,18 @@ export class EventRegistrationService {
 			dateTill: this.formatDate(event.dateTill),
 			departure: this.formatDeparture(event.dateFrom, event.timeFrom, event.meetingPlaceStart),
 			arrival: this.formatDeparture(event.dateTill, event.timeTill, event.meetingPlaceEnd),
-			descriptionHtml: event.description ? marked.parse(event.description, { async: false }) : "",
+			descriptionHtml: this.renderMarkdown(event.description),
 			price: event.price != null ? `${event.price} Kč` : "",
-			itemList: event.itemList || "",
-			noteHtml: note?.trim() ? marked.parse(note, { async: false }) : "",
+			itemListHtml: this.renderMarkdown(event.itemList),
+			noteHtml: this.renderMarkdown(note),
 			contactsLine: contactsLine.filter(Boolean).join(", "),
 		};
+	}
+
+	/** Renders a markdown field the same way the web does (`MarkdownPipe`), so the PDF matches the site. */
+	private renderMarkdown(markdown: string | null | undefined): string {
+		if (!markdown?.trim()) return "";
+		return marked.parse(markdown, { async: false, breaks: true });
 	}
 
 	private formatDate(date: string | null | undefined): string {


### PR DESCRIPTION
# Změny

 - Položka **Co s sebou** (`itemList`) se do vygenerované přihlášky vkládala jako holý text, takže markdown zůstal viditelný jako zdrojový kód (`- spacák`, `**pláštěnka**`). Nově se — stejně jako popis akce a poznámka — renderuje do HTML (`itemListHtml`).
 - Markdown se ve všech třech polích (popis, co s sebou, poznámka) renderuje s `breaks: true`, tedy stejně jako na webu (`MarkdownPipe`), aby PDF odpovídalo tomu, co je vidět na stránce akce. Tím zůstává zachované i dosavadní chování `white-space: pre-line` u víceřádkového textu psaného bez odrážek.
 - Ve všech čtyřech šablonách (turistická, sportovní, vodácká, výtvarný) je řádek přepsaný z `<p class="multiline">` na `<div class="item-list">`, aby do něj šel vložit blokový obsah (seznam). CSS drží krátký jednořádkový text vedle popisku „Co s sebou:" a seznam vysází pod něj.
 - README šablon doplněno o placeholdery `{{{itemListHtml}}}`, `{{{noteHtml}}}` a `{{price}}`.

Closes #337

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři akci, která má vyplněné **Co s sebou** markdownovými odrážkami (např. `- spacák`, `- karimatka`, `- **pláštěnka**`).
3. Vygeneruj přihlášku (tlačítko **Generovat**) v libovolné šabloně.
4. Zkontroluj, že v PDF je pod popiskem „Co s sebou:" opravdu odrážkový seznam a tučný text je tučný — nikoli text s hvězdičkami a pomlčkami.
5. Zkus i akci, kde je Co s sebou jen jeden krátký řádek — text má zůstat na stejném řádku hned za popiskem, jako dosud.
6. Ověř, že popis akce a poznámka zadaná při generování vypadají beze změny.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExStnhiJSVToYNyzrRtGxG)_