### PR TITLE
refactor(api)!: pojmenovat parametry cest podle entity místo id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,11 @@
 - Cancelled events stay in the feed as `STATUS:CANCELLED` with a `Zrušeno: ` summary prefix, mirroring the website. `UID` is `event-<id>@bosan.cz` — stable, so clients update instead of duplicating. The window is `ICAL_DAYS_BACK` (30) days back, unbounded forward; `EventsRepository.getPublicProgramIcal()` skips the 100-row cap the JSON program endpoint applies.
 - bosan.cz resolves the feed URL from the API root's `_links` (`program:ical`) in `CalendarSyncManualComponent`, falling back to the hardcoded URL — the hardcoded one going stale is what broke this in the first place (#352).
 
+## API routes & links
+
+- **Route parameters are named after their entity, never `id`** — `:eventId`, `:memberId`, `:contactId`, `:albumId`, `:photoId`, `:groupId`, `:userId`, `:expenseId`. The `Public API` controllers are the exception: their `:id` params are part of URLs bosan.cz already calls, so they stay. Renaming a param changes the generated SDK signature, so regenerate it (see *Frontend SDK*).
+- **`_links` hrefs are built by substituting `:param` from the document**, so a param named after the entity does not resolve from a doc that only has `id`. Each permission maps it with `params: { eventId: "id" },` — a `keyof DOC` property name, or a `(doc) => …` function when the value is not a plain property — applied to the **whole** href, controller prefix included. The older `path:` option cannot do this: it only replaces the *method* path, never the controller prefix, so on `@Controller("events/:eventId/expenses")` it left a literal `eventId` in the URL and, when it spelled the path out in full, duplicated the prefix (`/events/1/expenses/1/expenses/1`). Params the document genuinely does not know (`:memberId` on an event link, `:size` on a photo) stay literal by design.
+
 ## Backend entities
 
 - **One table, one entity mapping.** Never map a table twice (an explicit `@Entity("x")` *and* a `@ManyToMany`/`@JoinTable` over `"x"`): TypeORM builds two metadata objects for it and then **every** generated migration drops and recreates that table's indexes — permanent drift that survives being applied. `events_groups` was in this state for years; it is now mapped **only** by the `@ManyToMany`/`@JoinTable` on `Event.groups`, and must not get an entity of its own again.

