### PR TITLE
feat(events): badge s počty na tabech detailu akce

### DIFF
--- a/frontend/src/app/features/events/components/event-accounting/event-accounting.component.ts
+++ b/frontend/src/app/features/events/components/event-accounting/event-accounting.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, effect, input, OnDestroy, OnInit, signal } from "@angular/core";
+import { Component, effect, input, OnDestroy, OnInit, output, signal } from "@angular/core";
 import { IonBadge, IonButton, IonList } from "@ionic/angular/standalone";
 import { UntilDestroy } from "@ngneat/until-destroy";
 import { ApiService } from "src/app/core/services/api.service";
@@ -42,6 +42,7 @@ import { EventExpensesChartComponent } from "../event-expenses-chart/event-expen
 })
 export class EventAccountingComponent implements OnInit, OnDestroy {
 	event = input<SDK.EventResponseWithLinks | undefined>();
+	count = output<number>();
 
 	expenses = signal<SDK.EventExpenseResponseWithLinks[]>([]);
 
@@ -59,6 +60,8 @@ export class EventAccountingComponent implements OnInit, OnDestroy {
 			const event = this.event();
 			if (event) this.loadExpenses();
 		});
+
+		effect(() => this.count.emit(this.expenses().length));
 	}
 
 	ngOnInit(): void {}

--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.html
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.html
@@ -51,14 +51,12 @@
 			</div>
 		}
 
-		@if (event() && event()!._links.getEventAnnouncement.allowed) {
-			@if ((attendees()!.length + leaders()!.length) !=0){
-				<div class="text-center">
-					<ion-button (click)="getAnnouncement(event()!)" expand="block" fill="outline">
-						Stáhnout ohlášku
-					</ion-button>
-				</div>
-			}
+		@if (event() && event()!._links.getEventAnnouncement.allowed && attendeesCount()) {
+			<div class="text-center">
+				<ion-button (click)="getAnnouncement(event()!)" expand="block" fill="outline">
+					Stáhnout ohlášku
+				</ion-button>
+			</div>
 		}
 	</div>
 </div>

--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
@@ -42,9 +42,17 @@ const LEADER_ROLES: SDK.MemberRolesEnum[] = [SDK.MemberRolesEnum.Instruktor, SDK
 export class EventAttendeesComponent implements OnInit, OnDestroy {
 	event = input<SDK.EventResponseWithLinks | null | undefined>();
 	change = output<void>();
+	count = output<number | undefined>();
 
 	attendees = signal<SDK.EventAttendeeResponseWithLinks[] | undefined>(undefined);
 	leaders = signal<SDK.EventAttendeeResponseWithLinks[] | undefined>(undefined);
+
+	attendeesCount = computed(() => {
+		const attendees = this.attendees();
+		const leaders = this.leaders();
+		if (attendees === undefined || leaders === undefined) return undefined;
+		return attendees.length + leaders.length;
+	});
 
 	allMembers = computed(() =>
 		[...(this.leaders() ?? []), ...(this.attendees() ?? [])]
@@ -65,6 +73,8 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 			const event = this.event();
 			this.loadAttendees(event);
 		});
+
+		effect(() => this.count.emit(this.attendeesCount()));
 	}
 
 	ngOnInit(): void {}

--- a/frontend/src/app/features/events/components/event-problems/event-problems.component.ts
+++ b/frontend/src/app/features/events/components/event-problems/event-problems.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, input, signal } from "@angular/core";
+import { Component, computed, effect, input, output, signal } from "@angular/core";
 import { IonIcon, IonList, IonSkeletonText } from "@ionic/angular/standalone";
 import { UntilDestroy } from "@ngneat/until-destroy";
 import { addIcons } from "ionicons";
