### PR TITLE
feat(ui): tooltip s vysvětlením u nepovolených akcí v bo-action-buttons

### DIFF
--- a/frontend/src/app/shared/components/action-buttons/action-buttons.component.html
+++ b/frontend/src/app/shared/components/action-buttons/action-buttons.component.html
@@ -1,6 +1,11 @@
 <!-- PINNED -->
 @for (action of pinned(); track action) {
-	<ion-button class="pinned" [disabled]="action.disabled" (click)="onClick(action)">
+	<ion-button
+		class="pinned"
+		[disabled]="action.disabled"
+		[boTooltip]="action.disabled ? noPermissionText : null"
+		(click)="onClick(action)"
+	>
 		@if (action.icon) {
 			<ion-icon [class.d-xl-none]="!ios && action.text" [name]="action.icon"></ion-icon>
 		}
@@ -17,6 +22,7 @@
 	<ion-button
 		[disabled]="action.disabled"
 		[color]="action.color"
+		[boTooltip]="action.disabled ? noPermissionText : null"
 		(click)="onClick(action)"
 		class="d-none"
 		[class.d-xl-inline-block]="!ios"

--- a/frontend/src/app/shared/components/action-buttons/action-buttons.component.ts
+++ b/frontend/src/app/shared/components/action-buttons/action-buttons.component.ts
@@ -93,6 +93,8 @@ export class ActionButtonsComponent implements OnInit {
 	}
 
 	onClick(action: Action) {
+		if (action.disabled) return;
+
 		action.handler?.();
 	}
 

--- a/frontend/src/app/shared/components/action-buttons/action-buttons.component.ts
+++ b/frontend/src/app/shared/components/action-buttons/action-buttons.component.ts
@@ -4,6 +4,7 @@ import { ActionSheetButton, PredefinedColors } from "@ionic/core";
 import { addIcons } from "ionicons";
 import { ellipsisVertical } from "ionicons/icons";
 import { PlatformService } from "src/app/core/services/platform.service";
+import { TooltipDirective } from "../../directives/tooltip.directive";
 
 export interface Action extends ActionSheetButton {
 	disabled?: boolean;
@@ -17,7 +18,7 @@ export interface Action extends ActionSheetButton {
 	templateUrl: "./action-buttons.component.html",
 	styleUrls: ["./action-buttons.component.scss"],
 
-	imports: [IonButton, IonIcon, IonText],
+	imports: [IonButton, IonIcon, IonText, TooltipDirective],
 })
 export class ActionButtonsComponent implements OnInit {
 	actions = input<Action[]>([]);
@@ -25,6 +26,8 @@ export class ActionButtonsComponent implements OnInit {
 	subHeader = input<string | null | undefined>();
 
 	close = output<void>();
+
+	readonly noPermissionText = "K této akci nemáš oprávnění.";
 
 	pinned = signal<Action[]>([]);
 	buttons = signal<Action[]>([]);

--- a/frontend/src/app/shared/directives/tooltip.directive.ts
+++ b/frontend/src/app/shared/directives/tooltip.directive.ts
@@ -6,6 +6,8 @@ import { Directive, ElementRef, HostListener, OnDestroy, input } from "@angular/
  *
  * Works on any element, including a disabled `ion-button` — see the `ion-button.bo-tooltip` rule in
  * `styles/ionic.scss`, which hands the disabled host its pointer events back so the hover lands.
+ * That also makes the host the click target, so `blockDisabledClicks()` below swallows the click
+ * again — otherwise a disabled button would run its handler.
  *
  * The bubble is appended to `<body>` (so no parent's `overflow` can clip it) and therefore styled
  * inline — a component stylesheet would not reach it.
@@ -21,7 +23,9 @@ export class TooltipDirective implements OnDestroy {
 	private tooltip?: HTMLElement;
 	private readonly hideHandler = () => this.hide();
 
-	constructor(private el: ElementRef<HTMLElement>) {}
+	constructor(private el: ElementRef<HTMLElement>) {
+		blockDisabledClicks();
+	}
 
 	@HostListener("mouseenter")
 	@HostListener("focusin")
@@ -90,3 +94,27 @@ export class TooltipDirective implements OnDestroy {
 		tooltip.style.left = `${left}px`;
 	}
 }
+
+/**
+ * The pointer events handed back above land the click on the host, where Angular's `(click)` sits.
+ * A capture listener on `document` runs before any listener on the target, whatever order those
+ * were registered in, so this is where the click can still be stopped.
+ */
+function blockDisabledClicks() {
+	if (disabledClickGuard) return;
+	disabledClickGuard = true;
+
+	document.addEventListener(
+		"click",
+		(event) => {
+			const target = event.target as HTMLElement | null;
+			if (!target?.closest?.(".bo-tooltip.button-disabled")) return;
+
+			event.stopImmediatePropagation();
+			event.preventDefault();
+		},
+		true,
+	);
+}
+
+let disabledClickGuard = false;

--- a/frontend/src/app/shared/directives/tooltip.directive.ts
+++ b/frontend/src/app/shared/directives/tooltip.directive.ts
@@ -4,7 +4,7 @@ import { Directive, ElementRef, HostListener, OnDestroy, input } from "@angular/
  * Instant tooltip, a replacement for the native `title` attribute: that one only appears after
  * roughly a second and is never shown for disabled controls.
  *
- * Works on any element, including a disabled `ion-button` — see the `ion-button[boTooltip]` rule in
+ * Works on any element, including a disabled `ion-button` — see the `ion-button.bo-tooltip` rule in
  * `styles/ionic.scss`, which hands the disabled host its pointer events back so the hover lands.
  *
  * The bubble is appended to `<body>` (so no parent's `overflow` can clip it) and therefore styled
@@ -12,6 +12,7 @@ import { Directive, ElementRef, HostListener, OnDestroy, input } from "@angular/
  */
 @Directive({
 	selector: "[boTooltip]",
+	host: { class: "bo-tooltip" },
 })
 export class TooltipDirective implements OnDestroy {
 	boTooltip = input<string | null | undefined>();

--- a/frontend/src/styles/ionic.scss
+++ b/frontend/src/styles/ionic.scss
@@ -174,7 +174,7 @@ ion-content {
    would never see the hover that is supposed to explain *why* it is disabled. Give the host its
    pointer events back and kill them on the inner native button instead, so the button stays
    unclickable but the tooltip still fires. */
-ion-button[boTooltip].button-disabled {
+ion-button.bo-tooltip.button-disabled {
 	pointer-events: auto;
 	cursor: default;
 

--- a/frontend/src/styles/ionic.scss
+++ b/frontend/src/styles/ionic.scss
@@ -172,8 +172,8 @@ ion-content {
 
 /* A disabled ion-button gets `pointer-events: none` on its host, so a boTooltip sitting on it
    would never see the hover that is supposed to explain *why* it is disabled. Give the host its
-   pointer events back and kill them on the inner native button instead, so the button stays
-   unclickable but the tooltip still fires. */
+   pointer events back so the tooltip fires; the click that now reaches the host is swallowed by
+   the guard in `tooltip.directive.ts`. */
 ion-button.bo-tooltip.button-disabled {
 	pointer-events: auto;
 	cursor: default;


### PR DESCRIPTION
# Změny

 - `bo-action-buttons`: tlačítko, které je zobrazené (operace je `applicable`), ale zakázané (operace není `allowed`), teď při najetí myší ukáže bublinu **„K této akci nemáš oprávnění."**. Platí pro připnutá (`pinned`) i běžná tlačítka; použitá je stávající direktiva `boTooltip`.
 - `TooltipDirective` nově přidává hostitelskou třídu `bo-tooltip` a pravidlo ve `styles/ionic.scss` cílí na `ion-button.bo-tooltip.button-disabled` místo na `ion-button[boTooltip]`. Atribut v DOM vzniká jen u statického zápisu `boTooltip="…"`, takže u property bindingu `[boTooltip]="…"` zakázané tlačítko pointer events zpátky nedostalo a tooltip se nikdy neukázal — což je přesně případ, kdy má vysvětlit, proč je tlačítko zakázané. Opravuje to i stávající tlačítko „Generovat" u registrace akce.

# Testovací scénář

1. Otevři si test.bosan.cz a obnov stránku.
    - Windows: `CTRL + F5`
    - Mac: `⌘ Cmd + ⇧ Shift + R`
2. Přihlas se jako uživatel, který na detailu akce vidí nějakou akci (např. „Ke schválení", „Do programu", „Smazat") **zašedlou** — tedy operace na akci sedí, ale uživatel na ni nemá práva.
3. Zkontroluj, že po najetí myší na takové zašedlé tlačítko vyskočí bublina „K této akci nemáš oprávnění.".
4. Zkontroluj, že se na zašedlé tlačítko pořád nedá kliknout a nic se nespustí.
5. Zkontroluj, že u tlačítek, která zašedlá nejsou, se žádná bublina neukazuje.
6. Zkontroluj, že tooltipy jinde v aplikaci (lišta markdown editoru, kalendář na úvodní stránce, tlačítka u registrace akce) fungují jako dřív.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCMM4RF6KZmZAUCJwRqfTg

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCMM4RF6KZmZAUCJwRqfTg)_