### PR TITLE
docs(github): odstranit testovací scénář ze šablony pull requestu

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,3 @@
 # Změny
 
  - 
-
-# Testovací scénář
-
-1. Otevři si test.bosan.cz a obnov stránku.
-    - Windows: `CTRL + F5`
-    - Mac: `⌘ Cmd + ⇧ Shift + R`
-2. Zkontroluj, že …
-
- Po otestování vždy napiš feedback, buď `Approve review`, nebo `Request changes`. Návod zde: [Jak na testování](https://github.com/bosancz/bosan.cz/wiki/Jak-na-testov%C3%A1n%C3%AD%3F)


### PR DESCRIPTION
# Změny

 - Odstraněna sekce „Testovací scénář" ze šablony pull requestu (`.github/pull_request_template.md`) včetně kroků pro test.bosan.cz a závěrečné poznámky o feedbacku. Šabloně zůstává jen sekce „Změny".

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxptYCnky1qHCh4eNLRQY1)_