@@ -29,6 +29,7 @@ interface HealthSummaryRow {
 })
 export class EventProblemsComponent {
 	event = input<SDK.EventResponseWithLinks | null | undefined>();
+	count = output<number | undefined>();
 
 	readonly severities = HealthSeverities;
 
@@ -37,12 +38,21 @@ export class EventProblemsComponent {
 	allergies = computed<HealthSummaryRow[] | undefined>(() => this.buildRows("allergies"));
 	problems = computed<HealthSummaryRow[] | undefined>(() => this.buildRows("knownProblems"));
 
+	problemsCount = computed(() => {
+		const allergies = this.allergies();
+		const problems = this.problems();
+		if (allergies === undefined || problems === undefined) return undefined;
+		return allergies.length + problems.length;
+	});
+
 	constructor(private api: ApiService) {
 		addIcons({ ellipse, alertCircle, warning, helpCircle });
 
 		effect(() => {
 			this.loadAttendees(this.event());
 		});
+
+		effect(() => this.count.emit(this.problemsCount()));
 	}
 
 	private async loadAttendees(event?: SDK.EventResponseWithLinks | null) {

--- a/frontend/src/app/features/events/pages/event-view/event-view.component.html
+++ b/frontend/src/app/features/events/pages/event-view/event-view.component.html
@@ -16,9 +16,25 @@
 		<div class="d-none d-lg-block" style="min-width: 200px">
 			<bo-vertical-menu defaultTab="info" (change)="view.set($any($event))">
 				<bo-vertical-menu-item name="info" label="Info" icon="calendar"></bo-vertical-menu-item>
-				<bo-vertical-menu-item name="attendees" label="Lidé" icon="people-outline"></bo-vertical-menu-item>
-				<bo-vertical-menu-item name="problems" label="Potíže" icon="medkit-outline"></bo-vertical-menu-item>
-				<bo-vertical-menu-item name="accounting" label="Výdaje" icon="cash-outline"></bo-vertical-menu-item>
+				<bo-vertical-menu-item
+					name="attendees"
+					label="Lidé"
+					icon="people-outline"
+					[badge]="attendeesBadge()"
+				></bo-vertical-menu-item>
+				<bo-vertical-menu-item
+					name="problems"
+					label="Potíže"
+					icon="medkit-outline"
+					[badge]="problemsBadge()"
+					badgeVariant="attention"
+				></bo-vertical-menu-item>
+				<bo-vertical-menu-item
+					name="accounting"
+					label="Výdaje"
+					icon="cash-outline"
+					[badge]="expensesBadge()"
+				></bo-vertical-menu-item>
 				<bo-vertical-menu-item name="report" label="Report" icon="document-outline"></bo-vertical-menu-item>
 			</bo-vertical-menu>
 		</div>
@@ -37,12 +53,14 @@
 				class="mb-5"
 				[class.d-none]="view() !== 'attendees'"
 				(change)="reloadEvent()"
+				(count)="attendeesCount.set($event)"
 			></bo-event-attendees>
 
 			<bo-event-problems
 				[event]="event()"
 				class="mb-5"
 				[class.d-none]="view() !== 'problems'"
+				(count)="problemsCount.set($event)"
 			></bo-event-problems>
 
 			<bo-event-accounting
@@ -50,6 +68,7 @@
 				class="mb-5"
 				[class.d-none]="view() !== 'accounting'"
 				(change)="reloadEvent()"
+				(count)="expensesCount.set($event)"
 			></bo-event-accounting>
 
 			<bo-event-report
@@ -66,9 +85,15 @@
 <bo-page-footer class="d-lg-none">
 	<bo-tabs defaultTab="info" (change)="view.set($any($event))">
 		<bo-tab name="info" label="Info" icon="calendar"></bo-tab>
-		<bo-tab name="attendees" label="Lidé" icon="people-outline"></bo-tab>
-		<bo-tab name="problems" label="Potíže" icon="medkit-outline"></bo-tab>
-		<bo-tab name="accounting" label="Výdaje" icon="cash-outline"></bo-tab>
+		<bo-tab name="attendees" label="Lidé" icon="people-outline" [badge]="attendeesBadge()"></bo-tab>
+		<bo-tab
+			name="problems"
+			label="Potíže"
+			icon="medkit-outline"
+			[badge]="problemsBadge()"
+			badgeVariant="attention"
+		></bo-tab>
+		<bo-tab name="accounting" label="Výdaje" icon="cash-outline" [badge]="expensesBadge()"></bo-tab>
 		<bo-tab name="report" label="Report" icon="document-outline"></bo-tab>
 	</bo-tabs>
 </bo-page-footer>

--- a/frontend/src/app/features/events/pages/event-view/event-view.component.ts
+++ b/frontend/src/app/features/events/pages/event-view/event-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from "@angular/core";
+import { Component, computed, signal } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { ViewWillEnter, ViewWillLeave } from "@ionic/angular/standalone";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -70,6 +70,14 @@ export class EventViewComponent implements ViewWillEnter, ViewWillLeave {
 	actions: Action[] = [];
 
 	view = signal<"info" | "attendees" | "problems" | "accounting" | "registration" | "report">("info");
+
+	attendeesCount = signal<number | undefined>(undefined);
+	problemsCount = signal<number | undefined>(undefined);
+	expensesCount = signal<number | undefined>(undefined);
+
+	attendeesBadge = computed(() => this.attendeesCount() || undefined);
+	problemsBadge = computed(() => this.problemsCount() || undefined);
+	expensesBadge = computed(() => this.expensesCount() || undefined);
 
 	constructor(
 		private readonly api: ApiService,

--- a/frontend/src/app/shared/components/tab/tab.component.html
+++ b/frontend/src/app/shared/components/tab/tab.component.html
@@ -3,7 +3,7 @@
 		<ion-icon [name]="icon()"></ion-icon>
 	}
 	<ion-label>{{ label() }}</ion-label>
-	@if (badge() || badgeColor()) {
-		<ion-badge [color]="badgeColor()">{{ badge() || "&nbsp;&nbsp;" }}</ion-badge>
+	@if (badge() !== undefined) {
+		<ion-badge [class.badge-attention]="badgeVariant() === 'attention'">{{ badge() }}</ion-badge>
 	}
 </ion-tab-button>

--- a/frontend/src/app/shared/components/tab/tab.component.scss
+++ b/frontend/src/app/shared/components/tab/tab.component.scss
@@ -2,6 +2,22 @@ ion-label {
 	font-family: var(--font-san);
 }
 
+ion-badge {
+	--background: var(--bo-neutral-badge);
+	--color: var(--bo-neutral-badge-text);
+	border-radius: var(--bo-radius-pill);
+	font-size: 0.65rem;
+	font-weight: 700;
+	padding: 0.3em 0.5em;
+	min-width: 1.7em;
+	text-align: center;
+
+	&.badge-attention {
+		--background: var(--san-yellow);
+		--color: #1f2430;
+	}
+}
+
 ion-tab-button {
 	--color: var(--bo-muted);
 	--color-selected: var(--bo-nav-active-fg);

--- a/frontend/src/app/shared/components/tab/tab.component.ts
+++ b/frontend/src/app/shared/components/tab/tab.component.ts
@@ -18,7 +18,7 @@ export class TabComponent implements OnInit {
 	disabled = input<boolean | undefined>();
 
 	badge = input<string | number | undefined>();
-	badgeColor = input<string | undefined>();
+	badgeVariant = input<"neutral" | "attention">("neutral");
 
 	active = signal(false);
 

--- a/frontend/src/app/shared/components/vertical-menu-item/vertical-menu-item.component.html
+++ b/frontend/src/app/shared/components/vertical-menu-item/vertical-menu-item.component.html
@@ -3,4 +3,7 @@
 		<ion-icon [name]="icon()!" class="me-3"></ion-icon>
 	}
 	<ion-label>{{ label() }}</ion-label>
+	@if (badge() !== undefined) {
+		<ion-badge slot="end" [class.badge-attention]="badgeVariant() === 'attention'">{{ badge() }}</ion-badge>
+	}
 </ion-item>

--- a/frontend/src/app/shared/components/vertical-menu-item/vertical-menu-item.component.scss
+++ b/frontend/src/app/shared/components/vertical-menu-item/vertical-menu-item.component.scss
@@ -16,3 +16,19 @@ ion-item {
 		font-weight: 800;
 	}
 }
+
+ion-badge {
+	--background: var(--bo-neutral-badge);
+	--color: var(--bo-neutral-badge-text);
+	border-radius: var(--bo-radius-pill);
+	font-size: 0.7rem;
+	font-weight: 700;
+	padding: 0.3em 0.6em;
+	min-width: 1.8em;
+	text-align: center;
+
+	&.badge-attention {
+		--background: var(--san-yellow);
+		--color: #1f2430;
+	}
+}

--- a/frontend/src/app/shared/components/vertical-menu-item/vertical-menu-item.component.ts
+++ b/frontend/src/app/shared/components/vertical-menu-item/vertical-menu-item.component.ts
@@ -1,17 +1,20 @@
 import { Component, computed, inject, input } from "@angular/core";
-import { IonIcon, IonItem, IonLabel } from "@ionic/angular/standalone";
+import { IonBadge, IonIcon, IonItem, IonLabel } from "@ionic/angular/standalone";
 import { VerticalMenuComponent } from "../vertical-menu/vertical-menu.component";
 
 @Component({
 	selector: "bo-vertical-menu-item",
 	templateUrl: "./vertical-menu-item.component.html",
 	styleUrls: ["./vertical-menu-item.component.scss"],
-	imports: [IonItem, IonLabel, IonIcon],
+	imports: [IonItem, IonLabel, IonIcon, IonBadge],
 })
 export class VerticalMenuItemComponent {
 	name = input.required<string>();
 	label = input.required<string>();
 	icon = input<string>();
+
+	badge = input<string | number | undefined>();
+	badgeVariant = input<"neutral" | "attention">("neutral");
 
 	menu = inject(VerticalMenuComponent);
 


### PR DESCRIPTION
# Změny

- Taby detailu akce nesou malé badge s počty — **Lidé** (vedoucí + účastníci), **Potíže** (alergie + další známé problémy) a **Výdaje** (počet účtenek). Zobrazují se na spodním tabbaru na mobilu i v levém menu na desktopu.
- Barevnost podle důležitosti: Lidé a Výdaje nevýrazně šedě (`--bo-neutral-badge`), Potíže žlutě, aby byly vidět na první pohled.
- Nulový počet se nezobrazuje, badge naskočí až když data dorazí ze serveru.
- Počty jdou z komponent, které data už načítají (`bo-event-attendees`, `bo-event-problems`, `bo-event-accounting`) přes nový výstup `count`, takže nepřibyly žádné další requesty. Badge se tím pádem přepočítá hned po přidání/odebrání účastníka nebo účtenky.
- Sdílené komponenty `bo-tab` a `bo-vertical-menu-item` dostaly vstupy `badge` a `badgeVariant` (`neutral` / `attention`); nepoužívaný vstup `badgeColor` na `bo-tab` byl nahrazen.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři detail akce, která má účastníky, a zkontroluj, že v levém menu (desktop) i ve spodním tabbaru (mobil) je u **Lidé** počet vedoucích a účastníků dohromady.
3. Zkontroluj, že u **Potíže** je žlutý badge s počtem alergií a dalších problémů účastníků a u **Výdaje** šedý badge s počtem účtenek.
4. Přidej nebo odeber účastníka a zkontroluj, že se počet u **Lidé** hned změní; totéž zkus s účtenkou ve **Výdajích**.
5. Otevři akci bez účastníků a bez účtenek a zkontroluj, že u tabů žádný badge není.
6. Přepni na tmavý režim a zkontroluj, že jsou badge čitelné.

 Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)

Closes #353

---
_Generated by [Claude Code](https://claude.ai/code/session_016EqL4RYGAAvFzjMU2hHeaE)_