--- a/backend/src/access-control/access-control-lib/decorators/ac-entity.decorator.ts
+++ b/backend/src/access-control/access-control-lib/decorators/ac-entity.decorator.ts
@@ -18,7 +18,7 @@ export function AcEntity(
 			: { ...entityOrOptions };
 
 	return (target: Object, propertyKey: string | symbol) => {
-		let entity = EntityStore.find((e) => e.entity === target);
+		let entity = EntityStore.find((e) => e.entity === target.constructor);
 
 		if (!entity) {
 			entity = {

--- a/backend/src/access-control/access-control-lib/interceptors/ac-links.interceptor.ts
+++ b/backend/src/access-control/access-control-lib/interceptors/ac-links.interceptor.ts
@@ -90,13 +90,24 @@ export class AcLinksInterceptor implements NestInterceptor {
 		if (typeof route.acl.options.path === "function") pathItems.push(String(route.acl.options.path(doc)));
 		else pathItems.push(<string>Reflect.getMetadata(MetadataConstant.routePath, route.handler));
 
+		const params = route.acl.options.params ?? {};
+
 		const path = pathItems
 			.map((item) => String(item).replace(/^\//, "").replace(/\/$/, ""))
 			.filter((item) => !!item)
 			.join("/")
-			.replace(/\:([a-zA-Z]+)/g, (match, param) => (param in doc ? doc[param] : param));
+			.replace(/\:([a-zA-Z]+)/g, (match, param) => this.resolveParam(param, doc, params));
 
 		return path;
+	}
+
+	private resolveParam(param: string, doc: any, params: { [param: string]: keyof any | ((doc: any) => string | number) }) {
+		const resolve = params[param];
+
+		if (typeof resolve === "function") return String(resolve(doc));
+		if (resolve !== undefined) return String(doc[resolve]);
+
+		return param in doc ? doc[param] : param;
 	}
 
 	private getControllerPath(route: RouteStoreItem) {

--- a/backend/src/access-control/access-control-lib/schema/ac-route-acl.ts
+++ b/backend/src/access-control/access-control-lib/schema/ac-route-acl.ts
@@ -19,6 +19,9 @@ export interface AcRouteOptions<DOC = void, ROLES extends string = string, PDATA
 	/** Global condition whether this route is accessible (e.g. is document in the state to perform this operation) */
 	applicable?: (params: { doc: DOC; req: Request }) => boolean;
 
+	/** Resolves route parameters of the linked route from the document when building the link href, either by property name or by function */
+	params?: { [param: string]: keyof DOC | ((doc: DOC) => string | number) };
+
 	path?: (d: DOC) => string;
 
 	name?: string;

--- a/backend/src/api/albums/acl/albums.acl.ts
+++ b/backend/src/api/albums/acl/albums.acl.ts
@@ -29,6 +29,7 @@ export const AlbumsDeletedListPermission = new Permission<void>({
 export const AlbumReadPermission = new Permission({
 	linkTo: AlbumResponse,
 	contains: AlbumResponse,
+	params: { albumId: "id" },
 
 	allowed: {
 		vedouci: true,
@@ -46,6 +47,7 @@ export const AlbumCreatePermission = new Permission<void>({
 
 export const AlbumEditPermission = new Permission({
 	linkTo: AlbumResponse,
+	params: { albumId: "id" },
 	allowed: {
 		vedouci: true,
 	},
@@ -54,6 +56,7 @@ export const AlbumEditPermission = new Permission({
 
 export const AlbumDeletePermission = new Permission({
 	linkTo: AlbumResponse,
+	params: { albumId: "id" },
 	allowed: {
 		// Only the album's creator may delete it; admin (implicit) may delete any album.
 		vedouci: ({ doc, req }) => doc.createdById !== null && doc.createdById === req.user?.userId,
@@ -63,6 +66,7 @@ export const AlbumDeletePermission = new Permission({
 
 export const AlbumRestorePermission = new Permission({
 	linkTo: AlbumResponse,
+	params: { albumId: "id" },
 	// Restore mirrors delete: only the album's creator may restore it; admin (implicit) any album.
 	allowed: {
 		vedouci: ({ doc, req }) => doc.createdById !== null && doc.createdById === req.user?.userId,
@@ -72,6 +76,7 @@ export const AlbumRestorePermission = new Permission({
 
 export const AlbumDeletePermanentPermission = new Permission({
 	linkTo: AlbumResponse,
+	params: { albumId: "id" },
 	// Permanent deletion is irreversible and reserved for admins only.
 	allowed: {
 		admin: true,
@@ -81,12 +86,14 @@ export const AlbumDeletePermanentPermission = new Permission({
 
 export const AlbumPublishPermission = new Permission({
 	linkTo: AlbumResponse,
+	params: { albumId: "id" },
 	inherit: AlbumEditPermission,
 	applicable: ({ doc }) => doc.status === "draft" && !doc.deletedAt,
 });
 
 export const AlbumUnpublishPermission = new Permission({
 	linkTo: AlbumResponse,
+	params: { albumId: "id" },
 
 	inherit: AlbumEditPermission,
 
@@ -95,12 +102,14 @@ export const AlbumUnpublishPermission = new Permission({
 
 export const AlbumReorderPhotosPermission = new Permission({
 	linkTo: AlbumResponse,
+	params: { albumId: "id" },
 	inherit: AlbumEditPermission,
 });
 
 export const AlbumPhotosPermission = new Permission({
 	linkTo: AlbumResponse,
 	contains: PhotoResponse,
+	params: { albumId: "id" },
 
 	allowed: {
 		vedouci: true,

--- a/backend/src/api/albums/acl/photo.acl.ts
+++ b/backend/src/api/albums/acl/photo.acl.ts
@@ -14,6 +14,7 @@ export const PhotosListPermission = new Permission<void>({
 export const PhotoReadPermission = new Permission({
 	linkTo: PhotoResponse,
 	contains: PhotoResponse,
+	params: { photoId: "id" },
 
 	allowed: {
 		vedouci: true,
@@ -30,6 +31,7 @@ export const PhotoCreatePermission = new Permission<void>({
 
 export const PhotoEditPermission = new Permission({
 	linkTo: PhotoResponse,
+	params: { photoId: "id" },
 	allowed: {
 		vedouci: true,
 	},
@@ -37,10 +39,12 @@ export const PhotoEditPermission = new Permission({
 
 export const PhotoDeletePermission = new Permission({
 	linkTo: PhotoResponse,
+	params: { photoId: "id" },
 	inherit: PhotoEditPermission,
 });
 
 export const PhotoReadFilePermission = new Permission({
 	linkTo: PhotoResponse,
+	params: { photoId: "id" },
 	inherit: PhotoReadPermission,
 });

--- a/backend/src/api/albums/controllers/albums.controller.ts
+++ b/backend/src/api/albums/controllers/albums.controller.ts
@@ -83,11 +83,11 @@ export class AlbumsController {
 		return this.albums.getAlbumsYears();
 	}
 
-	@Get(":id")
+	@Get(":albumId")
 	@AcLinks(AlbumReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(AlbumResponse) })
-	async getAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<AlbumResponse> {
-		const album = await this.albums.getAlbum(id, { event: true });
+	async getAlbum(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request): Promise<AlbumResponse> {
+		const album = await this.albums.getAlbum(albumId, { event: true });
 		if (!album) throw new NotFoundException();
 
 		AlbumReadPermission.canOrThrow(req, album);
@@ -95,11 +95,11 @@ export class AlbumsController {
 		return album;
 	}
 
-	@Patch(":id")
+	@Patch(":albumId")
 	@AcLinks(AlbumEditPermission)
 	@ApiResponse({ status: 204 })
-	async updateAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request, @Body() body: AlbumUpdateBody): Promise<void> {
-		const album = await this.albums.getAlbum(id);
+	async updateAlbum(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request, @Body() body: AlbumUpdateBody): Promise<void> {
+		const album = await this.albums.getAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumEditPermission.canOrThrow(req, album);
@@ -107,88 +107,88 @@ export class AlbumsController {
 		await this.albums.updateAlbum(album.id, body);
 	}
 
-	@Delete(":id")
+	@Delete(":albumId")
 	@AcLinks(AlbumDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const album = await this.albums.getAlbum(id);
+	async deleteAlbum(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request): Promise<void> {
+		const album = await this.albums.getAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumDeletePermission.canOrThrow(req, album);
 
-		await this.albums.deleteAlbum(id);
+		await this.albums.deleteAlbum(albumId);
 	}
 
-	@Post(":id/restore")
+	@Post(":albumId/restore")
 	@AcLinks(AlbumRestorePermission)
 	@ApiResponse({ status: 204 })
-	async restoreAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const album = await this.albums.getDeletedAlbum(id);
+	async restoreAlbum(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request): Promise<void> {
+		const album = await this.albums.getDeletedAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumRestorePermission.canOrThrow(req, album);
 
-		await this.albums.restoreAlbum(id);
+		await this.albums.restoreAlbum(albumId);
 	}
 
-	@Delete(":id/permanent")
+	@Delete(":albumId/permanent")
 	@AcLinks(AlbumDeletePermanentPermission)
 	@ApiResponse({ status: 204 })
-	async deleteAlbumPermanent(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const album = await this.albums.getDeletedAlbum(id);
+	async deleteAlbumPermanent(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request): Promise<void> {
+		const album = await this.albums.getDeletedAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumDeletePermanentPermission.canOrThrow(req, album);
 
 		// removes the photo rows and their image files on disk along with the album
-		await this.albums.hardDeleteAlbum(id);
+		await this.albums.hardDeleteAlbum(albumId);
 	}
 
-	@Post(":id/publish")
+	@Post(":albumId/publish")
 	@AcLinks(AlbumPublishPermission)
 	@ApiResponse({ status: 204 })
-	async publishAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const album = await this.albums.getAlbum(id);
+	async publishAlbum(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request): Promise<void> {
+		const album = await this.albums.getAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumPublishPermission.canOrThrow(req, album);
 
-		await this.albums.updateAlbum(id, { status: AlbumStatus.public, datePublished: DateTime.local().toISO() });
+		await this.albums.updateAlbum(albumId, { status: AlbumStatus.public, datePublished: DateTime.local().toISO() });
 	}
 
-	@Post(":id/unpublish")
+	@Post(":albumId/unpublish")
 	@AcLinks(AlbumUnpublishPermission)
 	@ApiResponse({ status: 204 })
-	async unpublishAlbum(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const album = await this.albums.getAlbum(id);
+	async unpublishAlbum(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request): Promise<void> {
+		const album = await this.albums.getAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumUnpublishPermission.canOrThrow(req, album);
 
-		await this.albums.updateAlbum(id, { status: AlbumStatus.draft, datePublished: null });
+		await this.albums.updateAlbum(albumId, { status: AlbumStatus.draft, datePublished: null });
 	}
 
-	@Get(":id/photos")
+	@Get(":albumId/photos")
 	@AcLinks(AlbumPhotosPermission)
 	@ApiResponse({ status: 200, type: WithLinks(PhotoResponse), isArray: true })
-	async getAlbumPhotos(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<PhotoResponse[]> {
-		const album = await this.albums.getAlbum(id);
+	async getAlbumPhotos(@Param("albumId", ParseIntPipe) albumId: number, @Req() req: Request): Promise<PhotoResponse[]> {
+		const album = await this.albums.getAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumPhotosPermission.canOrThrow(req, album);
 
-		return this.photos.getPhotos({ album: id });
+		return this.photos.getPhotos({ album: albumId });
 	}
 
-	@Patch(":id/photos/order")
+	@Patch(":albumId/photos/order")
 	@AcLinks(AlbumReorderPhotosPermission)
 	@ApiResponse({ status: 204 })
 	async reorderAlbumPhotos(
-		@Param("id", ParseIntPipe) id: number,
+		@Param("albumId", ParseIntPipe) albumId: number,
 		@Req() req: Request,
 		@Body() body: AlbumPhotosOrderBody,
 	): Promise<void> {
-		const album = await this.albums.getAlbum(id);
+		const album = await this.albums.getAlbum(albumId);
 		if (!album) throw new NotFoundException();
 
 		AlbumReorderPhotosPermission.canOrThrow(req, album);

--- a/backend/src/api/albums/controllers/photos.controller.ts
+++ b/backend/src/api/albums/controllers/photos.controller.ts
@@ -74,11 +74,11 @@ export class PhotosController {
 		return this.photos.createPhoto(body.albumId, file, req.user?.userId ?? null);
 	}
 
-	@Get(":id")
+	@Get(":photoId")
 	@AcLinks(PhotoReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(PhotoResponse) })
-	async getPhoto(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-		const photo = await this.photos.getPhoto(id);
+	async getPhoto(@Param("photoId", ParseIntPipe) photoId: number, @Req() req: Request) {
+		const photo = await this.photos.getPhoto(photoId);
 		if (!photo) throw new NotFoundException();
 
 		PhotoReadPermission.canOrThrow(req, photo);
@@ -86,11 +86,11 @@ export class PhotosController {
 		return photo;
 	}
 
-	@Patch(":id")
+	@Patch(":photoId")
 	@AcLinks(PhotoEditPermission)
 	@ApiResponse({ status: 204 })
-	async updatePhoto(@Param("id", ParseIntPipe) id: number, @Req() req: Request, @Body() body: PhotoUpdateBody): Promise<void> {
-		const photo = await this.photos.getPhoto(id);
+	async updatePhoto(@Param("photoId", ParseIntPipe) photoId: number, @Req() req: Request, @Body() body: PhotoUpdateBody): Promise<void> {
+		const photo = await this.photos.getPhoto(photoId);
 		if (!photo) throw new NotFoundException();
 
 		PhotoEditPermission.canOrThrow(req, photo);
@@ -98,11 +98,11 @@ export class PhotosController {
 		await this.photos.updatePhoto(photo.id, body);
 	}
 
-	@Delete(":id")
+	@Delete(":photoId")
 	@AcLinks(PhotoDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deletePhoto(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const photo = await this.photos.getPhoto(id);
+	async deletePhoto(@Param("photoId", ParseIntPipe) photoId: number, @Req() req: Request): Promise<void> {
+		const photo = await this.photos.getPhoto(photoId);
 		if (!photo) throw new NotFoundException();
 
 		PhotoDeletePermission.canOrThrow(req, photo);
@@ -110,17 +110,17 @@ export class PhotosController {
 		await this.photos.deletePhoto(photo.id);
 	}
 
-	@Get(":id/image/:size")
+	@Get(":photoId/image/:size")
 	@AcLinks(PhotoReadFilePermission)
 	async getPhotoImage(
-		@Param("id", ParseIntPipe) id: number,
+		@Param("photoId", ParseIntPipe) photoId: number,
 		@Param("size") size: PhotoSizes,
 		@Req() req: Request,
 		@Res() res: Response,
 	): Promise<void> {
 		if (!Object.values(PhotoSizes).includes(size)) throw new BadRequestException("Unknown image size.");
 
-		const photo = await this.photos.getPhoto(id);
+		const photo = await this.photos.getPhoto(photoId);
 		if (!photo) throw new NotFoundException();
 
 		PhotoReadFilePermission.canOrThrow(req, photo);

--- a/backend/src/api/events/acl/events.acl.ts
+++ b/backend/src/api/events/acl/events.acl.ts
@@ -45,6 +45,7 @@ export const EventsStatusesPermission = new Permission<void>({
 export const EventReadPermission = new Permission({
 	linkTo: EventResponse,
 	contains: EventResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		vedouci: true,
@@ -62,6 +63,7 @@ export const EventCreatePermission = new Permission<void>({
 
 export const EventEditPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		program: true,
@@ -73,6 +75,7 @@ export const EventEditPermission = new Permission({
 
 export const EventDeletePermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	allowed: {
 		program: true,
 	},
@@ -81,6 +84,7 @@ export const EventDeletePermission = new Permission({
 
 export const EventRestorePermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	allowed: {
 		program: true,
 	},
@@ -89,6 +93,7 @@ export const EventRestorePermission = new Permission({
 
 export const EventDeletePermanentPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	// Permanent deletion is irreversible and reserved for admins only.
 	allowed: {
 		admin: true,
@@ -98,6 +103,7 @@ export const EventDeletePermanentPermission = new Permission({
 
 export const EventLeadPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		vedouci: true,
@@ -108,6 +114,7 @@ export const EventLeadPermission = new Permission({
 
 export const EventSubmitPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
@@ -118,6 +125,7 @@ export const EventSubmitPermission = new Permission({
 
 export const EventPublishPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	allowed: {
 		program: true,
 	},
@@ -127,6 +135,7 @@ export const EventPublishPermission = new Permission({
 
 export const EventRejectPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	allowed: {
 		program: true,
 	},
@@ -135,6 +144,7 @@ export const EventRejectPermission = new Permission({
 
 export const EventUnpublishPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	allowed: {
 		program: true,
 	},
@@ -143,6 +153,7 @@ export const EventUnpublishPermission = new Permission({
 
 export const EventCancelPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	allowed: {
 		program: true,
 	},
@@ -151,6 +162,7 @@ export const EventCancelPermission = new Permission({
 
 export const EventUncancelPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 	allowed: {
 		program: true,
 	},
@@ -159,6 +171,7 @@ export const EventUncancelPermission = new Permission({
 
 export const EventRegistrationReadPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	inherit: EventEditPermission,
 	applicable: ({ doc }) => doc.hasRegistration
@@ -166,12 +179,14 @@ export const EventRegistrationReadPermission = new Permission({
 
 export const EventRegistrationEditPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	inherit: EventEditPermission,
 });
 
 export const EventRegistrationGeneratePermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	inherit: EventEditPermission,
 	// The form prints the leader's name, phone and email — with no leader there is nothing to
@@ -181,6 +196,7 @@ export const EventRegistrationGeneratePermission = new Permission({
 
 export const EventRegistrationDeletePermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	inherit: EventEditPermission,
 	applicable: ({ doc }) => doc.hasRegistration
@@ -188,6 +204,7 @@ export const EventRegistrationDeletePermission = new Permission({
 
 export const EventReportReadPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	inherit: EventReadPermission,
 });
@@ -200,6 +217,7 @@ export const EventReportEditPermission = new Permission({
 
 export const EventAnnouncementGetPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		revizor: true,
@@ -209,6 +227,7 @@ export const EventAnnouncementGetPermission = new Permission({
 
 export const EventAccountingGetPermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		revizor: true,
@@ -219,10 +238,9 @@ export const EventAccountingGetPermission = new Permission({
 export const EventExpensesListPermission = new Permission({
 	linkTo: EventResponse,
 	contains: EventExpenseResponse,
+	params: { eventId: "id" },
 
 	inherit: EventReadPermission,
-
-	path: (e) => `${e.id}/attendees`,
 });
 
 export const EventExpenseReadPermission = new Permission({
@@ -235,6 +253,7 @@ export const EventExpenseReadPermission = new Permission({
 export const EventExpenseCreatePermission = new Permission({
 	linkTo: EventResponse,
 	contains: EventExpenseResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
@@ -243,27 +262,25 @@ export const EventExpenseCreatePermission = new Permission({
 
 export const EventExpenseEditPermission = new Permission({
 	linkTo: EventExpenseResponse,
+	params: { expenseId: "id" },
 
 	allowed: {
 		vedouci: ({ doc, req }) => isMyEvent(doc.event, req),
 	},
-
-	path: (d) => `${d.eventId}/expenses/${d.id}`,
 });
 
 export const EventExpenseDeletePermission = new Permission({
 	linkTo: EventExpenseResponse,
-	path: (d) => `${d.eventId}/expenses/${d.id}`,
+	params: { expenseId: "id" },
 	inherit: EventExpenseEditPermission,
 });
 
 export const EventAttendeesListPermission = new Permission({
 	linkTo: EventResponse,
 	contains: EventAttendeeResponse,
+	params: { eventId: "id" },
 
 	inherit: EventReadPermission,
-
-	path: (e) => `${e.id}/attendees`,
 });
 
 export const EventAttendeeReadPermission = new Permission({
@@ -275,6 +292,7 @@ export const EventAttendeeReadPermission = new Permission({
 
 export const EventAttendeeCreatePermission = new Permission({
 	linkTo: EventResponse,
+	params: { eventId: "id" },
 
 	allowed: {
 		vedouci: ({ doc, req }) => isMyEvent(doc, req),
@@ -287,12 +305,9 @@ export const EventAttendeeEditPermission = new Permission({
 	allowed: {
 		vedouci: ({ doc, req }) => isMyEvent(doc.event, req),
 	},
-
-	path: (d) => `${d.eventId}/attendees/${d.memberId}`,
 });
 
 export const EventAttendeeDeletePermission = new Permission({
 	linkTo: EventAttendeeResponse,
-	path: (e) => `${e.eventId}/attendees/${e.memberId}`,
 	inherit: EventAttendeeEditPermission,
 });

--- a/backend/src/api/events/controllers/events-accounting.controller.ts
+++ b/backend/src/api/events/controllers/events-accounting.controller.ts
@@ -21,19 +21,19 @@ export class EventsAccountingController {
 		private readonly eventAccountingService: EventAccountingService,
 	) {}
 
-	@Get(":id/accounting")
+	@Get(":eventId/accounting")
 	@HttpCode(200)
 	@AcLinks(EventAccountingGetPermission)
 	@ApiResponse({ status: 200 })
 	async getEventAccounting(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Res({ passthrough: true }) res: Response,
 	): Promise<StreamableFile> {
-		//const event = await this.events.getEvent(id);
+		//const event = await this.events.getEvent(eventId);
 
 		const event = await this.eventsRepository.findOne({
-			where: { id: id },
+			where: { id: eventId },
 			relations: { attendees: { member: { contacts: true } }, expenses: true }, // Important: load nested member relation
 		});
 

--- a/backend/src/api/events/controllers/events-announcement.controller.ts
+++ b/backend/src/api/events/controllers/events-announcement.controller.ts
@@ -21,19 +21,19 @@ export class EventsAnnouncementController {
 		private readonly eventAnnouncementService: EventAnnouncementService,
 	) {}
 
-	@Get(":id/announcement")
+	@Get(":eventId/announcement")
 	@HttpCode(200)
 	@AcLinks(EventAnnouncementGetPermission)
 	@ApiResponse({ status: 200 })
 	async getEventAnnouncement(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Res({ passthrough: true }) res: Response,
 	): Promise<StreamableFile> {
-		//const event = await this.events.getEvent(id);
+		//const event = await this.events.getEvent(eventId);
 
 		const event = await this.eventsRepository.findOne({
-			where: { id: id },
+			where: { id: eventId },
 			relations: { attendees: { member: { contacts: true } } }, // Important: load nested member relation
 		});
 

--- a/backend/src/api/events/controllers/events-registrations.controller.ts
+++ b/backend/src/api/events/controllers/events-registrations.controller.ts
@@ -92,10 +92,10 @@ export class EventsRegistrationsController {
 		await this.eventsRepository.update(event.id, { hasRegistration: true });
 	}
 
-	@Get(":id/registration")
+	@Get(":eventId/registration")
 	@AcLinks(EventRegistrationReadPermission)
-	async getEventRegistration(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Res() res: Response): Promise<void> {
-		const event = await this.events.getEvent(id);
+	async getEventRegistration(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number, @Res() res: Response): Promise<void> {
+		const event = await this.events.getEvent(eventId);
 		if (!event) throw new NotFoundException();
 		EventRegistrationReadPermission.canOrThrow(req, event);
 
@@ -125,7 +125,7 @@ export class EventsRegistrationsController {
 	}
 
 
-	@Put(":id/registration")
+	@Put(":eventId/registration")
 	@HttpCode(204)
 	@AcLinks(EventRegistrationEditPermission)
 	@ApiResponse({ status: 204 })
@@ -144,9 +144,9 @@ export class EventsRegistrationsController {
 	})
 	async saveEventRegistration(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@UploadedFile() registration: Express.Multer.File): Promise<void> {
-			const event = await this.events.getEvent(id);
+			const event = await this.events.getEvent(eventId);
 			if (!event) throw new NotFoundException();
 
 			EventRegistrationEditPermission.canOrThrow(req, event);
@@ -162,11 +162,11 @@ export class EventsRegistrationsController {
 			await this.storeRegistration(event, data);
 		}
 
-	@Get(":id/registration/templates")
+	@Get(":eventId/registration/templates")
 	@AcLinks(EventRegistrationGeneratePermission)
 	@ApiResponse({ status: 200, type: [RegistrationTemplateResponse] })
-	async getEventRegistrationTemplates(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<RegistrationTemplateResponse[]> {
-		const event = await this.events.getEvent(id);
+	async getEventRegistrationTemplates(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<RegistrationTemplateResponse[]> {
+		const event = await this.events.getEvent(eventId);
 		if (!event) throw new NotFoundException();
 
 		EventRegistrationGeneratePermission.canOrThrow(req, event);
@@ -174,7 +174,7 @@ export class EventsRegistrationsController {
 		return this.eventRegistrationService.listTemplates();
 	}
 
-	@Post(":id/registration/generate")
+	@Post(":eventId/registration/generate")
 	@HttpCode(204)
 	@AcLinks(EventRegistrationGeneratePermission)
 	@ApiResponse({ status: 204 })
@@ -183,14 +183,14 @@ export class EventsRegistrationsController {
 	@ApiQuery({ name: "note", required: false })
 	async generateEventRegistration(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Query("template") template: string,
 		@Query("color") color: string,
 		@Query("note") note?: string,
 	): Promise<void> {
 		// Load attendees with member contacts so the generated form can list organisers and their contacts.
 		const event = await this.eventsRepository.findOne({
-			where: { id },
+			where: { id: eventId },
 			relations: { attendees: { member: { contacts: true } } },
 		});
 		if (!event) throw new NotFoundException();
@@ -201,10 +201,10 @@ export class EventsRegistrationsController {
 		await this.storeRegistration(event, data);
 	}
 
-	@Delete(":id/registration")
+	@Delete(":eventId/registration")
 	@AcLinks(EventRegistrationDeletePermission)
-	async deleteEventRegistration(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
-		const event = await this.events.getEvent(id);
+	async deleteEventRegistration(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<void> {
+		const event = await this.events.getEvent(eventId);
 		if (!event) throw new NotFoundException();
 		EventRegistrationDeletePermission.canOrThrow(req, event);
 		const registrationFolder = this.registrationFolder(event);

--- a/backend/src/api/events/controllers/events-reports.controller.ts
+++ b/backend/src/api/events/controllers/events-reports.controller.ts
@@ -19,12 +19,12 @@ export class EventsReportsController {
 		@InjectRepository(Event) private eventsRepository: Repository<Event>,
 	) {}
 
-	@Get(":id/report")
+	@Get(":eventId/report")
 	@HttpCode(204)
 	@AcLinks(EventReportReadPermission)
 	@ApiResponse({ status: 204 })
-	async getEventReport(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
-		const event = await this.events.getEvent(id);
+	async getEventReport(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<void> {
+		const event = await this.events.getEvent(eventId);
 		if (!event) throw new NotFoundException();
 
 		EventReportReadPermission.canOrThrow(req, event);

--- a/backend/src/api/events/controllers/events.controller.ts
+++ b/backend/src/api/events/controllers/events.controller.ts
@@ -122,11 +122,11 @@ export class EventsController {
 		return this.events.getEventsStatuses();
 	}
 
-	@Get(":id")
+	@Get(":eventId")
 	@AcLinks(EventReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(EventResponse) })
-	async getEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<EventResponse> {
-		const event = await this.events.getEvent(id, { leaders: true });
+	async getEvent(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<EventResponse> {
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventReadPermission.canOrThrow(req, event);
@@ -134,12 +134,12 @@ export class EventsController {
 		return event;
 	}
 
-	@Patch(":id")
+	@Patch(":eventId")
 	@HttpCode(204)
 	@AcLinks(EventEditPermission)
 	@ApiResponse({ status: 204 })
-	async updateEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Body() body: EventUpdateBody): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+	async updateEvent(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number, @Body() body: EventUpdateBody): Promise<void> {
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventEditPermission.canOrThrow(req, event);
@@ -155,162 +155,162 @@ export class EventsController {
 			placeGeometry,
 		};
 
-		await this.events.updateEvent(id, updateData);
+		await this.events.updateEvent(eventId, updateData);
 	}
 
-	@Delete(":id")
+	@Delete(":eventId")
 	@HttpCode(204)
 	@AcLinks(EventDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+	async deleteEvent(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<void> {
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventDeletePermission.canOrThrow(req, event);
 
-		return this.events.deleteEvent(id);
+		return this.events.deleteEvent(eventId);
 	}
 
-	@Post(":id/restore")
+	@Post(":eventId/restore")
 	@HttpCode(204)
 	@AcLinks(EventRestorePermission)
 	@ApiResponse({ status: 204 })
-	async restoreEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+	async restoreEvent(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<void> {
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventRestorePermission.canOrThrow(req, event);
 
-		return this.events.restoreEvent(id);
+		return this.events.restoreEvent(eventId);
 	}
 
-	@Delete(":id/permanent")
+	@Delete(":eventId/permanent")
 	@HttpCode(204)
 	@AcLinks(EventDeletePermanentPermission)
 	@ApiResponse({ status: 204 })
-	async deleteEventPermanent(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+	async deleteEventPermanent(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number): Promise<void> {
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventDeletePermanentPermission.canOrThrow(req, event);
 
-		return this.events.hardDeleteEvent(id);
+		return this.events.hardDeleteEvent(eventId);
 	}
 
-	@Post(":id/lead")
+	@Post(":eventId/lead")
 	@HttpCode(204)
 	@AcLinks(EventLeadPermission)
 	@ApiResponse({ status: 204 })
-	async leadEvent(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @AuthUser() authUser: SessionUser): Promise<void> {
+	async leadEvent(@Req() req: Request, @Param("eventId", ParseIntPipe) eventId: number, @AuthUser() authUser: SessionUser): Promise<void> {
 		if (authUser.memberId === undefined) throw new ConflictException("User is not linked to a member.");
 
-		const event = await this.events.getEvent(id, { leaders: true });
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventLeadPermission.canOrThrow(req, event);
 
-		await this.events.createEventAttendee(id, authUser.memberId, { type: EventAttendeeType.leader });
+		await this.events.createEventAttendee(eventId, authUser.memberId, { type: EventAttendeeType.leader });
 	}
 
-	@Post(":id/submit")
+	@Post(":eventId/submit")
 	@HttpCode(204)
 	@AcLinks(EventSubmitPermission)
 	@ApiResponse({ status: 204 })
 	async submitEvent(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventSubmitPermission.canOrThrow(req, event);
 
-		await this.events.updateEvent(id, { status: EventStates.pending, statusNote: body.statusNote });
+		await this.events.updateEvent(eventId, { status: EventStates.pending, statusNote: body.statusNote });
 	}
 
-	@Post(":id/reject")
+	@Post(":eventId/reject")
 	@HttpCode(204)
 	@AcLinks(EventRejectPermission)
 	@ApiResponse({ status: 204 })
 	async rejectEvent(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventRejectPermission.canOrThrow(req, event);
 
-		await this.events.updateEvent(id, { status: EventStates.draft, statusNote: body.statusNote });
+		await this.events.updateEvent(eventId, { status: EventStates.draft, statusNote: body.statusNote });
 	}
 
-	@Post(":id/publish")
+	@Post(":eventId/publish")
 	@HttpCode(204)
 	@AcLinks(EventPublishPermission)
 	@ApiResponse({ status: 204 })
 	async publishEvent(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventPublishPermission.canOrThrow(req, event);
 
-		await this.events.updateEvent(id, { status: EventStates.public, statusNote: body.statusNote });
+		await this.events.updateEvent(eventId, { status: EventStates.public, statusNote: body.statusNote });
 	}
 
-	@Post(":id/unpublish")
+	@Post(":eventId/unpublish")
 	@HttpCode(204)
 	@AcLinks(EventUnpublishPermission)
 	@ApiResponse({ status: 204 })
 	async unpublishEvent(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventUnpublishPermission.canOrThrow(req, event);
 
-		await this.events.updateEvent(id, { status: EventStates.draft, statusNote: body.statusNote });
+		await this.events.updateEvent(eventId, { status: EventStates.draft, statusNote: body.statusNote });
 	}
 
-	@Post(":id/cancel")
+	@Post(":eventId/cancel")
 	@HttpCode(204)
 	@AcLinks(EventCancelPermission)
 	@ApiResponse({ status: 204 })
 	async cancelEvent(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventCancelPermission.canOrThrow(req, event);
 
-		await this.events.updateEvent(id, { status: EventStates.cancelled, statusNote: body.statusNote });
+		await this.events.updateEvent(eventId, { status: EventStates.cancelled, statusNote: body.statusNote });
 	}
 
-	@Post(":id/uncancel")
+	@Post(":eventId/uncancel")
 	@HttpCode(204)
 	@AcLinks(EventUncancelPermission)
 	@ApiResponse({ status: 204 })
 	async uncancelEvent(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("eventId", ParseIntPipe) eventId: number,
 		@Body() body: EventStatusChangeBody,
 	): Promise<void> {
-		const event = await this.events.getEvent(id, { leaders: true });
+		const event = await this.events.getEvent(eventId, { leaders: true });
 		if (!event) throw new NotFoundException();
 
 		EventUncancelPermission.canOrThrow(req, event);
 
-		await this.events.updateEvent(id, { status: EventStates.public, statusNote: body.statusNote });
+		await this.events.updateEvent(eventId, { status: EventStates.public, statusNote: body.statusNote });
 	}
 }

--- a/backend/src/api/members/acl/groups.acl.ts
+++ b/backend/src/api/members/acl/groups.acl.ts
@@ -19,6 +19,7 @@ export const GroupCreatePermission = new Permission<void>({
 export const GroupReadPermission = new Permission({
 	linkTo: GroupResponse,
 	contains: GroupResponse,
+	params: { groupId: "id" },
 
 	allowed: {
 		vedouci: true,
@@ -27,22 +28,26 @@ export const GroupReadPermission = new Permission({
 
 export const GroupEditPermission = new Permission({
 	linkTo: GroupResponse,
+	params: { groupId: "id" },
 });
 
 export const GroupDeletePermission = new Permission({
 	linkTo: GroupResponse,
+	params: { groupId: "id" },
 
 	applicable: ({ doc }) => !doc.deletedAt,
 });
 
 export const GroupRestorePermission = new Permission({
 	linkTo: GroupResponse,
+	params: { groupId: "id" },
 
 	applicable: ({ doc }) => !!doc.deletedAt,
 });
 
 export const GroupPermanentDeletePermission = new Permission({
 	linkTo: GroupResponse,
+	params: { groupId: "id" },
 
 	applicable: ({ doc }) => !!doc.deletedAt,
 });

--- a/backend/src/api/members/acl/member-contacts.acl.ts
+++ b/backend/src/api/members/acl/member-contacts.acl.ts
@@ -6,12 +6,14 @@ import { MemberReadPermission, MemberUpdatePermission } from "./members.acl";
 export const MemberContactsListPermission = new Permission({
 	linkTo: MemberResponse,
 	contains: MemberContactResponse,
+	params: { memberId: "id" },
 	inherit: MemberReadPermission,
 });
 
 export const MemberContactsCreatePermission = new Permission({
 	linkTo: MemberResponse,
 	contains: MemberContactResponse,
+	params: { memberId: "id" },
 	inherit: MemberUpdatePermission,
 });
 
@@ -23,5 +25,6 @@ export const MemberContactsUpdatePermission = new Permission({
 
 export const MemberContactsDeletePermission = new Permission({
 	linkTo: MemberContactResponse,
+	params: { contactId: "id" },
 	allowed: { vedouci: true },
 });

--- a/backend/src/api/members/acl/member-insurance-card.acl.ts
+++ b/backend/src/api/members/acl/member-insurance-card.acl.ts
@@ -4,17 +4,20 @@ import { MemberReadPermission, MemberUpdatePermission } from "./members.acl";
 
 export const MemberInsuranceCardReadPermission = new Permission({
 	linkTo: MemberResponse,
+	params: { memberId: "id" },
 	inherit: MemberReadPermission,
 	applicable: ({ doc }) => !!doc.insuranceCardFile,
 });
 
 export const MemberInsuranceCardUploadPermission = new Permission({
 	linkTo: MemberResponse,
+	params: { memberId: "id" },
 	inherit: MemberUpdatePermission,
 });
 
 export const MemberInsuranceCardDeletePermission = new Permission<MemberResponse>({
 	linkTo: MemberResponse,
+	params: { memberId: "id" },
 	inherit: MemberUpdatePermission,
 	applicable: ({ doc }) => !!doc.insuranceCardFile,
 });

--- a/backend/src/api/members/acl/members.acl.ts
+++ b/backend/src/api/members/acl/members.acl.ts
@@ -35,6 +35,7 @@ export const MemberCreatePermission = new Permission<void>({
 export const MemberReadPermission = new Permission({
 	linkTo: MemberResponse,
 	contains: MemberResponse,
+	params: { memberId: "id" },
 
 	allowed: {
 		vedouci: true,
@@ -43,6 +44,7 @@ export const MemberReadPermission = new Permission({
 
 export const MemberUpdatePermission = new Permission({
 	linkTo: MemberResponse,
+	params: { memberId: "id" },
 	allowed: {
 		vedouci: true,
 	},
@@ -50,6 +52,7 @@ export const MemberUpdatePermission = new Permission({
 
 export const MemberDeletePermission = new Permission({
 	linkTo: MemberResponse,
+	params: { memberId: "id" },
 	allowed: {
 		// A leader may delete only members of their own group; admin (implicit) may delete anyone.
 		vedouci: ({ doc, req }) => req.user?.memberGroupId !== undefined && doc.groupId === req.user.memberGroupId,
@@ -59,6 +62,7 @@ export const MemberDeletePermission = new Permission({
 
 export const MemberRestorePermission = new Permission({
 	linkTo: MemberResponse,
+	params: { memberId: "id" },
 	// Restore mirrors delete: a leader may restore only members of their own group; admin anyone.
 	allowed: {
 		vedouci: ({ doc, req }) => req.user?.memberGroupId !== undefined && doc.groupId === req.user.memberGroupId,
@@ -68,6 +72,7 @@ export const MemberRestorePermission = new Permission({
 
 export const MemberDeletePermanentPermission = new Permission({
 	linkTo: MemberResponse,
+	params: { memberId: "id" },
 	// Permanent deletion is irreversible and reserved for admins only.
 	allowed: {
 		admin: true,

--- a/backend/src/api/members/controllers/groups.controller.ts
+++ b/backend/src/api/members/controllers/groups.controller.ts
@@ -55,11 +55,11 @@ export class GroupsController {
 		return this.groups.createGroup(groupData);
 	}
 
-	@Get(":id")
+	@Get(":groupId")
 	@AcLinks(GroupReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(GroupResponse) })
-	async getGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request) {
-		const group = await this.groups.getGroup(id);
+	async getGroup(@Param("groupId", ParseIntPipe) groupId: number, @Req() req: Request) {
+		const group = await this.groups.getGroup(groupId);
 		if (!group) throw new NotFoundException();
 
 		GroupReadPermission.canOrThrow(req, group);
@@ -67,52 +67,52 @@ export class GroupsController {
 		return group;
 	}
 
-	@Patch(":id")
+	@Patch(":groupId")
 	@AcLinks(GroupEditPermission)
 	@ApiResponse({ status: HttpStatus.OK })
-	async updateGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request, @Body() body: UpdateGroupBody) {
-		const group = await this.groups.getGroup(id);
+	async updateGroup(@Param("groupId", ParseIntPipe) groupId: number, @Req() req: Request, @Body() body: UpdateGroupBody) {
+		const group = await this.groups.getGroup(groupId);
 		if (!group) throw new NotFoundException();
 
 		GroupEditPermission.canOrThrow(req, group);
 
-		await this.groups.updateGroup(id, body);
+		await this.groups.updateGroup(groupId, body);
 	}
 
-	@Delete(":id")
+	@Delete(":groupId")
 	@AcLinks(GroupDeletePermission)
-	async deleteGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const group = await this.groups.getGroup(id);
+	async deleteGroup(@Param("groupId", ParseIntPipe) groupId: number, @Req() req: Request): Promise<void> {
+		const group = await this.groups.getGroup(groupId);
 		if (!group) throw new NotFoundException();
 
 		GroupDeletePermission.canOrThrow(req, group);
 
-		await this.groups.deleteGroup(id);
+		await this.groups.deleteGroup(groupId);
 	}
 
-	@Post(":id/restore")
+	@Post(":groupId/restore")
 	@HttpCode(HttpStatus.NO_CONTENT)
 	@AcLinks(GroupRestorePermission)
 	@ApiResponse({ status: HttpStatus.NO_CONTENT })
-	async restoreGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const group = await this.groups.getGroup(id, { withDeleted: true });
+	async restoreGroup(@Param("groupId", ParseIntPipe) groupId: number, @Req() req: Request): Promise<void> {
+		const group = await this.groups.getGroup(groupId, { withDeleted: true });
 		if (!group) throw new NotFoundException();
 
 		GroupRestorePermission.canOrThrow(req, group);
 
-		await this.groups.restoreGroup(id);
+		await this.groups.restoreGroup(groupId);
 	}
 
-	@Delete(":id/permanent")
+	@Delete(":groupId/permanent")
 	@AcLinks(GroupPermanentDeletePermission)
-	async permanentlyDeleteGroup(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<void> {
-		const group = await this.groups.getGroup(id, { withDeleted: true });
+	async permanentlyDeleteGroup(@Param("groupId", ParseIntPipe) groupId: number, @Req() req: Request): Promise<void> {
+		const group = await this.groups.getGroup(groupId, { withDeleted: true });
 		if (!group) throw new NotFoundException();
 
 		GroupPermanentDeletePermission.canOrThrow(req, group);
 
 		try {
-			await this.groups.hardDeleteGroup(id);
+			await this.groups.hardDeleteGroup(groupId);
 		} catch (err) {
 			// Postgres foreign-key violation (23503): the members→groups FK (onDelete RESTRICT)
 			// still references this group, so it can't be permanently removed

--- a/backend/src/api/members/controllers/member-contacts.controller.ts
+++ b/backend/src/api/members/controllers/member-contacts.controller.ts
@@ -11,7 +11,7 @@ import {
 } from "../acl/member-contacts.acl";
 import { CreateContactBody, MemberContactResponse } from "../dto/member-contact.dto";
 
-@Controller("members/:id/contacts")
+@Controller("members/:memberId/contacts")
 @Authenticated()
 @AcController()
 @ApiTags("Members")
@@ -21,7 +21,7 @@ export class MemberContactsController {
 	@Get()
 	@AcLinks(MemberContactsListPermission)
 	@ApiResponse({ status: 200, type: WithLinks(MemberContactResponse), isArray: true })
-	async listContacts(@Req() req: Request, @Param("id", ParseIntPipe) memberId: number): Promise<MemberContactResponse[]> {
+	async listContacts(@Req() req: Request, @Param("memberId", ParseIntPipe) memberId: number): Promise<MemberContactResponse[]> {
 		const member = await this.membersRepository.getMember(memberId, { relations: { contacts: true } });
 		if (!member) throw new NotFoundException();
 
@@ -35,7 +35,7 @@ export class MemberContactsController {
 	@ApiResponse({ type: WithLinks(MemberContactResponse) })
 	async createContact(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) memberId: number,
+		@Param("memberId", ParseIntPipe) memberId: number,
 		@Body() body: CreateContactBody,
 	): Promise<MemberContactResponse> {
 		const member = await this.membersRepository.getMember(memberId);
@@ -51,7 +51,7 @@ export class MemberContactsController {
 	@ApiResponse({ type: WithLinks(MemberContactResponse) })
 	async updateContact(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) memberId: number,
+		@Param("memberId", ParseIntPipe) memberId: number,
 		@Param("contactId", ParseIntPipe) contactId: number,
 		@Body() body: CreateContactBody,
 	): Promise<MemberContactResponse> {
@@ -66,7 +66,7 @@ export class MemberContactsController {
 	@Delete(":contactId")
 	@AcLinks(MemberContactsDeletePermission)
 	@ApiResponse({ type: WithLinks(MemberContactResponse) })
-	async deleteContact(@Req() req: Request, @Param("id", ParseIntPipe) memberId: number, @Param("contactId", ParseIntPipe) contactId: number) {
+	async deleteContact(@Req() req: Request, @Param("memberId", ParseIntPipe) memberId: number, @Param("contactId", ParseIntPipe) contactId: number) {
 		const memberContact = await this.membersRepository.getContact(memberId, contactId);
 		if (!memberContact) throw new NotFoundException();
 

--- a/backend/src/api/members/controllers/member-insurance-card.controller.ts
+++ b/backend/src/api/members/controllers/member-insurance-card.controller.ts
@@ -37,7 +37,7 @@ import {
 // app origin would let it run as stored XSS, so those must never be accepted.
 const ALLOWED_INSURANCE_CARD_TYPES = ["pdf", "jpg", "jpeg", "png"];
 
-@Controller("members/:id/insurance-card")
+@Controller("members/:memberId/insurance-card")
 @Authenticated()
 @AcController()
 @ApiTags("Members")
@@ -53,7 +53,7 @@ export class MemberInsuranceCardController {
 	@Get("")
 	@AcLinks(MemberInsuranceCardReadPermission)
 	@ApiResponse({})
-	async getInsuranceCard(@Req() req: Request, @Res() res: Response, @Param("id", ParseIntPipe) memberId: number) {
+	async getInsuranceCard(@Req() req: Request, @Res() res: Response, @Param("memberId", ParseIntPipe) memberId: number) {
 		const member = await this.membersService.getMember(memberId);
 		if (!member) throw new NotFoundException("Member not found");
 
@@ -89,7 +89,7 @@ export class MemberInsuranceCardController {
 	@ApiResponse({ status: HttpStatus.NO_CONTENT })
 	async uploadInsuranceCard(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) memberId: number,
+		@Param("memberId", ParseIntPipe) memberId: number,
 		@UploadedFile() file: Express.Multer.File,
 	) {
 		const member = await this.membersService.getMember(memberId);
@@ -120,7 +120,7 @@ export class MemberInsuranceCardController {
 	@Delete("")
 	@AcLinks(MemberInsuranceCardDeletePermission)
 	@ApiResponse({ status: HttpStatus.NO_CONTENT })
-	async deleteInsuranceCard(@Req() req: Request, @Param("id", ParseIntPipe) memberId: number) {
+	async deleteInsuranceCard(@Req() req: Request, @Param("memberId", ParseIntPipe) memberId: number) {
 		const member = await this.membersService.getMember(memberId);
 		if (!member) throw new NotFoundException("Member not found");
 

--- a/backend/src/api/members/controllers/members.controller.ts
+++ b/backend/src/api/members/controllers/members.controller.ts
@@ -80,11 +80,11 @@ export class MembersController {
 		return await this.members.createMember(body);
 	}
 
-	@Get(":id")
+	@Get(":memberId")
 	@AcLinks(MemberReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(MemberResponse) })
-	async getMember(@Param("id", ParseIntPipe) id: number, @Req() req: Request): Promise<MemberResponse> {
-		const member = await this.members.getMember(id);
+	async getMember(@Param("memberId", ParseIntPipe) memberId: number, @Req() req: Request): Promise<MemberResponse> {
+		const member = await this.members.getMember(memberId);
 		if (!member) throw new NotFoundException();
 
 		MemberReadPermission.canOrThrow(req, member);
@@ -92,51 +92,51 @@ export class MembersController {
 		return member;
 	}
 
-	@Patch(":id")
+	@Patch(":memberId")
 	@AcLinks(MemberUpdatePermission)
 	@ApiResponse({ status: 204 })
-	async updateMember(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Body() body: MemberUpdateBody) {
-		const member = await this.members.getMember(id);
+	async updateMember(@Req() req: Request, @Param("memberId", ParseIntPipe) memberId: number, @Body() body: MemberUpdateBody) {
+		const member = await this.members.getMember(memberId);
 		if (!member) throw new NotFoundException();
 
 		MemberUpdatePermission.canOrThrow(req, member);
 
-		await this.members.updateMember(id, body);
+		await this.members.updateMember(memberId, body);
 	}
 
-	@Delete(":id")
+	@Delete(":memberId")
 	@AcLinks(MemberDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteMember(@Req() req: Request, @Param("id", ParseIntPipe) id: number) {
-		const member = await this.members.getMember(id);
+	async deleteMember(@Req() req: Request, @Param("memberId", ParseIntPipe) memberId: number) {
+		const member = await this.members.getMember(memberId);
 		if (!member) throw new NotFoundException();
 
 		MemberDeletePermission.canOrThrow(req, member);
 
-		await this.members.deleteMember(id);
+		await this.members.deleteMember(memberId);
 	}
 
-	@Post(":id/restore")
+	@Post(":memberId/restore")
 	@AcLinks(MemberRestorePermission)
 	@ApiResponse({ status: 204 })
-	async restoreMember(@Req() req: Request, @Param("id", ParseIntPipe) id: number) {
-		const member = await this.members.getDeletedMember(id);
+	async restoreMember(@Req() req: Request, @Param("memberId", ParseIntPipe) memberId: number) {
+		const member = await this.members.getDeletedMember(memberId);
 		if (!member) throw new NotFoundException();
 
 		MemberRestorePermission.canOrThrow(req, member);
 
-		await this.members.restoreMember(id);
+		await this.members.restoreMember(memberId);
 	}
 
-	@Delete(":id/permanent")
+	@Delete(":memberId/permanent")
 	@AcLinks(MemberDeletePermanentPermission)
 	@ApiResponse({ status: 204 })
-	async deleteMemberPermanent(@Req() req: Request, @Param("id", ParseIntPipe) id: number) {
-		const member = await this.members.getDeletedMember(id);
+	async deleteMemberPermanent(@Req() req: Request, @Param("memberId", ParseIntPipe) memberId: number) {
+		const member = await this.members.getDeletedMember(memberId);
 		if (!member) throw new NotFoundException();
 
 		MemberDeletePermanentPermission.canOrThrow(req, member);
 
-		await this.members.hardDeleteMember(id);
+		await this.members.hardDeleteMember(memberId);
 	}
 }

--- a/backend/src/api/users/acl/user.acl.ts
+++ b/backend/src/api/users/acl/user.acl.ts
@@ -20,6 +20,7 @@ export const UserCreatePermission = new Permission<void>({
 export const UserReadPermission = new Permission<User>({
 	linkTo: UserResponse,
 	contains: UserResponse,
+	params: { userId: "id" },
 
 	allowed: {
 		revizor: true,
@@ -29,14 +30,17 @@ export const UserReadPermission = new Permission<User>({
 
 export const UserEditPermission = new Permission<User>({
 	linkTo: UserResponse,
+	params: { userId: "id" },
 });
 
 export const UserDeletePermission = new Permission<User>({
 	linkTo: UserResponse,
+	params: { userId: "id" },
 });
 
 export const UserSetPassword = new Permission<User>({
 	linkTo: UserResponse,
+	params: { userId: "id" },
 
 	allowed: {
 		uzivatel: ({ doc, req }) => doc.id === req.user?.userId,
@@ -45,4 +49,5 @@ export const UserSetPassword = new Permission<User>({
 
 export const UserImpersonatePermission = new Permission<User>({
 	linkTo: UserResponse,
+	params: { userId: "id" },
 });

--- a/backend/src/api/users/controllers/users.controller.ts
+++ b/backend/src/api/users/controllers/users.controller.ts
@@ -96,16 +96,16 @@ export class UsersController {
 		return this.userService.createUser(body);
 	}
 
-	@Get(":id")
+	@Get(":userId")
 	@AcLinks(UserReadPermission)
 	@ApiResponse({ status: 200, type: WithLinks(UserResponse) })
 	async getUser(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("userId", ParseIntPipe) userId: number,
 		@Query() query: GetUserQueryDto,
 	): Promise<UserResponse> {
 		const user = await this.userRepository.findOne({
-			where: { id },
+			where: { id: userId },
 			relations: query.includeMember ? { member: { group: true } } : {},
 		});
 		if (!user) throw new NotFoundException();
@@ -115,56 +115,56 @@ export class UsersController {
 		return user;
 	}
 
-	@Patch(":id")
+	@Patch(":userId")
 	@AcLinks(UserEditPermission)
 	@ApiResponse({ status: 204 })
-	async updateUser(@Req() req: Request, @Param("id", ParseIntPipe) id: number, @Body() body: UserUpdateBody): Promise<void> {
-		const user = await this.userService.getUser(id);
+	async updateUser(@Req() req: Request, @Param("userId", ParseIntPipe) userId: number, @Body() body: UserUpdateBody): Promise<void> {
+		const user = await this.userService.getUser(userId);
 		if (!user) throw new NotFoundException();
 
 		UserEditPermission.canOrThrow(req, user);
 
-		await this.userService.updateUser(id, body);
+		await this.userService.updateUser(userId, body);
 	}
 
-	@Delete(":id")
+	@Delete(":userId")
 	@AcLinks(UserDeletePermission)
 	@ApiResponse({ status: 204 })
-	async deleteUser(@Req() req: Request, @Param("id", ParseIntPipe) id: number): Promise<void> {
-		const user = await this.userService.getUser(id);
+	async deleteUser(@Req() req: Request, @Param("userId", ParseIntPipe) userId: number): Promise<void> {
+		const user = await this.userService.getUser(userId);
 		if (!user) throw new NotFoundException();
 
 		UserDeletePermission.canOrThrow(req, user);
 
-		await this.userService.deleteUser(id);
+		await this.userService.deleteUser(userId);
 	}
 
-	@Put(":id/password")
+	@Put(":userId/password")
 	@AcLinks(UserSetPassword)
 	@ApiResponse({ status: 204 })
 	async setUserPassword(
 		@Req() req: Request,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("userId", ParseIntPipe) userId: number,
 		@Body() body: UserSetPasswordBody,
 	): Promise<void> {
-		const user = await this.userService.getUser(id);
+		const user = await this.userService.getUser(userId);
 		if (!user) throw new NotFoundException();
 
 		UserSetPassword.canOrThrow(req, user);
 
 		// the password column stores a bcrypt hash, never the plaintext
 		const password = await this.hashService.generateHash(body.password);
-		await this.userService.updateUser(id, { password });
+		await this.userService.updateUser(userId, { password });
 	}
 
-	@Post(":id/impersonate")
+	@Post(":userId/impersonate")
 	@AcLinks(UserImpersonatePermission)
 	async impersonateUser(
 		@Req() req: Request,
 		@Res({ passthrough: true }) res: Response,
-		@Param("id", ParseIntPipe) id: number,
+		@Param("userId", ParseIntPipe) userId: number,
 	) {
-		const user = await this.userService.getUser(id);
+		const user = await this.userService.getUser(userId);
 		if (!user) throw new NotFoundException();
 
 		UserImpersonatePermission.canOrThrow(req, user);

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -5629,28 +5629,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async cancelEvent(
-            id: number,
+            eventId: number,
             body: EventStatusChangeBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('cancelEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('cancelEvent', 'eventId', eventId)
             assertParamExists('cancelEvent', 'eventStatusChangeBody', body)
             
             // verify required parameter 'eventStatusChangeBody' is not null or undefined
-            assertParamExists('cancelEvent', 'id', id)
+            assertParamExists('cancelEvent', 'eventId', eventId)
             assertParamExists('cancelEvent', 'eventStatusChangeBody', body)
             
-            const localVarPath = `/api/events/{id}/cancel`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/cancel`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -5727,22 +5727,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async deleteEvent(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('deleteEvent', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -5875,22 +5875,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async deleteEventPermanent(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteEventPermanent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('deleteEventPermanent', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/permanent`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/permanent`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -5919,22 +5919,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async deleteEventRegistration(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteEventRegistration', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('deleteEventRegistration', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/registration`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/registration`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -5963,7 +5963,7 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {EventsApiGenerateEventRegistrationQueryParams} queryParams Query parameters.
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
@@ -5971,28 +5971,28 @@ export namespace SDK {
          */
         
         public async generateEventRegistration(
-            id: number,
+            eventId: number,
             queryParams: EventsApiGenerateEventRegistrationQueryParams,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('generateEventRegistration', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('generateEventRegistration', 'eventId', eventId)
             assertParamExists('generateEventRegistration', 'template', queryParams.template)
             assertParamExists('generateEventRegistration', 'color', queryParams.color)
             
             // verify required parameter 'template' is not null or undefined
-            assertParamExists('generateEventRegistration', 'id', id)
+            assertParamExists('generateEventRegistration', 'eventId', eventId)
             assertParamExists('generateEventRegistration', 'template', queryParams.template)
             assertParamExists('generateEventRegistration', 'color', queryParams.color)
             
             // verify required parameter 'color' is not null or undefined
-            assertParamExists('generateEventRegistration', 'id', id)
+            assertParamExists('generateEventRegistration', 'eventId', eventId)
             assertParamExists('generateEventRegistration', 'template', queryParams.template)
             assertParamExists('generateEventRegistration', 'color', queryParams.color)
             
-            const localVarPath = `/api/events/{id}/registration/generate`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/registration/generate`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6071,22 +6071,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async getEvent(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('getEvent', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6115,22 +6115,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async getEventAccounting(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getEventAccounting', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('getEventAccounting', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/accounting`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/accounting`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6159,22 +6159,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async getEventAnnouncement(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getEventAnnouncement', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('getEventAnnouncement', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/announcement`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/announcement`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6203,22 +6203,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async getEventRegistration(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getEventRegistration', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('getEventRegistration', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/registration`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/registration`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6247,22 +6247,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async getEventRegistrationTemplates(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getEventRegistrationTemplates', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('getEventRegistrationTemplates', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/registration/templates`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/registration/templates`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6291,22 +6291,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async getEventReport(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getEventReport', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('getEventReport', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/report`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/report`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6411,22 +6411,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async leadEvent(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('leadEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('leadEvent', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/lead`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/lead`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6669,28 +6669,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async publishEvent(
-            id: number,
+            eventId: number,
             body: EventStatusChangeBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('publishEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('publishEvent', 'eventId', eventId)
             assertParamExists('publishEvent', 'eventStatusChangeBody', body)
             
             // verify required parameter 'eventStatusChangeBody' is not null or undefined
-            assertParamExists('publishEvent', 'id', id)
+            assertParamExists('publishEvent', 'eventId', eventId)
             assertParamExists('publishEvent', 'eventStatusChangeBody', body)
             
-            const localVarPath = `/api/events/{id}/publish`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/publish`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6722,28 +6722,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async rejectEvent(
-            id: number,
+            eventId: number,
             body: EventStatusChangeBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('rejectEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('rejectEvent', 'eventId', eventId)
             assertParamExists('rejectEvent', 'eventStatusChangeBody', body)
             
             // verify required parameter 'eventStatusChangeBody' is not null or undefined
-            assertParamExists('rejectEvent', 'id', id)
+            assertParamExists('rejectEvent', 'eventId', eventId)
             assertParamExists('rejectEvent', 'eventStatusChangeBody', body)
             
-            const localVarPath = `/api/events/{id}/reject`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/reject`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6775,22 +6775,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async restoreEvent(
-            id: number,
+            eventId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('restoreEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('restoreEvent', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/restore`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/restore`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6819,23 +6819,23 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async saveEventRegistration(
-            id: number,
+            eventId: number,
             registration: File,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('saveEventRegistration', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('saveEventRegistration', 'eventId', eventId)
             
-            const localVarPath = `/api/events/{id}/registration`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/registration`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6872,28 +6872,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async submitEvent(
-            id: number,
+            eventId: number,
             body: EventStatusChangeBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('submitEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('submitEvent', 'eventId', eventId)
             assertParamExists('submitEvent', 'eventStatusChangeBody', body)
             
             // verify required parameter 'eventStatusChangeBody' is not null or undefined
-            assertParamExists('submitEvent', 'id', id)
+            assertParamExists('submitEvent', 'eventId', eventId)
             assertParamExists('submitEvent', 'eventStatusChangeBody', body)
             
-            const localVarPath = `/api/events/{id}/submit`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/submit`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6925,28 +6925,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async uncancelEvent(
-            id: number,
+            eventId: number,
             body: EventStatusChangeBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('uncancelEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('uncancelEvent', 'eventId', eventId)
             assertParamExists('uncancelEvent', 'eventStatusChangeBody', body)
             
             // verify required parameter 'eventStatusChangeBody' is not null or undefined
-            assertParamExists('uncancelEvent', 'id', id)
+            assertParamExists('uncancelEvent', 'eventId', eventId)
             assertParamExists('uncancelEvent', 'eventStatusChangeBody', body)
             
-            const localVarPath = `/api/events/{id}/uncancel`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/uncancel`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -6978,28 +6978,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async unpublishEvent(
-            id: number,
+            eventId: number,
             body: EventStatusChangeBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('unpublishEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('unpublishEvent', 'eventId', eventId)
             assertParamExists('unpublishEvent', 'eventStatusChangeBody', body)
             
             // verify required parameter 'eventStatusChangeBody' is not null or undefined
-            assertParamExists('unpublishEvent', 'id', id)
+            assertParamExists('unpublishEvent', 'eventId', eventId)
             assertParamExists('unpublishEvent', 'eventStatusChangeBody', body)
             
-            const localVarPath = `/api/events/{id}/unpublish`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}/unpublish`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -7031,28 +7031,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} eventId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof EventsApi
          */
         
         public async updateEvent(
-            id: number,
+            eventId: number,
             body: EventUpdateBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('updateEvent', 'id', id)
+            // verify required parameter 'eventId' is not null or undefined
+            assertParamExists('updateEvent', 'eventId', eventId)
             assertParamExists('updateEvent', 'eventUpdateBody', body)
             
             // verify required parameter 'eventUpdateBody' is not null or undefined
-            assertParamExists('updateEvent', 'id', id)
+            assertParamExists('updateEvent', 'eventId', eventId)
             assertParamExists('updateEvent', 'eventUpdateBody', body)
             
-            const localVarPath = `/api/events/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/events/{eventId}`
+                .replace(`{${"eventId"}}`, encodeURIComponent(String(eventId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -7660,28 +7660,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async createContact(
-            id: number,
+            memberId: number,
             body: CreateContactBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('createContact', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('createContact', 'memberId', memberId)
             assertParamExists('createContact', 'createContactBody', body)
             
             // verify required parameter 'createContactBody' is not null or undefined
-            assertParamExists('createContact', 'id', id)
+            assertParamExists('createContact', 'memberId', memberId)
             assertParamExists('createContact', 'createContactBody', body)
             
-            const localVarPath = `/api/members/{id}/contacts`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}/contacts`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -7803,7 +7803,7 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {number} contactId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
@@ -7811,21 +7811,21 @@ export namespace SDK {
          */
         
         public async deleteContact(
-            id: number,
+            memberId: number,
             contactId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteContact', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('deleteContact', 'memberId', memberId)
             assertParamExists('deleteContact', 'contactId', contactId)
             
             // verify required parameter 'contactId' is not null or undefined
-            assertParamExists('deleteContact', 'id', id)
+            assertParamExists('deleteContact', 'memberId', memberId)
             assertParamExists('deleteContact', 'contactId', contactId)
             
-            const localVarPath = `/api/members/{id}/contacts/{contactId}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
+            const localVarPath = `/api/members/{memberId}/contacts/{contactId}`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)))
                 .replace(`{${"contactId"}}`, encodeURIComponent(String(contactId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -7855,22 +7855,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} groupId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async deleteGroup(
-            id: number,
+            groupId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteGroup', 'id', id)
+            // verify required parameter 'groupId' is not null or undefined
+            assertParamExists('deleteGroup', 'groupId', groupId)
             
-            const localVarPath = `/api/groups/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/groups/{groupId}`
+                .replace(`{${"groupId"}}`, encodeURIComponent(String(groupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -7899,22 +7899,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async deleteInsuranceCard(
-            id: number,
+            memberId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteInsuranceCard', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('deleteInsuranceCard', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}/insurance-card`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}/insurance-card`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -7943,22 +7943,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async deleteMember(
-            id: number,
+            memberId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteMember', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('deleteMember', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -7987,22 +7987,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async deleteMemberPermanent(
-            id: number,
+            memberId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteMemberPermanent', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('deleteMemberPermanent', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}/permanent`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}/permanent`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8115,22 +8115,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} groupId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async getGroup(
-            id: number,
+            groupId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getGroup', 'id', id)
+            // verify required parameter 'groupId' is not null or undefined
+            assertParamExists('getGroup', 'groupId', groupId)
             
-            const localVarPath = `/api/groups/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/groups/{groupId}`
+                .replace(`{${"groupId"}}`, encodeURIComponent(String(groupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8159,22 +8159,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async getInsuranceCard(
-            id: number,
+            memberId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getInsuranceCard', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('getInsuranceCard', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}/insurance-card`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}/insurance-card`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8203,22 +8203,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async getMember(
-            id: number,
+            memberId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getMember', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('getMember', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8247,22 +8247,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async listContacts(
-            id: number,
+            memberId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('listContacts', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('listContacts', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}/contacts`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}/contacts`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8503,22 +8503,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} groupId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async permanentlyDeleteGroup(
-            id: number,
+            groupId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('permanentlyDeleteGroup', 'id', id)
+            // verify required parameter 'groupId' is not null or undefined
+            assertParamExists('permanentlyDeleteGroup', 'groupId', groupId)
             
-            const localVarPath = `/api/groups/{id}/permanent`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/groups/{groupId}/permanent`
+                .replace(`{${"groupId"}}`, encodeURIComponent(String(groupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8547,22 +8547,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} groupId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async restoreGroup(
-            id: number,
+            groupId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('restoreGroup', 'id', id)
+            // verify required parameter 'groupId' is not null or undefined
+            assertParamExists('restoreGroup', 'groupId', groupId)
             
-            const localVarPath = `/api/groups/{id}/restore`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/groups/{groupId}/restore`
+                .replace(`{${"groupId"}}`, encodeURIComponent(String(groupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8591,22 +8591,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async restoreMember(
-            id: number,
+            memberId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('restoreMember', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('restoreMember', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}/restore`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}/restore`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8635,7 +8635,7 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {number} contactId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
@@ -8643,29 +8643,29 @@ export namespace SDK {
          */
         
         public async updateContact(
-            id: number,
+            memberId: number,
             contactId: number,
             body: CreateContactBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('updateContact', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('updateContact', 'memberId', memberId)
             assertParamExists('updateContact', 'contactId', contactId)
             assertParamExists('updateContact', 'createContactBody', body)
             
             // verify required parameter 'contactId' is not null or undefined
-            assertParamExists('updateContact', 'id', id)
+            assertParamExists('updateContact', 'memberId', memberId)
             assertParamExists('updateContact', 'contactId', contactId)
             assertParamExists('updateContact', 'createContactBody', body)
             
             // verify required parameter 'createContactBody' is not null or undefined
-            assertParamExists('updateContact', 'id', id)
+            assertParamExists('updateContact', 'memberId', memberId)
             assertParamExists('updateContact', 'contactId', contactId)
             assertParamExists('updateContact', 'createContactBody', body)
             
-            const localVarPath = `/api/members/{id}/contacts/{contactId}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
+            const localVarPath = `/api/members/{memberId}/contacts/{contactId}`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)))
                 .replace(`{${"contactId"}}`, encodeURIComponent(String(contactId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -8698,28 +8698,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} groupId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async updateGroup(
-            id: number,
+            groupId: number,
             body: UpdateGroupBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('updateGroup', 'id', id)
+            // verify required parameter 'groupId' is not null or undefined
+            assertParamExists('updateGroup', 'groupId', groupId)
             assertParamExists('updateGroup', 'updateGroupBody', body)
             
             // verify required parameter 'updateGroupBody' is not null or undefined
-            assertParamExists('updateGroup', 'id', id)
+            assertParamExists('updateGroup', 'groupId', groupId)
             assertParamExists('updateGroup', 'updateGroupBody', body)
             
-            const localVarPath = `/api/groups/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/groups/{groupId}`
+                .replace(`{${"groupId"}}`, encodeURIComponent(String(groupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8751,28 +8751,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async updateMember(
-            id: number,
+            memberId: number,
             body: MemberUpdateBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('updateMember', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('updateMember', 'memberId', memberId)
             assertParamExists('updateMember', 'memberUpdateBody', body)
             
             // verify required parameter 'memberUpdateBody' is not null or undefined
-            assertParamExists('updateMember', 'id', id)
+            assertParamExists('updateMember', 'memberId', memberId)
             assertParamExists('updateMember', 'memberUpdateBody', body)
             
-            const localVarPath = `/api/members/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -8804,23 +8804,23 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} memberId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof MembersApi
          */
         
         public async uploadInsuranceCard(
-            id: number,
+            memberId: number,
             file: File,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('uploadInsuranceCard', 'id', id)
+            // verify required parameter 'memberId' is not null or undefined
+            assertParamExists('uploadInsuranceCard', 'memberId', memberId)
             
-            const localVarPath = `/api/members/{id}/insurance-card`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/members/{memberId}/insurance-card`
+                .replace(`{${"memberId"}}`, encodeURIComponent(String(memberId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9133,22 +9133,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async deleteAlbum(
-            id: number,
+            albumId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteAlbum', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('deleteAlbum', 'albumId', albumId)
             
-            const localVarPath = `/api/albums/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9177,22 +9177,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async deleteAlbumPermanent(
-            id: number,
+            albumId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteAlbumPermanent', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('deleteAlbumPermanent', 'albumId', albumId)
             
-            const localVarPath = `/api/albums/{id}/permanent`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}/permanent`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9221,22 +9221,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} photoId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async deletePhoto(
-            id: number,
+            photoId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deletePhoto', 'id', id)
+            // verify required parameter 'photoId' is not null or undefined
+            assertParamExists('deletePhoto', 'photoId', photoId)
             
-            const localVarPath = `/api/photos/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/photos/{photoId}`
+                .replace(`{${"photoId"}}`, encodeURIComponent(String(photoId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9265,22 +9265,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async getAlbum(
-            id: number,
+            albumId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getAlbum', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('getAlbum', 'albumId', albumId)
             
-            const localVarPath = `/api/albums/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9309,22 +9309,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async getAlbumPhotos(
-            id: number,
+            albumId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getAlbumPhotos', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('getAlbumPhotos', 'albumId', albumId)
             
-            const localVarPath = `/api/albums/{id}/photos`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}/photos`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9391,22 +9391,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} photoId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async getPhoto(
-            id: number,
+            photoId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getPhoto', 'id', id)
+            // verify required parameter 'photoId' is not null or undefined
+            assertParamExists('getPhoto', 'photoId', photoId)
             
-            const localVarPath = `/api/photos/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/photos/{photoId}`
+                .replace(`{${"photoId"}}`, encodeURIComponent(String(photoId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9435,7 +9435,7 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} photoId 
          * @param {string} size 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
@@ -9443,21 +9443,21 @@ export namespace SDK {
          */
         
         public async getPhotoImage(
-            id: number,
+            photoId: number,
             size: string,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getPhotoImage', 'id', id)
+            // verify required parameter 'photoId' is not null or undefined
+            assertParamExists('getPhotoImage', 'photoId', photoId)
             assertParamExists('getPhotoImage', 'size', size)
             
             // verify required parameter 'size' is not null or undefined
-            assertParamExists('getPhotoImage', 'id', id)
+            assertParamExists('getPhotoImage', 'photoId', photoId)
             assertParamExists('getPhotoImage', 'size', size)
             
-            const localVarPath = `/api/photos/{id}/image/{size}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
+            const localVarPath = `/api/photos/{photoId}/image/{size}`
+                .replace(`{${"photoId"}}`, encodeURIComponent(String(photoId)))
                 .replace(`{${"size"}}`, encodeURIComponent(String(size)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -9631,22 +9631,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async publishAlbum(
-            id: number,
+            albumId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('publishAlbum', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('publishAlbum', 'albumId', albumId)
             
-            const localVarPath = `/api/albums/{id}/publish`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}/publish`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9675,28 +9675,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async reorderAlbumPhotos(
-            id: number,
+            albumId: number,
             body: AlbumPhotosOrderBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('reorderAlbumPhotos', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('reorderAlbumPhotos', 'albumId', albumId)
             assertParamExists('reorderAlbumPhotos', 'albumPhotosOrderBody', body)
             
             // verify required parameter 'albumPhotosOrderBody' is not null or undefined
-            assertParamExists('reorderAlbumPhotos', 'id', id)
+            assertParamExists('reorderAlbumPhotos', 'albumId', albumId)
             assertParamExists('reorderAlbumPhotos', 'albumPhotosOrderBody', body)
             
-            const localVarPath = `/api/albums/{id}/photos/order`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}/photos/order`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9728,22 +9728,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async restoreAlbum(
-            id: number,
+            albumId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('restoreAlbum', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('restoreAlbum', 'albumId', albumId)
             
-            const localVarPath = `/api/albums/{id}/restore`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}/restore`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9772,22 +9772,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async unpublishAlbum(
-            id: number,
+            albumId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('unpublishAlbum', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('unpublishAlbum', 'albumId', albumId)
             
-            const localVarPath = `/api/albums/{id}/unpublish`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}/unpublish`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9816,28 +9816,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} albumId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async updateAlbum(
-            id: number,
+            albumId: number,
             body: AlbumUpdateBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('updateAlbum', 'id', id)
+            // verify required parameter 'albumId' is not null or undefined
+            assertParamExists('updateAlbum', 'albumId', albumId)
             assertParamExists('updateAlbum', 'albumUpdateBody', body)
             
             // verify required parameter 'albumUpdateBody' is not null or undefined
-            assertParamExists('updateAlbum', 'id', id)
+            assertParamExists('updateAlbum', 'albumId', albumId)
             assertParamExists('updateAlbum', 'albumUpdateBody', body)
             
-            const localVarPath = `/api/albums/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/albums/{albumId}`
+                .replace(`{${"albumId"}}`, encodeURIComponent(String(albumId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -9869,28 +9869,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} photoId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof PhotoGalleryApi
          */
         
         public async updatePhoto(
-            id: number,
+            photoId: number,
             body: PhotoUpdateBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('updatePhoto', 'id', id)
+            // verify required parameter 'photoId' is not null or undefined
+            assertParamExists('updatePhoto', 'photoId', photoId)
             assertParamExists('updatePhoto', 'photoUpdateBody', body)
             
             // verify required parameter 'photoUpdateBody' is not null or undefined
-            assertParamExists('updatePhoto', 'id', id)
+            assertParamExists('updatePhoto', 'photoId', photoId)
             assertParamExists('updatePhoto', 'photoUpdateBody', body)
             
-            const localVarPath = `/api/photos/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/photos/{photoId}`
+                .replace(`{${"photoId"}}`, encodeURIComponent(String(photoId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -11335,22 +11335,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} userId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof UsersApi
          */
         
         public async deleteUser(
-            id: number,
+            userId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deleteUser', 'id', id)
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('deleteUser', 'userId', userId)
             
-            const localVarPath = `/api/users/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/users/{userId}`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -11379,7 +11379,7 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} userId 
          * @param {UsersApiGetUserQueryParams} queryParams Query parameters.
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
@@ -11387,16 +11387,16 @@ export namespace SDK {
          */
         
         public async getUser(
-            id: number,
+            userId: number,
             queryParams: UsersApiGetUserQueryParams,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('getUser', 'id', id)
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('getUser', 'userId', userId)
             
-            const localVarPath = `/api/users/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/users/{userId}`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -11429,22 +11429,22 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} userId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof UsersApi
          */
         
         public async impersonateUser(
-            id: number,
+            userId: number,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('impersonateUser', 'id', id)
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('impersonateUser', 'userId', userId)
             
-            const localVarPath = `/api/users/{id}/impersonate`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/users/{userId}/impersonate`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -11537,28 +11537,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} userId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof UsersApi
          */
         
         public async setUserPassword(
-            id: number,
+            userId: number,
             body: UserSetPasswordBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('setUserPassword', 'id', id)
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('setUserPassword', 'userId', userId)
             assertParamExists('setUserPassword', 'userSetPasswordBody', body)
             
             // verify required parameter 'userSetPasswordBody' is not null or undefined
-            assertParamExists('setUserPassword', 'id', id)
+            assertParamExists('setUserPassword', 'userId', userId)
             assertParamExists('setUserPassword', 'userSetPasswordBody', body)
             
-            const localVarPath = `/api/users/{id}/password`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/users/{userId}/password`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -11590,28 +11590,28 @@ export namespace SDK {
         /**
          * 
     
-         * @param {number} id 
+         * @param {number} userId 
          * @param {AxiosRequestConfig} [options] Override http request option.
          * @throws {RequiredError}
          * @memberof UsersApi
          */
         
         public async updateUser(
-            id: number,
+            userId: number,
             body: UserUpdateBody,
             options: AxiosRequestConfig = {}
         ) {
     
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('updateUser', 'id', id)
+            // verify required parameter 'userId' is not null or undefined
+            assertParamExists('updateUser', 'userId', userId)
             assertParamExists('updateUser', 'userUpdateBody', body)
             
             // verify required parameter 'userUpdateBody' is not null or undefined
-            assertParamExists('updateUser', 'id', id)
+            assertParamExists('updateUser', 'userId', userId)
             assertParamExists('updateUser', 'userUpdateBody', body)
             
-            const localVarPath = `/api/users/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            const localVarPath = `/api/users/{userId}`
+                .replace(`{${"userId"}}`, encodeURIComponent(String(userId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const requestUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;


### PR DESCRIPTION
# Změny

 - Všechny neveřejné routy používají parametr pojmenovaný podle entity místo `:id` — `:eventId` (events, včetně announcement, registration, report a accounting), `:memberId` (members, kontakty, průkazka), `:contactId`, `:albumId`, `:photoId`, `:groupId`, `:userId`, `:expenseId`.
 - `Public API` zůstává beze změny — jeho `:id` je součástí URL, které už volá bosan.cz.
 - `Permission` má novou volbu `params`, která doplní parametr routy z dokumentu — buď jménem property (`params: { eventId: "id" }`, typované jako `keyof DOC`), nebo funkcí `(doc) => …`, když hodnota není prostá property. Aplikuje se na celou adresu **včetně prefixu controlleru**, což `path` neumí — ta přepisuje jen cestu metody.
 - Tím padají ruční `path` v events ACL. Ty na parametr v prefixu `@Controller("events/:eventId/expenses")` nedosáhly, takže odkazy na výdaje na masteru vycházely jako `/events/eventId/expenses/1/attendees` a `/events/1/expenses/1/expenses/1`.
 - Parametry, které dokument opravdu nezná (`:memberId` u odkazu z akce, `:contactId` u odkazu ze člena, `:size` u fotky), zůstávají v adrese jako dřív.
 - Frontendová SDK je přegenerována — mění se jen jména parametrů, volání jsou poziční, takže kód frontendu se nemění.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Zkontroluj, že detail akce jde otevřít, upravit, publikovat/zrušit a smazat.
3. Zkontroluj, že u akce jde přidat a odebrat účastníka a výdaj a stáhnout přihlášku, vyúčtování a rozpis.
4. Zkontroluj, že u člena jde upravit kontakty a nahrát/smazat kartičku pojišťovny.
5. Zkontroluj, že jdou otevřít a upravit oddíly, alba, fotky a uživatelé.
6. Zkontroluj, že program a galerie na bosan.cz fungují dál (veřejné API se neměnilo).