### PR TITLE
chore(claude): vypiš očekávaný version tag po spuštění NEXT workflow

### DIFF
--- a/.claude/skills/release-next/SKILL.md
+++ b/.claude/skills/release-next/SKILL.md
@@ -17,4 +17,4 @@ mcp__github__actions_run_trigger
   ref: <output of `git rev-parse --abbrev-ref HEAD`>
 ```
 
-Then point the user at https://github.com/bosancz/interni-sekce/actions/workflows/release-next.yml and stop.
+Then print the expected version tag — `NEXT-` plus the current commit's short SHA (`git rev-parse --short=7 HEAD`), e.g. `NEXT-389fe80` — point the user at https://github.com/bosancz/interni-sekce/actions/workflows/release-next.yml and stop.

--- a/.claude/skills/release-next/SKILL.md
+++ b/.claude/skills/release-next/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash(git rev-parse:*), mcp__github__actions_run_trigger
 
 # Release current branch to NEXT
 
-Dispatch the workflow against the current branch and report the run link. Nothing else — no pre-checks, no watching the run.
+1. Dispatch the workflow against the current branch. Nothing else — no pre-checks, no watching the run.
 
 ```
 mcp__github__actions_run_trigger
@@ -17,4 +17,9 @@ mcp__github__actions_run_trigger
   ref: <output of `git rev-parse --abbrev-ref HEAD`>
 ```
 
-Then print the expected version tag — `NEXT-` plus the current commit's short SHA (`git rev-parse --short=7 HEAD`), e.g. `NEXT-389fe80` — point the user at https://github.com/bosancz/interni-sekce/actions/workflows/release-next.yml and stop.
+2. Print following three lines:
+* `Expected tag: NEXT-<git sha>` (use current commit's short SHA - `git rev-parse --short=7 HEAD`)
+* `Workflow: https://github.com/bosancz/interni-sekce/actions/workflows/release-next.yml`
+* `NEXT deployment: https://next.interni.bosan.cz`
+
+3. Stop.


### PR DESCRIPTION
Skill `release-next` nyní po spuštění workflow vypíše i očekávaný version tag: `NEXT-` + prvních 7 znaků hashe aktuálního commitu (`git rev-parse --short=7 HEAD`), např. `NEXT-389fe80` — stejně, jako ho sestavuje `.github/workflows/release-next.yml` z `GITHUB_SHA`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014tF7AYppPnQaLrXMfvkoQ4)_