### PR TITLE
feat(home): zobraz vlastní pořadí pod žebříčkem nejlepších vedoucích

### DIFF
--- a/backend/src/api/statistics/controllers/leaders-statistics.controller.ts
+++ b/backend/src/api/statistics/controllers/leaders-statistics.controller.ts
@@ -30,6 +30,7 @@ export class LeadersStatisticsController {
 		return this.statistics.getLeadersStatistics(
 			query.year ?? new Date().getFullYear(),
 			query.limit ?? DEFAULT_TOP_LEADERS_LIMIT,
+			req.user?.memberId,
 		);
 	}
 

--- a/backend/src/api/statistics/dto/top-leaders.dto.ts
+++ b/backend/src/api/statistics/dto/top-leaders.dto.ts
@@ -13,14 +13,12 @@ export class TopLeaderResponse {
 	/** How many events that score comes from. */
 	@ApiProperty() eventsCount!: number;
 
-	/** Place in the ranking; equal scores share a place and the next one skips ahead (1., 1., 3., …). */
 	@ApiProperty() rank!: number;
 
 	@ApiPropertyOptional({ type: "string" }) firstName?: string | null;
 	@ApiPropertyOptional({ type: "string" }) lastName?: string | null;
 }
 
-/** The caller's own place, which may be well below the shown top. */
 export class MyRankingResponse {
 	@ApiProperty() memberId!: number;
 	@ApiProperty() nickname!: string;
@@ -28,7 +26,6 @@ export class MyRankingResponse {
 	@ApiProperty() childDays!: number;
 	@ApiProperty() eventsCount!: number;
 
-	/** Missing when the member led no event with children that year, so they are not ranked at all. */
 	@ApiPropertyOptional({ type: "number" }) rank?: number | null;
 
 	@ApiPropertyOptional({ type: "string" }) firstName?: string | null;
@@ -47,7 +44,6 @@ export class TopLeadersResponse {
 
 	@ApiProperty({ type: TopLeaderResponse, isArray: true }) leaders!: TopLeaderResponse[];
 
-	/** Where the caller stands — missing when their user has no member of its own. */
 	@ApiPropertyOptional({ type: MyRankingResponse }) me?: MyRankingResponse;
 }
 

--- a/backend/src/api/statistics/dto/top-leaders.dto.ts
+++ b/backend/src/api/statistics/dto/top-leaders.dto.ts
@@ -13,6 +13,24 @@ export class TopLeaderResponse {
 	/** How many events that score comes from. */
 	@ApiProperty() eventsCount!: number;
 
+	/** Place in the ranking; equal scores share a place and the next one skips ahead (1., 1., 3., …). */
+	@ApiProperty() rank!: number;
+
+	@ApiPropertyOptional({ type: "string" }) firstName?: string | null;
+	@ApiPropertyOptional({ type: "string" }) lastName?: string | null;
+}
+
+/** The caller's own place, which may be well below the shown top. */
+export class MyRankingResponse {
+	@ApiProperty() memberId!: number;
+	@ApiProperty() nickname!: string;
+	@ApiProperty() groupId!: number;
+	@ApiProperty() childDays!: number;
+	@ApiProperty() eventsCount!: number;
+
+	/** Missing when the member led no event with children that year, so they are not ranked at all. */
+	@ApiPropertyOptional({ type: "number" }) rank?: number | null;
+
 	@ApiPropertyOptional({ type: "string" }) firstName?: string | null;
 	@ApiPropertyOptional({ type: "string" }) lastName?: string | null;
 }
@@ -28,6 +46,9 @@ export class TopLeadersResponse {
 	@ApiProperty() lastYear!: number;
 
 	@ApiProperty({ type: TopLeaderResponse, isArray: true }) leaders!: TopLeaderResponse[];
+
+	/** Where the caller stands — missing when their user has no member of its own. */
+	@ApiPropertyOptional({ type: MyRankingResponse }) me?: MyRankingResponse;
 }
 
 /** One of the events behind a leader's score, as shown when their row is opened. */

--- a/backend/src/models/statistics/services/leaders-statistics.service.ts
+++ b/backend/src/models/statistics/services/leaders-statistics.service.ts
@@ -30,7 +30,12 @@ export interface TopLeader {
 	childDays: number;
 	/** How many events that score comes from. */
 	eventsCount: number;
+	/** Place in the ranking; equal scores share a place and the next one skips ahead (1., 1., 3., …). */
+	rank: number;
 }
+
+/** The caller's own place, which may be outside the shown top — `rank` is null when they scored nothing. */
+export type MyRanking = Omit<TopLeader, "rank"> & { rank: number | null };
 
 export interface LeaderEvent {
 	eventId: number;
@@ -49,6 +54,8 @@ export interface LeadersStatistics {
 	firstYear: number;
 	lastYear: number;
 	leaders: TopLeader[];
+	/** Where the caller themselves stands, so the card can show it under the top. */
+	me?: MyRanking;
 }
 
 @Injectable()
@@ -56,20 +63,52 @@ export class LeadersStatisticsService {
 	constructor(
 		@InjectRepository(EventAttendee) private eventAttendeesRepository: Repository<EventAttendee>,
 		@InjectRepository(Event) private eventsRepository: Repository<Event>,
+		@InjectRepository(Member) private membersRepository: Repository<Member>,
 	) {}
 
 	/**
 	 * Everything the dashboard's leaders block shows for one year: the year's total děťodny, the
-	 * best leaders in it, and the range of years that have any data at all.
+	 * best leaders in it, the range of years that have any data at all, and — when the caller has a
+	 * member of their own — where that member stands.
 	 */
-	async getLeadersStatistics(year: number, limit: number): Promise<LeadersStatistics> {
-		const [childDays, leaders, { firstYear, lastYear }] = await Promise.all([
+	async getLeadersStatistics(year: number, limit: number, memberId?: number): Promise<LeadersStatistics> {
+		const [childDays, ranking, { firstYear, lastYear }] = await Promise.all([
 			this.getChildDays(year),
-			this.getTopLeaders(year, limit),
+			this.getRankedLeaders(year),
 			this.getYearRange(),
 		]);
 
-		return { year, childDays, firstYear, lastYear, leaders };
+		const leaders = ranking.slice(0, limit);
+		const me = memberId !== undefined ? await this.getMyRanking(ranking, memberId) : undefined;
+
+		return { year, childDays, firstYear, lastYear, leaders, me };
+	}
+
+	/**
+	 * The caller's own row, taken from the ranking they are already in. A member who led nothing that
+	 * year is not in it at all — they still get a row, with no place and a zero score, so the card can
+	 * show them what they are missing out on.
+	 */
+	private async getMyRanking(ranking: TopLeader[], memberId: number): Promise<MyRanking | undefined> {
+		const ranked = ranking.find((leader) => leader.memberId === memberId);
+		if (ranked) return ranked;
+
+		const member = await this.membersRepository.findOne({
+			where: { id: memberId },
+			select: { id: true, nickname: true, firstName: true, lastName: true, groupId: true },
+		});
+		if (!member) return undefined;
+
+		return {
+			memberId: member.id,
+			nickname: member.nickname,
+			firstName: member.firstName ?? null,
+			lastName: member.lastName ?? null,
+			groupId: member.groupId,
+			childDays: 0,
+			eventsCount: 0,
+			rank: null,
+		};
 	}
 
 	/**
@@ -77,8 +116,10 @@ export class LeadersStatisticsService {
 	 * number of child attendees multiplied by how many days it lasted, so a two-day event with three
 	 * children scores 6. Every leader of an event gets the full score, so co-leaders each score the
 	 * whole event.
+	 *
+	 * Returns the whole ranking rather than its top — the caller's own place can be anywhere in it.
 	 */
-	private async getTopLeaders(year: number, limit: number): Promise<TopLeader[]> {
+	private async getRankedLeaders(year: number): Promise<TopLeader[]> {
 		const childDays = `SUM(ec.children_count * ${EVENT_DAYS})`;
 
 		const rows = await this.eventAttendeesRepository
@@ -103,15 +144,33 @@ export class LeadersStatisticsService {
 			// depends on how the database happens to return the rows
 			.addOrderBy("COUNT(*)", "ASC")
 			.addOrderBy("m.nickname", "ASC")
-			.limit(limit)
-			.getRawMany<Omit<TopLeader, "childDays" | "eventsCount"> & { childDays: string; eventsCount: string }>();
+			.getRawMany<
+				Omit<TopLeader, "childDays" | "eventsCount" | "rank"> & { childDays: string; eventsCount: string }
+			>();
 
 		// SUM()/COUNT() come back as strings (Postgres bigint/numeric)
-		return rows.map((row) => ({
-			...row,
-			childDays: Number(row.childDays),
-			eventsCount: Number(row.eventsCount),
-		}));
+		return this.setRanks(
+			rows.map((row) => ({
+				...row,
+				childDays: Number(row.childDays),
+				eventsCount: Number(row.eventsCount),
+			})),
+		);
+	}
+
+	/** Leaders with the same score share a place, the next one skips ahead (1., 1., 3., …). */
+	private setRanks(leaders: Omit<TopLeader, "rank">[]): TopLeader[] {
+		let rank = 0;
+		let previousChildDays: number | undefined = undefined;
+
+		return leaders.map((leader, index) => {
+			if (leader.childDays !== previousChildDays) {
+				rank = index + 1;
+				previousChildDays = leader.childDays;
+			}
+
+			return { ...leader, rank };
+		});
 	}
 
 	/**

--- a/backend/src/models/statistics/services/leaders-statistics.service.ts
+++ b/backend/src/models/statistics/services/leaders-statistics.service.ts
@@ -30,11 +30,9 @@ export interface TopLeader {
 	childDays: number;
 	/** How many events that score comes from. */
 	eventsCount: number;
-	/** Place in the ranking; equal scores share a place and the next one skips ahead (1., 1., 3., …). */
 	rank: number;
 }
 
-/** The caller's own place, which may be outside the shown top — `rank` is null when they scored nothing. */
 export type MyRanking = Omit<TopLeader, "rank"> & { rank: number | null };
 
 export interface LeaderEvent {
@@ -54,7 +52,6 @@ export interface LeadersStatistics {
 	firstYear: number;
 	lastYear: number;
 	leaders: TopLeader[];
-	/** Where the caller themselves stands, so the card can show it under the top. */
 	me?: MyRanking;
 }
 
@@ -68,8 +65,7 @@ export class LeadersStatisticsService {
 
 	/**
 	 * Everything the dashboard's leaders block shows for one year: the year's total děťodny, the
-	 * best leaders in it, the range of years that have any data at all, and — when the caller has a
-	 * member of their own — where that member stands.
+	 * best leaders in it, and the range of years that have any data at all.
 	 */
 	async getLeadersStatistics(year: number, limit: number, memberId?: number): Promise<LeadersStatistics> {
 		const [childDays, ranking, { firstYear, lastYear }] = await Promise.all([
@@ -84,11 +80,6 @@ export class LeadersStatisticsService {
 		return { year, childDays, firstYear, lastYear, leaders, me };
 	}
 
-	/**
-	 * The caller's own row, taken from the ranking they are already in. A member who led nothing that
-	 * year is not in it at all — they still get a row, with no place and a zero score, so the card can
-	 * show them what they are missing out on.
-	 */
 	private async getMyRanking(ranking: TopLeader[], memberId: number): Promise<MyRanking | undefined> {
 		const ranked = ranking.find((leader) => leader.memberId === memberId);
 		if (ranked) return ranked;
@@ -116,8 +107,6 @@ export class LeadersStatisticsService {
 	 * number of child attendees multiplied by how many days it lasted, so a two-day event with three
 	 * children scores 6. Every leader of an event gets the full score, so co-leaders each score the
 	 * whole event.
-	 *
-	 * Returns the whole ranking rather than its top — the caller's own place can be anywhere in it.
 	 */
 	private async getRankedLeaders(year: number): Promise<TopLeader[]> {
 		const childDays = `SUM(ec.children_count * ${EVENT_DAYS})`;
@@ -158,7 +147,6 @@ export class LeadersStatisticsService {
 		);
 	}
 
-	/** Leaders with the same score share a place, the next one skips ahead (1., 1., 3., …). */
 	private setRanks(leaders: Omit<TopLeader, "rank">[]): TopLeader[] {
 		let rank = 0;
 		let previousChildDays: number | undefined = undefined;

--- a/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.html
+++ b/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.html
@@ -70,6 +70,28 @@
 								</div>
 							</ion-item>
 						}
+
+						@if (myRanking(); as me) {
+							@if (myRankingHasGap()) {
+								<div class="ranking-gap" aria-hidden="true">⋮</div>
+							}
+
+							<ion-item button class="my-ranking" [detail]="false" (click)="openLeaderEvents($event, me)">
+								<div class="rank" [class.rank-unranked]="!me.rank" slot="start">
+									{{ me.rank ? me.rank + "." : "–" }}
+								</div>
+								<ion-label>
+									<h4>
+										<strong>{{ me.nickname }}</strong>
+									</h4>
+									<p>{{ me.eventsCount }} {{ me.eventsCount | i18nPlural: eventsPluralMap }}</p>
+								</ion-label>
+								<div class="score" slot="end">
+									<span class="score-value">{{ me.childDays }}</span>
+									<span class="score-label">{{ me.childDays | i18nPlural: childDaysPluralMap }}</span>
+								</div>
+							</ion-item>
+						}
 					</ion-list>
 				} @else {
 					<p class="m-0 mt-2 mb-3 text-center">V tomto roce nikdo nevedl akci s dětmi.</p>

--- a/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.scss
+++ b/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.scss
@@ -93,6 +93,37 @@ ion-list {
 	font-size: 0.85rem;
 }
 
+// the ranks between the shown top and the user's own place, which are not listed
+.ranking-gap {
+	padding: 0.35rem 0;
+	color: var(--bo-muted);
+	font-family: var(--font-regular);
+	font-size: 1.5rem;
+	font-weight: 700;
+	line-height: 0.8;
+	text-align: center;
+}
+
+// the user's own row, set apart from the top so they find themselves at a glance
+.my-ranking {
+	--ion-item-background: var(--bo-blue-tint);
+	--border-radius: var(--bo-radius-btn);
+	--inner-border-width: 0;
+	--border-width: 0;
+	// the rows above end flush with the card, but here the score would touch the tinted edge
+	--inner-padding-end: 0.6rem;
+
+	.rank {
+		background-color: var(--bo-blue-mid);
+		color: #fff;
+	}
+}
+
+// no place yet — the brand font has no dash glyph, so the placeholder needs the text font
+.rank-unranked {
+	font-family: var(--font-regular);
+}
+
 .rank-first {
 	background-color: var(--bo-yellow);
 	color: #fff;

--- a/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.scss
+++ b/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.scss
@@ -93,7 +93,6 @@ ion-list {
 	font-size: 0.85rem;
 }
 
-// the ranks between the shown top and the user's own place, which are not listed
 .ranking-gap {
 	padding: 0.35rem 0;
 	color: var(--bo-muted);
@@ -104,13 +103,11 @@ ion-list {
 	text-align: center;
 }
 
-// the user's own row, set apart from the top so they find themselves at a glance
 .my-ranking {
 	--ion-item-background: var(--bo-blue-tint);
 	--border-radius: var(--bo-radius-btn);
 	--inner-border-width: 0;
 	--border-width: 0;
-	// the rows above end flush with the card, but here the score would touch the tinted edge
 	--inner-padding-end: 0.6rem;
 
 	.rank {
@@ -119,7 +116,6 @@ ion-list {
 	}
 }
 
-// no place yet — the brand font has no dash glyph, so the placeholder needs the text font
 .rank-unranked {
 	font-family: var(--font-regular);
 }

--- a/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.ts
+++ b/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.ts
@@ -14,7 +14,6 @@ import { SDK } from "src/sdk";
 /** How many leaders the ranking shows. */
 const TOP_LEADERS_LIMIT = 5;
 
-/** A row of the ranking — one of the top leaders, or the user's own place shown under them. */
 export type RankedLeader = SDK.TopLeaderResponse | SDK.MyRankingResponse;
 
 @Component({
@@ -44,10 +43,6 @@ export class HomeCardTopLeadersComponent {
 
 	year = signal(new Date().getFullYear());
 
-	/**
-	 * The user's own place, shown under the top when they did not make it into it — being 23rd is
-	 * the part of the ranking that is supposed to motivate.
-	 */
 	myRanking = computed(() => {
 		const statistics = this.statistics();
 		if (!statistics?.me) return undefined;
@@ -57,7 +52,6 @@ export class HomeCardTopLeadersComponent {
 		return inTop ? undefined : statistics.me;
 	});
 
-	/** Whether anybody at all is ranked between the shown top and the user's own row. */
 	myRankingHasGap = computed(() => {
 		const rank = this.myRanking()?.rank;
 		const lastShown = this.statistics()?.leaders.at(-1)?.rank;

--- a/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.ts
+++ b/frontend/src/app/features/home/components/home-card-top-leaders/home-card-top-leaders.component.ts
@@ -14,9 +14,8 @@ import { SDK } from "src/sdk";
 /** How many leaders the ranking shows. */
 const TOP_LEADERS_LIMIT = 5;
 
-export type RankedLeader = SDK.TopLeaderResponse & { rank: number };
-
-export type LeadersStatistics = Omit<SDK.TopLeadersResponse, "leaders"> & { leaders: RankedLeader[] };
+/** A row of the ranking — one of the top leaders, or the user's own place shown under them. */
+export type RankedLeader = SDK.TopLeaderResponse | SDK.MyRankingResponse;
 
 @Component({
 	selector: "bo-home-card-top-leaders",
@@ -41,9 +40,30 @@ export type LeadersStatistics = Omit<SDK.TopLeadersResponse, "leaders"> & { lead
 })
 export class HomeCardTopLeadersComponent {
 	/** `undefined` until the first response arrives, so the card can show its skeleton rows. */
-	statistics = signal<LeadersStatistics | undefined>(undefined);
+	statistics = signal<SDK.TopLeadersResponse | undefined>(undefined);
 
 	year = signal(new Date().getFullYear());
+
+	/**
+	 * The user's own place, shown under the top when they did not make it into it — being 23rd is
+	 * the part of the ranking that is supposed to motivate.
+	 */
+	myRanking = computed(() => {
+		const statistics = this.statistics();
+		if (!statistics?.me) return undefined;
+
+		const inTop = statistics.leaders.some((leader) => leader.memberId === statistics.me!.memberId);
+
+		return inTop ? undefined : statistics.me;
+	});
+
+	/** Whether anybody at all is ranked between the shown top and the user's own row. */
+	myRankingHasGap = computed(() => {
+		const rank = this.myRanking()?.rank;
+		const lastShown = this.statistics()?.leaders.at(-1)?.rank;
+
+		return rank == null || lastShown === undefined || rank > lastShown + 1;
+	});
 
 	/** The ranking is a leaders-only statistic — the root `_links` say whether this user may see it. */
 	canSeeLeaders = computed(() => this.api.links()?.getTopLeaders?.allowed ?? false);
@@ -120,21 +140,6 @@ export class HomeCardTopLeadersComponent {
 		// a slow response must not overwrite a year the user has already clicked past
 		if (this.year() !== year) return;
 
-		this.statistics.set({ ...statistics, leaders: this.setRanks(statistics.leaders) });
-	}
-
-	/** Leaders with the same score share a place, the next one skips ahead (1., 1., 3., …). */
-	private setRanks(leaders: SDK.TopLeaderResponse[]): RankedLeader[] {
-		let rank = 0;
-		let previousChildDays: number | undefined = undefined;
-
-		return leaders.map((leader, index) => {
-			if (leader.childDays !== previousChildDays) {
-				rank = index + 1;
-				previousChildDays = leader.childDays;
-			}
-
-			return { ...leader, rank };
-		});
+		this.statistics.set(statistics);
 	}
 }

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -3838,7 +3838,7 @@ export namespace SDK {
          */
         'eventsCount': number;
         /**
-         * Missing when the member led no event with children that year, so they are not ranked at all.
+         * 
          * @type {number}
          * @memberof MyRankingResponse
          */
@@ -4478,7 +4478,7 @@ export namespace SDK {
          */
         'eventsCount': number;
         /**
-         * Place in the ranking; equal scores share a place and the next one skips ahead (1., 1., 3., …).
+         * 
          * @type {number}
          * @memberof TopLeaderResponse
          */
@@ -4534,7 +4534,7 @@ export namespace SDK {
          */
         'leaders': Array<TopLeaderResponse>;
         /**
-         * Where the caller stands — missing when their user has no member of its own.
+         * 
          * @type {MyRankingResponse}
          * @memberof TopLeadersResponse
          */

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -3804,6 +3804,62 @@ export namespace SDK {
         /**
      * 
      * @export
+     * @interface MyRankingResponse
+     */
+    export interface MyRankingResponse {
+        /**
+         * 
+         * @type {number}
+         * @memberof MyRankingResponse
+         */
+        'memberId': number;
+        /**
+         * 
+         * @type {string}
+         * @memberof MyRankingResponse
+         */
+        'nickname': string;
+        /**
+         * 
+         * @type {number}
+         * @memberof MyRankingResponse
+         */
+        'groupId': number;
+        /**
+         * 
+         * @type {number}
+         * @memberof MyRankingResponse
+         */
+        'childDays': number;
+        /**
+         * 
+         * @type {number}
+         * @memberof MyRankingResponse
+         */
+        'eventsCount': number;
+        /**
+         * Missing when the member led no event with children that year, so they are not ranked at all.
+         * @type {number}
+         * @memberof MyRankingResponse
+         */
+        'rank'?: number | null;
+        /**
+         * 
+         * @type {string}
+         * @memberof MyRankingResponse
+         */
+        'firstName'?: string | null;
+        /**
+         * 
+         * @type {string}
+         * @memberof MyRankingResponse
+         */
+        'lastName'?: string | null;
+    }
+    
+        /**
+     * 
+     * @export
      * @interface PaddlersRankingResponse
      */
     export interface PaddlersRankingResponse {
@@ -4422,6 +4478,12 @@ export namespace SDK {
          */
         'eventsCount': number;
         /**
+         * Place in the ranking; equal scores share a place and the next one skips ahead (1., 1., 3., …).
+         * @type {number}
+         * @memberof TopLeaderResponse
+         */
+        'rank': number;
+        /**
          * 
          * @type {string}
          * @memberof TopLeaderResponse
@@ -4471,6 +4533,12 @@ export namespace SDK {
          * @memberof TopLeadersResponse
          */
         'leaders': Array<TopLeaderResponse>;
+        /**
+         * Where the caller stands — missing when their user has no member of its own.
+         * @type {MyRankingResponse}
+         * @memberof TopLeadersResponse
+         */
+        'me'?: MyRankingResponse;
     }
     
         /**


### PR DESCRIPTION
# Změny

 - Karta „Nejlepší vedoucí“ na hlavní stránce nově pod top 5 ukazuje i řádek přihlášeného vedoucího — jeho pořadí, počet akcí a děťodny.
 - Pokud je mezi poslední zobrazenou příčkou a vlastním pořadím ještě někdo další, oddělují řádky tři tečky (`⋮`). Když je vlastní pořadí hned následující, oddělovač se nezobrazuje.
 - Vedoucí, který v daném roce nevedl žádnou akci s dětmi, vidí svůj řádek s pomlčkou místo pořadí a nulovým skóre.
 - Vlastní řádek se dá rozkliknout stejně jako ostatní — otevře přehled akcí, ze kterých se skóre skládá.
 - Pořadí (včetně sdílených příček při shodném skóre) se nově počítá na backendu; frontend si ho už nedopočítává, protože místo mimo zobrazenou špičku odtud určit nelze.
 - `GET /api/statistics/leaders/top` proto vrací `rank` u každého vedoucího a nové pole `me` s pořadím volajícího; vygenerováno do SDK.

Closes #346

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že na hlavní stránce v kartě „Nejlepší vedoucí“ je pod pěti nejlepšími zvýrazněný řádek s tebou — pořadím, počtem akcí a děťodny.
3. Pokud jsi sám v top 5, žádný řádek navíc být nemá.
4. Klikni na svůj řádek — má se otevřít přehled tvých akcí a jejich děťodnů za daný rok.
5. Přepni šipkami na starší rok a zkontroluj, že se pořadí přepočítá (u roku bez tvých akcí se u tebe zobrazí pomlčka a 0 děťodní).

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYMMrk6jMj3wGBU9Kh8BrJ)_