### PR TITLE
feat(account): tlačítko pro otevření svého člena z Mého účtu

### DIFF
--- a/frontend/src/app/features/account/pages/account.component.html
+++ b/frontend/src/app/features/account/pages/account.component.html
@@ -112,6 +112,11 @@
 								Člen skupiny
 							</span>
 						</bo-card-title>
+						<ion-buttons slot="buttons">
+							@if (user.member; as member) {
+								<bo-card-open-button [routerLink]="['/databaze/clenove', member.id]" />
+							}
+						</ion-buttons>
 					</bo-card-header>
 					<bo-card-content>
 						@if (user.member; as member) {

--- a/frontend/src/app/features/account/pages/account.component.ts
+++ b/frontend/src/app/features/account/pages/account.component.ts
@@ -1,6 +1,7 @@
 import { Component } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import { IonIcon } from "@ionic/angular/standalone";
+import { RouterLink } from "@angular/router";
+import { IonButtons, IonIcon } from "@ionic/angular/standalone";
 import { addIcons } from "ionicons";
 import { mailOutline, peopleOutline } from "ionicons/icons";
 import { UserRoles } from "src/app/core/config/user-roles";
@@ -11,6 +12,7 @@ import { UserService } from "src/app/core/services/user.service";
 import { AvatarComponent } from "src/app/shared/components/avatar/avatar.component";
 import { CardContentComponent } from "src/app/shared/components/card-content/card-content.component";
 import { CardHeaderComponent } from "src/app/shared/components/card-header/card-header.component";
+import { CardOpenButtonComponent } from "src/app/shared/components/card-open-button/card-open-button.component";
 import { CardTitleComponent } from "src/app/shared/components/card-title/card-title.component";
 import { CardComponent } from "src/app/shared/components/card/card.component";
 import { EditButtonComponent } from "src/app/shared/components/edit-button/edit-button.component";
@@ -31,11 +33,14 @@ import { AccountCredentialsComponent } from "../components/account-credentials/a
 		PageHeaderComponent,
 		PageContentComponent,
 		IonIcon,
+		IonButtons,
+		RouterLink,
 		AvatarComponent,
 		CardComponent,
 		CardHeaderComponent,
 		CardTitleComponent,
 		CardContentComponent,
+		CardOpenButtonComponent,
 		AccountCredentialsComponent,
 		AccountAppComponent,
 		EditButtonComponent,


### PR DESCRIPTION
# Změny

 - Do hlavičky karty „Člen skupiny“ na stránce Můj účet přibylo tlačítko `bo-card-open-button`, které vede na detail vlastního člena (`/databaze/clenove/:id`) — stejný vzor, jaký už používá detail uživatele v administraci.
 - Tlačítko se zobrazuje jen tehdy, když je účet s členem spárovaný; u nespárovaného účtu karta vypadá jako dosud.

Closes #360

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Otevři stránku **Můj účet** (`/ucet`).
3. Zkontroluj, že v hlavičce karty **Člen skupiny** je vpravo šipka a že po kliknutí přejde na detail tvého člena v databázi.
4. Zkontroluj, že u účtu bez propojeného člena (např. servisní účet) se šipka nezobrazuje a karta dál hlásí „Nespárováno s členským účtem“.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ui5wTPoUv3wRRmGwkjhyhF)_