### PR TITLE
feat(members): zobrazit věk u lidí v seznamu účastníků i v profilu

### DIFF
--- a/frontend/src/app/features/events/components/event-age-histogram/event-age-histogram.component.ts
+++ b/frontend/src/app/features/events/components/event-age-histogram/event-age-histogram.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from "@angular/common";
 import { Component, effect, input, signal } from "@angular/core";
-import { DateTime } from "luxon";
+import { getAge } from "src/helpers/age";
 import { SDK } from "src/sdk";
 
 @Component({
@@ -28,13 +28,10 @@ export class EventAgeHistogramComponent {
 
 	updateAges(event: SDK.EventResponseWithLinks): void {
 		const members = this.members();
-		const dateFrom = DateTime.fromISO(event.dateFrom).set({ hour: 0 });
 
-		const ages: number[] = [];
-		members.forEach((member) => {
-			if (!member.birthday) return;
-			ages.push(Math.floor(-1 * DateTime.fromISO(member.birthday).diff(dateFrom, "years").toObject().years!));
-		});
+		const ages = members
+			.map((member) => getAge(member.birthday, event.dateFrom))
+			.filter((age): age is number => age !== null);
 
 		if (!ages.length) {
 			this.histogram.set([]);

--- a/frontend/src/app/features/events/components/event-attendees-list/event-attendees-list.component.html
+++ b/frontend/src/app/features/events/components/event-attendees-list/event-attendees-list.component.html
@@ -7,7 +7,10 @@
 		>
 			<p class="text-muted">
 				@if (attendee.member) {
-					<bo-member-item-detail [member]="attendee.member"></bo-member-item-detail>
+					<bo-member-item-detail
+						[member]="attendee.member"
+						[referenceDate]="event()?.dateFrom"
+					></bo-member-item-detail>
 				}
 			</p>
 

--- a/frontend/src/app/features/events/components/event-attendees-list/event-attendees-list.component.ts
+++ b/frontend/src/app/features/events/components/event-attendees-list/event-attendees-list.component.ts
@@ -2,11 +2,11 @@ import { DatePipe } from "@angular/common";
 import { Component, computed, input, output } from "@angular/core";
 import { RouterLink } from "@angular/router";
 import { IonBadge, IonList, IonSkeletonText } from "@ionic/angular/standalone";
-import { DateTime } from "luxon";
 import { DeleteButtonComponent } from "src/app/shared/components/delete-button/delete-button.component";
 import { GroupBadgeComponent } from "src/app/shared/components/group-badge/group-badge.component";
 import { ItemComponent } from "src/app/shared/components/item/item.component";
 import { MemberItemDetailComponent } from "src/app/shared/components/member-item-detail/member-item-detail.component";
+import { hasBirthdayBetween } from "src/helpers/age";
 import { SDK } from "src/sdk";
 import { MemberPipe } from "../../../../shared/pipes/member.pipe";
 import { RolePipe } from "../../../../shared/pipes/role.pipe";
@@ -43,14 +43,6 @@ export class EventAttendeesListComponent {
 
 	hasBirthday(attendee: SDK.EventAttendeeResponseWithLinks) {
 		const event = this.event();
-		if (!attendee.member?.birthday || !event?.dateFrom || !event?.dateTill) return false;
-
-		const eventFrom = DateTime.fromISO(event.dateFrom);
-		const eventTill = DateTime.fromISO(event.dateTill);
-
-		let birthday = DateTime.fromISO(attendee.member.birthday).set({ year: eventFrom.year });
-		if (birthday < eventFrom) birthday = birthday.plus({ years: 1 });
-
-		return birthday <= eventTill;
+		return hasBirthdayBetween(attendee.member?.birthday, event?.dateFrom, event?.dateTill);
 	}
 }

--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.html
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.html
@@ -27,6 +27,8 @@
 				<bo-add-button (click)="addAttendee('attendee')">Přidat účastníka</bo-add-button>
 			</div>
 		}
+
+		<p class="attendees-note text-muted">Věk je uvedený ke dni začátku akce.</p>
 	</div>
 	<div class="order-1 order-lg-2 col-12 col-xl-4">
 		@if (event()) {

--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.scss
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.scss
@@ -1,0 +1,7 @@
+@use "src/styles/variables" as *;
+
+.attendees-note {
+	margin-top: 1rem;
+	font-size: $font-small;
+	font-style: italic;
+}

--- a/frontend/src/app/features/events/components/event-birthday-list/event-birthday-list.component.ts
+++ b/frontend/src/app/features/events/components/event-birthday-list/event-birthday-list.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component, effect, input, signal } from "@angular/core";
 import { IonItem, IonLabel, IonList } from "@ionic/angular/standalone";
-import { DateTime } from "luxon";
+import { getAge, hasBirthdayBetween } from "src/helpers/age";
 import { SDK } from "src/sdk";
 
 @Component({
@@ -27,15 +27,11 @@ export class EventBirthdayListComponent {
 	updateBirthdays(event: SDK.EventResponseWithLinks) {
 		const members = this.members();
 
-		const dateFrom = DateTime.fromISO(event.dateFrom).set({ hour: 0, minute: 0 });
-		const dateTill = DateTime.fromISO(event.dateTill).set({ hour: 23, minute: 59 });
-
 		const birthdays: Array<{ age: number; date: string; member: SDK.MemberResponse }> = [];
 		members.forEach((member) => {
 			if (!member.birthday) return;
-			var ageStart = Math.floor(-1 * DateTime.fromISO(member.birthday).diff(dateFrom, "years").toObject().years!);
-			var ageEnd = Math.floor(-1 * DateTime.fromISO(member.birthday).diff(dateTill, "years").toObject().years!);
-			if (ageStart < ageEnd) birthdays.push({ age: ageEnd, date: member.birthday, member: member });
+			if (!hasBirthdayBetween(member.birthday, event.dateFrom, event.dateTill)) return;
+			birthdays.push({ age: getAge(member.birthday, event.dateTill)!, date: member.birthday, member });
 		});
 
 		this.birthdays.set(birthdays);

--- a/frontend/src/app/features/members/components/member-info/member-info.component.html
+++ b/frontend/src/app/features/members/components/member-info/member-info.component.html
@@ -52,7 +52,12 @@
 					<span class="bo-info-label">Datum narození</span>
 					<span class="bo-info-action">
 						<span class="bo-info-value">{{
-							memberValue.birthday ? (memberValue.birthday | date: "d. M. y") : "-"
+							memberValue.birthday
+								? (memberValue.birthday | date: "d. M. y") +
+									" (" +
+									(memberValue | member: "ageLabel") +
+									")"
+								: "-"
 						}}</span>
 						<bo-edit-button-date
 							label="Datum narození"

--- a/frontend/src/app/features/members/components/member-info/member-info.component.ts
+++ b/frontend/src/app/features/members/components/member-info/member-info.component.ts
@@ -14,6 +14,7 @@ import { EditButtonDateComponent } from "../../../../shared/components/edit-butt
 import { EditButtonNameComponent } from "../../../../shared/components/edit-button-name/edit-button-name.component";
 import { EditButtonTextComponent } from "../../../../shared/components/edit-button-text/edit-button-text.component";
 import { EditButtonComponent } from "../../../../shared/components/edit-button/edit-button.component";
+import { MemberPipe } from "../../../../shared/pipes/member.pipe";
 
 @UntilDestroy()
 @Component({
@@ -32,6 +33,7 @@ import { EditButtonComponent } from "../../../../shared/components/edit-button/e
 		EditButtonNameComponent,
 		EditButtonTextComponent,
 		EditButtonDateComponent,
+		MemberPipe,
 	],
 })
 export class MemberInfoComponent {

--- a/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.html
+++ b/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.html
@@ -1,1 +1,4 @@
 <span>{{ member().firstName }}&nbsp;{{ member().lastName }}</span>
+@if (member() | member: "ageLabel" : referenceDate(); as age) {
+	<span class="age">{{ age }}</span>
+}

--- a/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.scss
+++ b/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.scss
@@ -1,0 +1,4 @@
+.age::before {
+	content: "•";
+	margin: 0 0.35em;
+}

--- a/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.ts
+++ b/frontend/src/app/shared/components/member-item-detail/member-item-detail.component.ts
@@ -1,16 +1,14 @@
-import { Component, input, OnInit } from "@angular/core";
+import { Component, input } from "@angular/core";
 import { SDK } from "src/sdk";
+import { MemberPipe } from "../../pipes/member.pipe";
 
 @Component({
 	selector: "bo-member-item-detail",
 	templateUrl: "./member-item-detail.component.html",
 	styleUrls: ["./member-item-detail.component.scss"],
-	imports: [],
+	imports: [MemberPipe],
 })
-export class MemberItemDetailComponent implements OnInit {
+export class MemberItemDetailComponent {
 	member = input.required<SDK.MemberResponse>();
-
-	constructor() {}
-
-	ngOnInit(): void {}
+	referenceDate = input<string | null | undefined>();
 }

--- a/frontend/src/app/shared/pipes/member.pipe.ts
+++ b/frontend/src/app/shared/pipes/member.pipe.ts
@@ -10,7 +10,8 @@ import { SDK } from "src/sdk";
 export class MemberPipe implements PipeTransform {
 	transform(
 		member: SDK.MemberResponse | undefined,
-		property: "nickname" | "age" | "membership" | "role" | "initials",
+		property: "nickname" | "age" | "ageLabel" | "membership" | "role" | "initials",
+		referenceDate?: string | DateTime | null,
 	) {
 		if (!member) return "";
 
@@ -18,14 +19,16 @@ export class MemberPipe implements PipeTransform {
 			case "nickname":
 				return member.nickname || member.firstName || member.lastName || "?";
 
-			case "age":
-				let birthday: DateTime | string | null | undefined = member.birthday;
+			case "age": {
+				const age = this.getAge(member, referenceDate);
+				return age === null ? "" : String(age);
+			}
 
-				if (!birthday) return "";
-
-				if (typeof birthday === "string") birthday = DateTime.fromISO(birthday);
-
-				return String(Math.floor(birthday.diffNow("years").years * -1));
+			case "ageLabel": {
+				const age = this.getAge(member, referenceDate);
+				if (age === null) return "";
+				return `${age} ${age === 1 ? "rok" : age < 5 ? "roky" : "let"}`;
+			}
 
 			case "membership":
 				return MembershipStates[member.membership].title;
@@ -36,6 +39,18 @@ export class MemberPipe implements PipeTransform {
 			case "initials":
 				return member ? this.getInitials(member) : "";
 		}
+	}
+
+	getAge(member: SDK.MemberResponse, referenceDate?: string | DateTime | null): number | null {
+		if (!member.birthday) return null;
+
+		const birthday = DateTime.fromISO(member.birthday);
+		if (!birthday.isValid) return null;
+
+		const reference = typeof referenceDate === "string" ? DateTime.fromISO(referenceDate) : referenceDate;
+		const to = reference?.isValid ? reference : DateTime.now();
+
+		return Math.floor(to.diff(birthday, "years").years);
 	}
 
 	getInitials(member: SDK.MemberResponse): string {

--- a/frontend/src/app/shared/pipes/member.pipe.ts
+++ b/frontend/src/app/shared/pipes/member.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from "@angular/core";
-import { DateTime } from "luxon";
 import { MemberRoles } from "src/app/core/config/member-roles";
 import { MembershipStates } from "src/app/core/config/membership-states";
+import { getAge, getAgeLabel } from "src/helpers/age";
 import { SDK } from "src/sdk";
 
 @Pipe({
@@ -11,7 +11,7 @@ export class MemberPipe implements PipeTransform {
 	transform(
 		member: SDK.MemberResponse | undefined,
 		property: "nickname" | "age" | "ageLabel" | "membership" | "role" | "initials",
-		referenceDate?: string | DateTime | null,
+		referenceDate?: string | null,
 	) {
 		if (!member) return "";
 
@@ -20,15 +20,12 @@ export class MemberPipe implements PipeTransform {
 				return member.nickname || member.firstName || member.lastName || "?";
 
 			case "age": {
-				const age = this.getAge(member, referenceDate);
+				const age = getAge(member.birthday, referenceDate);
 				return age === null ? "" : String(age);
 			}
 
-			case "ageLabel": {
-				const age = this.getAge(member, referenceDate);
-				if (age === null) return "";
-				return `${age} ${age === 1 ? "rok" : age < 5 ? "roky" : "let"}`;
-			}
+			case "ageLabel":
+				return getAgeLabel(member.birthday, referenceDate);
 
 			case "membership":
 				return MembershipStates[member.membership].title;
@@ -39,18 +36,6 @@ export class MemberPipe implements PipeTransform {
 			case "initials":
 				return member ? this.getInitials(member) : "";
 		}
-	}
-
-	getAge(member: SDK.MemberResponse, referenceDate?: string | DateTime | null): number | null {
-		if (!member.birthday) return null;
-
-		const birthday = DateTime.fromISO(member.birthday);
-		if (!birthday.isValid) return null;
-
-		const reference = typeof referenceDate === "string" ? DateTime.fromISO(referenceDate) : referenceDate;
-		const to = reference?.isValid ? reference : DateTime.now();
-
-		return Math.floor(to.diff(birthday, "years").years);
 	}
 
 	getInitials(member: SDK.MemberResponse): string {

--- a/frontend/src/helpers/age.ts
+++ b/frontend/src/helpers/age.ts
@@ -1,0 +1,37 @@
+import { DateTime } from "luxon";
+
+type DateInput = string | DateTime | null | undefined;
+
+function toDateTime(value: DateInput): DateTime | null {
+	if (!value) return null;
+	const date = typeof value === "string" ? DateTime.fromISO(value) : value;
+	return date.isValid ? date : null;
+}
+
+export function getAge(birthday: DateInput, at?: DateInput): number | null {
+	const birthdayDate = toDateTime(birthday);
+	if (!birthdayDate) return null;
+
+	const reference = toDateTime(at) ?? DateTime.now();
+
+	return Math.floor(reference.diff(birthdayDate, "years").years);
+}
+
+export function getAgeLabel(birthday: DateInput, at?: DateInput): string {
+	const age = getAge(birthday, at);
+	if (age === null) return "";
+
+	return `${age} ${age === 1 ? "rok" : age < 5 ? "roky" : "let"}`;
+}
+
+export function hasBirthdayBetween(birthday: DateInput, from: DateInput, till: DateInput): boolean {
+	const birthdayDate = toDateTime(birthday);
+	const fromDate = toDateTime(from)?.startOf("day");
+	const tillDate = toDateTime(till)?.endOf("day");
+	if (!birthdayDate || !fromDate || !tillDate) return false;
+
+	let next = birthdayDate.set({ year: fromDate.year }).startOf("day");
+	if (next < fromDate) next = next.plus({ years: 1 });
+
+	return next <= tillDate;
+}


### PR DESCRIPTION
# Změny

- Výpočet věku je nově na jednom místě — `frontend/src/helpers/age.ts` (`getAge`, `getAgeLabel`, `hasBirthdayBetween`). Dřív se počítal zvlášť ve čtyřech místech: `MemberPipe` (seznam členů, oddíl), kartička „Věk účastníků“, kartička „Narozeniny během akce“ a ikonka 🎉 u účastníka. Všechna čtyři teď volají helper.
- Vedlejší efekt sjednocení: kartička „Narozeniny během akce“ nově zahrne i narozeniny padnoucí přesně na **první den akce** — dřív je vynechávala, i když ikonka u účastníka je ukazovala.
- `MemberPipe` má vlastnost `ageLabel` (věk se skloňováním: „1 rok“ / „3 roky“ / „12 let“) a volitelné referenční datum.
- `bo-member-item-detail` (řádek se jménem) zobrazuje za jménem věk: `Bilbo Pytlík • 46 let`. Používá se v **seznamu účastníků akce** i ve výběru člena při přidávání účastníka.
- V seznamu účastníků se věk počítá **ke dni začátku akce** (stejně jako kartička „Věk účastníků“), takže u budoucích akcí sedí na počítání jízdenek. Pod seznamem je to napsané jako vysvětlivka. Ve výběru člena (mimo akci) se počítá k dnešku.
- V kartě „Osobní informace“ na profilu člena je za datem narození věk: `22. 9. 1980 (45 let)`.

Ověřeno v běžícím devu (Postgres + seed) na akci „Tábor v Roklince“ v desktopu i mobilním rozložení a na profilu člena; hraniční případy narozenin (první den akce / poslední den / den před akcí) ověřené proti upraveným datům narození.

Closes #379