### PR TITLE
feat(frontend): tlačítko aktualizace ukazuje cílovou verzi

### DIFF
--- a/frontend/src/app/shared/components/version/version.component.html
+++ b/frontend/src/app/shared/components/version/version.component.html
@@ -7,7 +7,13 @@
 		@if (updating()) {
 			<ion-spinner></ion-spinner>
 		} @else {
-			<a (click)="doUpdate()" class="clickable">Aktualizovat</a>
+			<a (click)="doUpdate()" class="clickable">
+				@if (newVersion(); as targetVersion) {
+					Aktualizovat na {{ targetVersion }}
+				} @else {
+					Aktualizovat
+				}
+			</a>
 		}
 	</p>
 }

--- a/frontend/src/app/shared/components/version/version.component.ts
+++ b/frontend/src/app/shared/components/version/version.component.ts
@@ -1,8 +1,9 @@
-import { Component, signal } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { Component, computed, signal } from "@angular/core";
+import { takeUntilDestroyed, toSignal } from "@angular/core/rxjs-interop";
 import { SwUpdate } from "@angular/service-worker";
 import { IonSpinner } from "@ionic/angular/standalone";
-import { filter } from "rxjs";
+import { filter, map } from "rxjs";
+import { ApiService } from "src/app/core/services/api.service";
 import { ModalService } from "src/app/core/services/modal.service";
 import { ChangelogModalComponent } from "src/app/shared/components/changelog-modal/changelog-modal.component";
 import { Config } from "src/config";
@@ -21,12 +22,26 @@ export class VersionComponent {
 	updateAvailable = signal(false);
 	updating = signal(false);
 
+	/**
+	 * Version the backend currently serves — always the one the app updates *to*, since the API is
+	 * refetched on tab focus while the loaded frontend keeps its build-time version.
+	 */
+	private readonly apiVersion = toSignal(
+		this.api.info.pipe(map((info) => info.version.replace(/^v(?=\d)/, ""))),
+	);
+
+	newVersion = computed(() => {
+		const apiVersion = this.apiVersion();
+		return apiVersion && apiVersion !== this.version ? apiVersion : null;
+	});
+
 	private updateCheck?: Promise<boolean>;
 
 	constructor(
 		private readonly config: Config,
 		private readonly swUpdate: SwUpdate,
 		private readonly modal: ModalService,
+		private readonly api: ApiService,
 	) {
 		this.swUpdate.versionUpdates
 			.pipe(


### PR DESCRIPTION
# Změny

 - Tlačítko aktualizace v patičce nově ukazuje **„Aktualizovat na X.X.X“** — verzi, na kterou se aplikace aktualizuje. Nad ním zůstává „Verze X.X.X“ s aktuálně načtenou verzí, takže je vidět z které na kterou.
 - Cílová verze se bere z `GET /api` (`RootResponse.version`), tedy z backendu, který je vždy aktuální. `ApiService.info` se navíc obnovuje při návratu na záložku, zatímco načtený frontend si drží svoji buildovou verzi.
 - Pokud verze z API chybí nebo se shoduje s načtenou, tlačítko zobrazí původní text „Aktualizovat“.

Closes #320

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že se aplikace chová beze změny, dokud není k dispozici nová verze.
3. Po nasazení novější verze (nebo při otevřené starší záložce) zkontroluj, že se v patičce objeví „Aktualizovat na X.X.X“ s číslem nové verze a že kliknutí aplikaci jako dřív aktualizuje a znovu načte.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_015qww96fVgj3XgM288WHyN9)_