### PR TITLE
fix(feedback): odstranit název prostředí z názvu GitHub issue

### DIFF
--- a/backend/src/api/feedback/services/feedback.service.ts
+++ b/backend/src/api/feedback/services/feedback.service.ts
@@ -72,7 +72,7 @@ export class FeedbackService {
 
 		try {
 			const issue = await this.github.createIssue(this.config.github.bugReportRepo, {
-				title: this.issueTitle(title, this.config.app.environmentTitle),
+				title: title || "Nahlášená chyba",
 				body: this.issueBody(report, body),
 				labels: [this.config.github.bugReportLabel],
 			});
@@ -114,14 +114,5 @@ export class FeedbackService {
 			title: `${firstLine.slice(0, cut).trimEnd()}…`,
 			body: [`…${firstLine.slice(cut).trim()}`, otherLines].filter(Boolean).join("\n"),
 		};
-	}
-
-	/**
-	 * Non-production environments (ENV_TITLE set, e.g. "TEST") are prefixed so a report from
-	 * the testing environment is recognizable straight from the issue list.
-	 */
-	private issueTitle(title: string, environmentTitle: string): string {
-		const prefix = environmentTitle ? `[${environmentTitle}] ` : "";
-		return `${prefix}${title || "Nahlášená chyba"}`;
 	}
 }


### PR DESCRIPTION
# Změny

 - Nahlášená chyba se do GitHub issue už nezakládá s prefixem prostředí v hranatých závorkách (`[TEST] …`) — název issue je nyní jen první řádek popisu (nebo `Nahlášená chyba`, když je prázdný).
 - Odstraněna privátní metoda `issueTitle()` ve `FeedbackService`, která prefix skládala z `config.app.environmentTitle`. `environmentTitle` se jinde (frontend, `/api/root`) používá dál beze změny.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Nahlaš chybu přes formulář zpětné vazby.
3. Zkontroluj, že založené GitHub issue má v názvu pouze text z prvního řádku popisu, bez `[TEST]` na začátku.

---
_Generated by [Claude Code](https://claude.ai/code/session_012vL2LdfooLF75tWdKJ1VxY)_