### PR TITLE
style(program): odsaď obsah modalu tisku programu od okrajů

### DIFF
--- a/frontend/src/app/features/home/components/program-print-modal/program-print-modal.component.html
+++ b/frontend/src/app/features/home/components/program-print-modal/program-print-modal.component.html
@@ -1,6 +1,6 @@
 <bo-modal-layout>
 	<h4 slot="title">Tisk programu</h4>
-	<div class="mb-3">
+	<div class="options">
 		<bo-trimester-selector
 			labelPosition="floating"
 			[ngModel]="dateRange()"

--- a/frontend/src/app/features/home/components/program-print-modal/program-print-modal.component.scss
+++ b/frontend/src/app/features/home/components/program-print-modal/program-print-modal.component.scss
@@ -1,0 +1,8 @@
+.options {
+	padding: 0 16px 16px;
+
+	::ng-deep ion-item {
+		--padding-start: 0;
+		--inner-padding-end: 0;
+	}
+}


### PR DESCRIPTION
# Změny

 - Obsah modalu **Tisk programu** (výběr roku a trimestru) dostal `padding: 0 16px 16px` — dosud doléhal až na okraj dialogu, protože `bo-modal-layout` svému content slotu žádné odsazení nedává (stejně to řeší i changelog modal).
 - Zároveň se u polí uvnitř vynuluje vnitřní odsazení `ion-item` (`--padding-start`, `--inner-padding-end`), takže popisky „Rok“ a „Trimestr“ zůstávají zarovnané s nadpisem a tlačítky a odsazení se nesčítá.
 - Původní `mb-3` na wrapperu nahradilo `padding-bottom` ve stejné hodnotě, spodní mezera se tedy nemění.

Closes #343

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Na úvodní stránce přepni na záložku **Kalendář** a otevři **Tisk programu**.
3. Zkontroluj, že podtržení polí „Rok“ a „Trimestr“ končí kousek od okraje dialogu a nedoléhá do zaoblených rohů karty.
4. Zkontroluj, že popisky „Rok“ a „Trimestr“ jsou vlevo zarovnané s nadpisem „Tisk programu“ a s tlačítky dole.
5. Zkontroluj totéž na mobilu, kde se pole zalamují pod sebe.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_016K13yYnJZLxcfhQ5v4aVWR)_