### PR TITLE
feat(events): picker na lidi ukazuje, kdo už je vybraný, a přidává bez zavření

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,11 @@
 
 ## People picker
 
-- **`MemberSelectorModalComponent` is the only picker on people.** Ionic assigns `componentProps` as plain properties, so `selectedIds` is a **`Signal<number[]>` owned by the caller** — that is what repaints the checked state when the underlying list changes. Without it the picker stays as it was: no checkboxes, "Zrušit", closes on the first pick (`users-view`).
-- With `keepOpenAfterSelect` the modal stays open, the button reads "Hotovo" (everything is already saved) and `onSelect`/`onDeselect` may be async — the row shows a spinner and ignores further clicks meanwhile. `event-attendees` both adds and removes through it; unchecking a leader there is deliberately not confirmed, unlike the list's delete button, because one more click puts them back.
+- **`MemberSelectorModalComponent` is the only picker on people.** It wraps `bo-modal-layout` like every other modal — title/subtitle + ✕ in the title slot, sticky search and group chips above the scrolling list, count and buttons in the footer (design handoff "Výběr lidí", #357). `dialog-picker` pins it to 560 px / 720 px.
+- Ionic assigns `componentProps` as plain properties, so `selectedIds` is a **`Signal<number[]>` owned by the caller** — that is what repaints the checked state when the underlying list changes. Without it the picker is single-select: no checkboxes, no count, "Zrušit", closes on the first pick (`users-view`).
+- With `keepOpenAfterSelect` the modal stays open, the button reads "Hotovo" (everything is already saved) and `onSelect`/`onDeselect`/`onClearAll` may be async — the row shows a spinner and ignores further clicks meanwhile. `event-attendees` adds, removes and (confirmed) clears through it; unchecking a single leader there is deliberately not confirmed, unlike the list's delete button, because one more click puts them back.
+- **Filtering never touches the selection** — the footer count is the source of truth. Search is diacritics-insensitive substring over nickname + first/last name; group chips come from the groups actually present in the loaded list. Group tags tint the group's own colour (`rgba` + a fixed-lightness `hsl`, both themes as `--mp-tag-*` custom properties) instead of the solid badge used in lists.
+- **Content projection ignores `slot=` on elements inside `@if`** — the footer must be projected unconditionally, with the branch inside it, or it silently lands in the default slot. The host also needs `display: flex; max-height: 100%`, or the list overflows past the footer instead of scrolling.
 
 ## API routes & links
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,11 @@
 - **Bootstrap is loaded globally, so `.modal-header`/`.modal-body`/`.modal-footer` are taken** — its rules centred the title. Component classes there are prefixed `bm-`.
 - **A modal's "can I edit this" flag must read the persisted value, not its own checkbox signal** — `unmarkX.allowed` is false while `xSentAt` is null, so deriving it from the checkbox disables the save button the instant the box is ticked.
 
+## People picker
+
+- **`MemberSelectorModalComponent` is the only picker on people.** Ionic assigns `componentProps` as plain properties, so `selectedIds` is a **`Signal<number[]>` owned by the caller** — that is what repaints the checked state when the underlying list changes. Without it the picker stays as it was: no checkboxes, "Zrušit", closes on the first pick (`users-view`).
+- With `keepOpenAfterSelect` the modal stays open, the button reads "Hotovo" (everything is already saved) and `onSelect`/`onDeselect` may be async — the row shows a spinner and ignores further clicks meanwhile. `event-attendees` both adds and removes through it; unchecking a leader there is deliberately not confirmed, unlike the list's delete button, because one more click puts them back.
+
 ## API routes & links
 
 - **Route parameters are named after their entity, never `id`** — `:eventId`, `:memberId`, `:albumId`, … The `Public API` controllers are the exception: their `:id` params are in URLs bosan.cz already calls. Renaming a param changes the SDK signature, so regenerate it.

--- a/frontend/src/app/features/admin/pages/users-view/users-view.component.ts
+++ b/frontend/src/app/features/admin/pages/users-view/users-view.component.ts
@@ -115,7 +115,14 @@ export class UsersViewComponent {
 		const user = this.user();
 		if (!user?._links.updateUser.allowed) return;
 
-		const member = await this.modalService.componentModal(MemberSelectorModalComponent);
+		const member = await this.modalService.componentModal(
+			MemberSelectorModalComponent,
+			{
+				title: "Propojit člena",
+				subtitle: "Vyber člena, kterému tenhle účet patří.",
+			},
+			{ cssClass: "dialog-picker" },
+		);
 		if (member) await this.updateUser({ memberId: member.id });
 	}
 

--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
@@ -108,27 +108,41 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 		const event = this.event();
 		if (!event) return;
 
-		const addSelectedMember = async (member?: SDK.MemberResponse | null) => {
-			if (!member?.id) return;
+		const selectedIds = computed(() =>
+			((type === "leader" ? this.leaders() : this.attendees()) ?? []).map((attendee) => attendee.memberId),
+		);
 
+		const addSelectedMember = async (member: SDK.MemberResponse) => {
 			try {
-				const existingAttendee = [...(this.attendees() ?? []), ...(this.leaders() ?? [])].find(
-					(item) => item.member && item.member.id === member.id,
-				);
-				if (existingAttendee && existingAttendee.type === type) {
-					this.toastService.toast("Účastník už v seznamu je.");
-					return;
-				}
-
-				if (existingAttendee) {
+				if (this.findAttendee(member.id)) {
 					await this.api.EventsApi.updateEventAttendee(event.id, member.id, { type });
 				} else {
 					await this.api.EventsApi.addEventAttendee(event.id, member.id, { type });
 				}
-
-				this.toastService.toast("Účastník přidán.");
 			} catch (e) {
-				this.toastService.toast("Nepodařilo se přidat účastníka." + e);
+				this.toastService.toast("Nepodařilo se přidat účastníka.", { color: "danger" });
+				return;
+			}
+
+			await this.loadAttendees(event);
+
+			this.change.emit();
+		};
+
+		const removeSelectedMember = async (member: SDK.MemberResponse) => {
+			const attendee = this.findAttendee(member.id);
+			if (!attendee) return;
+
+			if (!attendee._links.deleteEventAttendee.allowed) {
+				this.toastService.toast("Tohoto účastníka nemůžete odebrat.", { color: "danger" });
+				return;
+			}
+
+			try {
+				await this.api.EventsApi.deleteEventAttendee(event.id, member.id);
+			} catch (e) {
+				this.toastService.toast("Nepodařilo se odebrat účastníka.", { color: "danger" });
+				return;
 			}
 
 			await this.loadAttendees(event);
@@ -139,8 +153,16 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 		await this.modalService.componentModal(MemberSelectorModalComponent, {
 			keepOpenAfterSelect: true,
 			roles: type === "leader" ? LEADER_ROLES : undefined,
-			onSelect: (member: SDK.MemberResponse) => void addSelectedMember(member),
+			selectedIds,
+			onSelect: addSelectedMember,
+			onDeselect: removeSelectedMember,
 		});
+	}
+
+	private findAttendee(memberId: number) {
+		return [...(this.attendees() ?? []), ...(this.leaders() ?? [])].find(
+			(attendee) => attendee.memberId === memberId,
+		);
 	}
 
 	async removeAttendee(attendee: SDK.EventAttendeeResponseWithLinks) {

--- a/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
+++ b/frontend/src/app/features/events/components/event-attendees/event-attendees.component.ts
@@ -108,9 +108,8 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 		const event = this.event();
 		if (!event) return;
 
-		const selectedIds = computed(() =>
-			((type === "leader" ? this.leaders() : this.attendees()) ?? []).map((attendee) => attendee.memberId),
-		);
+		const selectedAttendees = computed(() => (type === "leader" ? this.leaders() : this.attendees()) ?? []);
+		const selectedIds = computed(() => selectedAttendees().map((attendee) => attendee.memberId));
 
 		const addSelectedMember = async (member: SDK.MemberResponse) => {
 			try {
@@ -150,13 +149,50 @@ export class EventAttendeesComponent implements OnInit, OnDestroy {
 			this.change.emit();
 		};
 
-		await this.modalService.componentModal(MemberSelectorModalComponent, {
-			keepOpenAfterSelect: true,
-			roles: type === "leader" ? LEADER_ROLES : undefined,
-			selectedIds,
-			onSelect: addSelectedMember,
-			onDeselect: removeSelectedMember,
-		});
+		const clearAllMembers = async () => {
+			const removable = (selectedAttendees() ?? []).filter(
+				(attendee) => attendee._links.deleteEventAttendee.allowed,
+			);
+			if (!removable.length) return;
+
+			const confirmation = await this.modalService.deleteConfirmationModal(
+				type === "leader"
+					? "Opravdu chcete odebrat všechny vedoucí akce?"
+					: "Opravdu chcete odebrat všechny účastníky akce?",
+				{ header: "Odebrat vše?", buttonText: "Odebrat" },
+			);
+			if (!confirmation) return;
+
+			try {
+				for (const attendee of removable) {
+					await this.api.EventsApi.deleteEventAttendee(event.id, attendee.memberId);
+				}
+			} catch (e) {
+				this.toastService.toast("Nepodařilo se odebrat účastníky.", { color: "danger" });
+			}
+
+			await this.loadAttendees(event);
+
+			this.change.emit();
+		};
+
+		await this.modalService.componentModal(
+			MemberSelectorModalComponent,
+			{
+				keepOpenAfterSelect: true,
+				roles: type === "leader" ? LEADER_ROLES : undefined,
+				title: type === "leader" ? "Přidat vedoucí" : "Přidat účastníky",
+				subtitle:
+					type === "leader"
+						? "Vyber vedoucí a instruktory ze svého oddílu."
+						: "Vyber účastníky ze svého oddílu.",
+				selectedIds,
+				onSelect: addSelectedMember,
+				onDeselect: removeSelectedMember,
+				onClearAll: clearAllMembers,
+			},
+			{ cssClass: "dialog-picker" },
+		);
 	}
 
 	private findAttendee(memberId: number) {

--- a/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.html
+++ b/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.html
@@ -1,53 +1,106 @@
-<ion-toolbar>
-	<ion-searchbar
-		#searchBar
-		placeholder="Hledej…"
-		enterkeyhint="search"
-		(ionInput)="searchMembers($any($event).detail.value)"
-	></ion-searchbar>
-	<ion-buttons slot="end">
-		<ion-button (click)="close.emit()">{{ keepOpenAfterSelect ? "Hotovo" : "Zrušit" }}</ion-button>
-	</ion-buttons>
-</ion-toolbar>
-
-@if (selectable) {
-	<div class="selection-summary" [class.empty]="!selectedCount()">
-		<ion-icon [name]="selectedCount() ? 'checkmark-circle' : 'ellipse-outline'"></ion-icon>
-		{{ selectedLabel() }}
+<bo-modal-layout>
+	<div slot="title" class="mp-head">
+		<div class="mp-head-text">
+			<h4>{{ title }}</h4>
+			@if (subtitle) {
+				<p class="mp-subtitle">{{ subtitle }}</p>
+			}
+		</div>
+		<button type="button" class="mp-close" aria-label="Zavřít" (click)="close.emit()">
+			<ion-icon name="close-outline"></ion-icon>
+		</button>
 	</div>
-}
 
-<div class="member-selector-scrollable">
-	<ion-list>
+	<div class="mp-tools">
+		<div class="mp-search">
+			<ion-icon name="search-outline" aria-hidden="true"></ion-icon>
+			<input
+				#searchInput
+				type="text"
+				enterkeyhint="search"
+				autocomplete="off"
+				placeholder="Hledat podle jména nebo přezdívky"
+				aria-label="Hledat podle jména nebo přezdívky"
+				[value]="query()"
+				(input)="query.set($any($event.target).value)"
+			/>
+			@if (query()) {
+				<button type="button" class="mp-clear" (click)="clearQuery()">Zrušit</button>
+			}
+		</div>
+
+		@if (groupChips().length > 1) {
+			<div class="mp-chips">
+				<button
+					type="button"
+					class="mp-chip"
+					[class.active]="groupFilter() === null"
+					(click)="groupFilter.set(null)"
+				>
+					Všichni
+				</button>
+				@for (chip of groupChips(); track chip.id) {
+					<button
+						type="button"
+						class="mp-chip"
+						[class.active]="groupFilter() === chip.id"
+						(click)="groupFilter.set(chip.id)"
+					>
+						{{ chip.name }}
+					</button>
+				}
+			</div>
+		}
+	</div>
+
+	<div class="mp-list">
 		@for (member of filteredMembers(); track member.id) {
-			<ion-item [button]="true" [class.selected]="isSelected(member.id)" (click)="toggleMember(member)">
+			<label class="mp-row" [class.selected]="isSelected(member.id)" [class.pending]="isPending(member.id)">
+				<input
+					class="bm-visually-hidden"
+					[attr.type]="selectable ? 'checkbox' : 'radio'"
+					name="member-selector"
+					[checked]="isSelected(member.id)"
+					[disabled]="isPending(member.id)"
+					(change)="toggleMember(member)"
+				/>
 				@if (selectable) {
-					<div class="state" slot="start">
+					<span class="bm-checkbox mp-box">
 						@if (isPending(member.id)) {
 							<ion-spinner name="crescent"></ion-spinner>
-						} @else {
-							<ion-icon [name]="isSelected(member.id) ? 'checkbox' : 'square-outline'"></ion-icon>
+						} @else if (isSelected(member.id)) {
+							<ion-icon name="checkmark-outline"></ion-icon>
 						}
-					</div>
+					</span>
 				}
-				<ion-label>
-					<h3>{{ member | member: "nickname" }}</h3>
-					<p><bo-member-item-detail [member]="member"></bo-member-item-detail></p>
-				</ion-label>
-				<ion-badge mode="ios" [style.background-color]="member.groupId | group: 'color'">
+				<span class="mp-row-text">
+					<span class="mp-nickname">{{ member | member: "nickname" }}</span>
+					<span class="mp-name"><bo-member-item-detail [member]="member"></bo-member-item-detail></span>
+				</span>
+				<span class="mp-tag" [style]="tagStyles().get(member.groupId)">
 					{{ member.groupId | group: "name" }}
-				</ion-badge>
-			</ion-item>
+				</span>
+			</label>
 		}
 
 		@if (loading()) {
-			<ion-item>
-				<ion-label class="loading"><ion-spinner name="crescent"></ion-spinner></ion-label>
-			</ion-item>
+			<div class="mp-placeholder"><ion-spinner name="crescent"></ion-spinner></div>
 		} @else if (!filteredMembers().length) {
-			<ion-item>
-				<ion-label class="text-muted"><em>Nikoho jsme nenašli</em></ion-label>
-			</ion-item>
+			<div class="mp-placeholder mp-empty">Nikdo nenalezen.</div>
 		}
-	</ion-list>
-</div>
+	</div>
+
+	<div slot="buttons" class="mp-foot">
+		@if (selectable) {
+			<span class="mp-count">{{ selectedLabel() }}</span>
+			@if (onClearAll && selectedCount()) {
+				<button type="button" class="bm-btn-ghost" [disabled]="clearing()" (click)="clearAll()">
+					Odebrat vše
+				</button>
+			}
+			<button type="button" class="bm-btn-primary" (click)="close.emit()">Hotovo</button>
+		} @else {
+			<button type="button" class="bm-btn-ghost" (click)="close.emit()">Zrušit</button>
+		}
+	</div>
+</bo-modal-layout>

--- a/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.html
+++ b/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.html
@@ -1,18 +1,35 @@
 <ion-toolbar>
 	<ion-searchbar
 		#searchBar
+		placeholder="Hledej…"
 		enterkeyhint="search"
 		(ionInput)="searchMembers($any($event).detail.value)"
 	></ion-searchbar>
 	<ion-buttons slot="end">
-		<ion-button (click)="close.emit()">Zrušit</ion-button>
+		<ion-button (click)="close.emit()">{{ keepOpenAfterSelect ? "Hotovo" : "Zrušit" }}</ion-button>
 	</ion-buttons>
 </ion-toolbar>
+
+@if (selectable) {
+	<div class="selection-summary" [class.empty]="!selectedCount()">
+		<ion-icon [name]="selectedCount() ? 'checkmark-circle' : 'ellipse-outline'"></ion-icon>
+		{{ selectedLabel() }}
+	</div>
+}
 
 <div class="member-selector-scrollable">
 	<ion-list>
 		@for (member of filteredMembers(); track member.id) {
-			<ion-item [button]="true" (click)="selectMember(member)">
+			<ion-item [button]="true" [class.selected]="isSelected(member.id)" (click)="toggleMember(member)">
+				@if (selectable) {
+					<div class="state" slot="start">
+						@if (isPending(member.id)) {
+							<ion-spinner name="crescent"></ion-spinner>
+						} @else {
+							<ion-icon [name]="isSelected(member.id) ? 'checkbox' : 'square-outline'"></ion-icon>
+						}
+					</div>
+				}
 				<ion-label>
 					<h3>{{ member | member: "nickname" }}</h3>
 					<p><bo-member-item-detail [member]="member"></bo-member-item-detail></p>
@@ -20,6 +37,16 @@
 				<ion-badge mode="ios" [style.background-color]="member.groupId | group: 'color'">
 					{{ member.groupId | group: "name" }}
 				</ion-badge>
+			</ion-item>
+		}
+
+		@if (loading()) {
+			<ion-item>
+				<ion-label class="loading"><ion-spinner name="crescent"></ion-spinner></ion-label>
+			</ion-item>
+		} @else if (!filteredMembers().length) {
+			<ion-item>
+				<ion-label class="text-muted"><em>Nikoho jsme nenašli</em></ion-label>
 			</ion-item>
 		}
 	</ion-list>

--- a/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.scss
+++ b/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.scss
@@ -2,3 +2,66 @@
 	max-height: 50vh;
 	overflow-y: auto;
 }
+
+.selection-summary {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.5rem 1rem;
+	border-bottom: 1px solid var(--bo-line);
+	color: var(--bo-green);
+	font-weight: 700;
+
+	ion-icon {
+		font-size: 1.1rem;
+	}
+
+	&.empty {
+		color: var(--bo-muted);
+		font-weight: 400;
+	}
+}
+
+ion-item {
+	--padding-start: 0.75rem;
+
+	.loading {
+		display: flex;
+		justify-content: center;
+
+		ion-spinner {
+			color: var(--bo-blue);
+		}
+	}
+
+	.state {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		margin-inline-end: 0.5rem;
+
+		ion-icon {
+			font-size: 1.35rem;
+			color: var(--bo-muted);
+		}
+
+		ion-spinner {
+			width: 1.2rem;
+			height: 1.2rem;
+			color: var(--bo-blue);
+		}
+	}
+
+	&.selected {
+		--background: var(--bo-green-tint);
+
+		.state ion-icon {
+			color: var(--bo-green);
+		}
+
+		h3 {
+			font-weight: 700;
+		}
+	}
+}

--- a/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.scss
+++ b/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.scss
@@ -1,67 +1,296 @@
-.member-selector-scrollable {
-	max-height: 50vh;
-	overflow-y: auto;
+@use "./../../../../../styles/brand-modal" as *;
+
+:host {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	max-height: 100%;
+	overflow: hidden;
 }
 
-.selection-summary {
+.mp-head {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.mp-head-text {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	min-width: 0;
+}
+
+.mp-subtitle {
+	margin: 0;
+	font-size: 14px;
+	font-weight: 400;
+	color: var(--bm-muted);
+}
+
+.mp-close {
+	flex: none;
 	display: flex;
 	align-items: center;
-	gap: 0.4rem;
-	padding: 0.5rem 1rem;
-	border-bottom: 1px solid var(--bo-line);
-	color: var(--bo-green);
-	font-weight: 700;
+	justify-content: center;
+	width: 32px;
+	height: 32px;
+	margin: -4px -6px 0 0;
+	padding: 0;
+	border: none;
+	border-radius: 9px;
+	background: transparent;
+	color: var(--bm-muted-2);
+	cursor: pointer;
 
 	ion-icon {
-		font-size: 1.1rem;
+		font-size: 22px;
 	}
 
-	&.empty {
-		color: var(--bo-muted);
-		font-weight: 400;
+	&:hover {
+		background: var(--bm-surface-hover);
+		color: var(--bm-blue);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--bm-blue);
+		outline-offset: 2px;
 	}
 }
 
-ion-item {
-	--padding-start: 0.75rem;
+.mp-tools {
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	margin: 0 -12px;
+	padding: 2px 28px 14px;
+	border-bottom: 1px solid var(--bm-border-soft);
+	background: var(--bo-paper);
+}
 
-	.loading {
-		display: flex;
-		justify-content: center;
+.mp-search {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	height: 46px;
+	padding: 0 14px;
+	border: 1.5px solid var(--bm-border);
+	border-radius: 11px;
+	background: var(--bm-surface-alt);
 
-		ion-spinner {
-			color: var(--bo-blue);
-		}
+	&:focus-within {
+		border-color: var(--bm-blue);
 	}
 
-	.state {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 1.75rem;
-		margin-inline-end: 0.5rem;
+	> ion-icon {
+		flex: none;
+		font-size: 17px;
+		color: var(--bm-muted-2);
+	}
 
-		ion-icon {
-			font-size: 1.35rem;
-			color: var(--bo-muted);
-		}
+	input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		outline: none;
+		background: transparent;
+		font: inherit;
+		font-size: 15px;
+		color: var(--bm-text);
 
-		ion-spinner {
-			width: 1.2rem;
-			height: 1.2rem;
-			color: var(--bo-blue);
+		&::placeholder {
+			color: var(--bm-muted-2);
 		}
+	}
+}
+
+.mp-clear {
+	flex: none;
+	padding: 4px 6px;
+	border: none;
+	border-radius: 6px;
+	background: transparent;
+	font-family: inherit;
+	font-size: 12px;
+	font-weight: 700;
+	color: var(--bm-muted-2);
+	cursor: pointer;
+
+	&:hover {
+		color: var(--bm-blue);
+	}
+}
+
+.mp-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.mp-chip {
+	padding: 7px 13px;
+	border: 1.5px solid var(--bm-border);
+	border-radius: var(--bo-radius-pill);
+	background: transparent;
+	font-family: inherit;
+	font-size: 13px;
+	font-weight: 700;
+	color: var(--bm-muted);
+	cursor: pointer;
+
+	&:hover {
+		border-color: var(--bm-blue);
+		color: var(--bm-blue);
+	}
+
+	&.active {
+		border-color: var(--bm-blue);
+		background: var(--bm-blue);
+		color: #ffffff;
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--bm-blue);
+		outline-offset: 2px;
+	}
+}
+
+.mp-list {
+	display: flex;
+	flex-direction: column;
+	padding-top: 8px;
+}
+
+.mp-row {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	padding: 12px 14px;
+	border-radius: 11px;
+	cursor: pointer;
+
+	&:hover {
+		background: var(--bm-surface-hover);
 	}
 
 	&.selected {
-		--background: var(--bo-green-tint);
+		background: var(--bm-checked-bg);
+	}
 
-		.state ion-icon {
-			color: var(--bo-green);
-		}
+	&.pending {
+		cursor: default;
+	}
 
-		h3 {
-			font-weight: 700;
-		}
+	&:focus-within {
+		outline: 2px solid var(--bm-blue);
+		outline-offset: -2px;
+	}
+}
+
+.mp-box {
+	margin-top: 0;
+
+	ion-spinner {
+		width: 15px;
+		height: 15px;
+		color: var(--bm-blue);
+	}
+}
+
+.mp-row.selected .mp-box {
+	border-color: var(--bm-blue);
+	background: var(--bm-blue);
+}
+
+.mp-row-text {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.mp-nickname {
+	font-size: 15px;
+	font-weight: 700;
+	color: var(--bm-text);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.mp-name {
+	font-size: 13px;
+	color: var(--bm-muted);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.mp-tag {
+	flex: none;
+	padding: 4px 10px;
+	border-radius: 7px;
+	font-size: 12px;
+	font-weight: 700;
+	background: var(--mp-tag-bg, var(--bm-chip-bg));
+	color: var(--mp-tag-fg, var(--bm-chip-fg));
+}
+
+:host-context(body.dark) .mp-tag {
+	background: var(--mp-tag-bg-dark, var(--bm-chip-bg));
+	color: var(--mp-tag-fg-dark, var(--bm-chip-fg));
+}
+
+.mp-placeholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 44px 20px;
+	font-size: 14px;
+	color: var(--bm-muted-2);
+
+	ion-spinner {
+		color: var(--bm-blue);
+	}
+}
+
+.mp-foot {
+	display: flex;
+	flex: 1;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 10px;
+}
+
+.mp-count {
+	margin-right: auto;
+	text-align: left;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--bm-muted);
+}
+
+.mp-foot button {
+	white-space: nowrap;
+}
+
+@media (max-width: 480px) {
+	.mp-tools {
+		padding-inline: 16px;
+	}
+
+	.mp-foot {
+		flex-wrap: wrap;
+		row-gap: 10px;
+	}
+
+	.mp-count {
+		flex: 1 0 100%;
+		margin-right: 0;
 	}
 }

--- a/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.ts
+++ b/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.ts
@@ -1,24 +1,13 @@
-import { CommonModule } from "@angular/common";
-import { Component, computed, input, OnInit, Signal, signal, ViewChild } from "@angular/core";
-import {
-	IonBadge,
-	IonButton,
-	IonButtons,
-	IonIcon,
-	IonItem,
-	IonLabel,
-	IonList,
-	IonSearchbar,
-	IonSpinner,
-	IonToolbar,
-	ModalController,
-	ViewDidEnter,
-} from "@ionic/angular/standalone";
+import { Component, computed, ElementRef, inject, input, OnInit, Signal, signal, ViewChild } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { IonIcon, IonSpinner, ModalController, ViewDidEnter } from "@ionic/angular/standalone";
 import { addIcons } from "ionicons";
-import { checkbox, checkmarkCircle, ellipseOutline, squareOutline } from "ionicons/icons";
+import { checkmarkOutline, closeOutline, searchOutline } from "ionicons/icons";
 import { ApiService } from "src/app/core/services/api.service";
+import { GroupsService } from "src/app/core/services/groups.service";
 import { InputModalComponent } from "src/app/core/services/modal.service";
 import { MemberItemDetailComponent } from "src/app/shared/components/member-item-detail/member-item-detail.component";
+import { ModalLayoutComponent } from "src/app/shared/components/modal-layout/modal-layout.component";
 import { SDK } from "src/sdk";
 import { GroupPipe } from "../../../../shared/pipes/group.pipe";
 import { MemberPipe } from "../../../../shared/pipes/member.pipe";
@@ -27,22 +16,7 @@ import { MemberPipe } from "../../../../shared/pipes/member.pipe";
 	selector: "bo-member-selector-modal",
 	templateUrl: "./member-selector-modal.component.html",
 	styleUrls: ["./member-selector-modal.component.scss"],
-	imports: [
-		CommonModule,
-		IonSearchbar,
-		IonToolbar,
-		IonButtons,
-		IonButton,
-		IonList,
-		IonItem,
-		IonLabel,
-		IonBadge,
-		IonIcon,
-		IonSpinner,
-		MemberItemDetailComponent,
-		GroupPipe,
-		MemberPipe,
-	],
+	imports: [IonIcon, IonSpinner, ModalLayoutComponent, MemberItemDetailComponent, GroupPipe, MemberPipe],
 })
 export class MemberSelectorModalComponent
 	extends InputModalComponent<SDK.MemberResponse>
@@ -51,15 +25,55 @@ export class MemberSelectorModalComponent
 	members = input<SDK.MemberResponse[]>([]);
 	keepOpenAfterSelect = false;
 	roles?: SDK.MemberRolesEnum[];
+	title = "Vybrat člověka";
+	subtitle?: string;
 	selectedIds?: Signal<number[]>;
 	onSelect?: (member: SDK.MemberResponse) => void | Promise<void>;
 	onDeselect?: (member: SDK.MemberResponse) => void | Promise<void>;
+	onClearAll?: () => void | Promise<void>;
 
-	membersIndex: string[] = [];
-
-	filteredMembers = signal<SDK.MemberResponse[]>([]);
-	pendingIds = signal<number[]>([]);
+	query = signal("");
+	groupFilter = signal<number | null>(null);
 	loading = signal(true);
+	clearing = signal(false);
+	pendingIds = signal<number[]>([]);
+
+	private api = inject(ApiService);
+	private groupsService = inject(GroupsService);
+
+	private allMembers = signal<SDK.MemberResponse[]>([]);
+	private groups = toSignal(this.groupsService.groups, { initialValue: [] as SDK.GroupResponseWithLinks[] });
+
+	private membersIndex = computed(
+		() =>
+			new Map(
+				this.allMembers().map((member) => [
+					member.id,
+					this.normalize([member.nickname, member.firstName, member.lastName].filter(Boolean).join(" ")),
+				]),
+			),
+	);
+
+	filteredMembers = computed(() => {
+		const group = this.groupFilter();
+		const query = this.normalize(this.query().trim());
+		const index = this.membersIndex();
+
+		return this.allMembers().filter(
+			(member) =>
+				(group === null || member.groupId === group) &&
+				(!query || (index.get(member.id) ?? "").includes(query)),
+		);
+	});
+
+	groupChips = computed(() => {
+		const groupIds = new Set(this.allMembers().map((member) => member.groupId));
+		return this.groups()
+			.filter((group) => groupIds.has(group.id))
+			.map((group) => ({ id: group.id, name: group.name ?? group.shortName }));
+	});
+
+	tagStyles = computed(() => new Map(this.groups().map((group) => [group.id, this.tagStyle(group.color)] as const)));
 
 	private selectedIdsSet = computed(() => new Set(this.selectedIds?.() ?? []));
 
@@ -67,22 +81,17 @@ export class MemberSelectorModalComponent
 
 	selectedLabel = computed(() => {
 		const count = this.selectedCount();
-		if (count === 0) return "Zatím nikdo není vybraný";
+		if (count === 0) return "Nikdo nevybrán";
 		if (count === 1) return "Vybrán 1 člověk";
 		if (count < 5) return `Vybráni ${count} lidé`;
 		return `Vybráno ${count} lidí`;
 	});
 
-	private _members: SDK.MemberResponse[] = [];
+	@ViewChild("searchInput") searchInput!: ElementRef<HTMLInputElement>;
 
-	@ViewChild("searchBar") searchBar!: IonSearchbar;
-
-	constructor(
-		private api: ApiService,
-		modalController: ModalController,
-	) {
-		super(modalController);
-		addIcons({ checkbox, checkmarkCircle, ellipseOutline, squareOutline });
+	constructor() {
+		super(inject(ModalController));
+		addIcons({ checkmarkOutline, closeOutline, searchOutline });
 	}
 
 	get selectable() {
@@ -92,27 +101,24 @@ export class MemberSelectorModalComponent
 	ngOnInit(): void {
 		this.loadMembers();
 	}
+
 	private async loadMembers() {
 		const roles = this.roles;
 
 		const inputMembers = this.members();
 		if (inputMembers && inputMembers.length === 0) {
-			this._members = await this.api.MembersApi.listMembers({ limit: 1000, roles }).then((res) => res.data);
+			this.allMembers.set(
+				await this.api.MembersApi.listMembers({ limit: 1000, roles }).then((res) => this.sort(res.data)),
+			);
 		} else {
-			this._members = (inputMembers || []).filter((member) => !roles || roles.includes(member.role));
+			this.allMembers.set(this.sort(inputMembers.filter((member) => !roles || roles.includes(member.role))));
 		}
-
-		this.sortMembers();
-
-		this.createIndex();
-
-		this.searchMembers();
 
 		this.loading.set(false);
 	}
 
 	ionViewDidEnter() {
-		window.setTimeout(() => this.searchBar.setFocus(), 300);
+		window.setTimeout(() => this.searchInput?.nativeElement.focus(), 300);
 	}
 
 	isSelected(memberId: number) {
@@ -121,6 +127,11 @@ export class MemberSelectorModalComponent
 
 	isPending(memberId: number) {
 		return this.pendingIds().includes(memberId);
+	}
+
+	clearQuery() {
+		this.query.set("");
+		this.searchInput?.nativeElement.focus();
 	}
 
 	async toggleMember(member: SDK.MemberResponse) {
@@ -143,33 +154,82 @@ export class MemberSelectorModalComponent
 		if (!selected && !this.keepOpenAfterSelect) this.submit.emit(member);
 	}
 
-	searchMembers(searchString?: string) {
-		if (!searchString) {
-			this.filteredMembers.set(this._members);
-			return;
+	async clearAll() {
+		if (!this.onClearAll || this.clearing()) return;
+
+		this.clearing.set(true);
+		try {
+			await this.onClearAll();
+		} finally {
+			this.clearing.set(false);
 		}
-
-		searchString = searchString.replace(/[.*+?^${}()|[\]\\]/gi, "\\$&");
-		const re = new RegExp("(^| )" + searchString, "i");
-
-		this.filteredMembers.set(this._members.filter((member, i) => re.test(this.membersIndex[i])));
 	}
 
 	private setPending(memberId: number, pending: boolean) {
 		this.pendingIds.update((ids) => (pending ? [...ids, memberId] : ids.filter((id) => id !== memberId)));
 	}
 
-	private createIndex() {
-		this.membersIndex = this._members.map((member) => {
-			return [member.nickname, member.firstName, member.lastName].filter((value) => !!value).join(" ");
-		});
-	}
-
-	private sortMembers() {
-		this._members.sort((a, b) => {
+	private sort(members: SDK.MemberResponse[]) {
+		return [...members].sort((a, b) => {
 			const aString = a.nickname || a.firstName || a.lastName || "";
 			const bString = b.nickname || b.firstName || b.lastName || "";
 			return aString.localeCompare(bString);
 		});
+	}
+
+	private normalize(value: string) {
+		return value
+			.toLocaleLowerCase()
+			.normalize("NFD")
+			.replace(/\p{Diacritic}/gu, "");
+	}
+
+	private tagStyle(color?: string | null) {
+		const rgb = this.parseColor(color);
+		if (!rgb) return {};
+
+		const [hue, saturation] = this.toHueSaturation(rgb);
+
+		return {
+			"--mp-tag-bg": `rgba(${rgb.join(", ")}, 0.16)`,
+			"--mp-tag-fg": `hsl(${hue} ${saturation}% 32%)`,
+			"--mp-tag-bg-dark": `rgba(${rgb.join(", ")}, 0.26)`,
+			"--mp-tag-fg-dark": `hsl(${hue} ${saturation}% 74%)`,
+		};
+	}
+
+	private parseColor(color?: string | null): [number, number, number] | null {
+		const value = (color ?? "").trim().replace(/^#/, "");
+		const hex =
+			value.length === 3
+				? value
+						.split("")
+						.map((char) => char + char)
+						.join("")
+				: value;
+
+		if (!/^[0-9a-f]{6}$/i.test(hex)) return null;
+
+		const number = parseInt(hex, 16);
+		return [(number >> 16) & 255, (number >> 8) & 255, number & 255];
+	}
+
+	private toHueSaturation([r, g, b]: [number, number, number]) {
+		const [red, green, blue] = [r / 255, g / 255, b / 255];
+		const max = Math.max(red, green, blue);
+		const min = Math.min(red, green, blue);
+		const delta = max - min;
+		const lightness = (max + min) / 2;
+
+		if (!delta) return [0, 0];
+
+		const saturation = delta / (1 - Math.abs(2 * lightness - 1));
+
+		let hue: number;
+		if (max === red) hue = ((green - blue) / delta) % 6;
+		else if (max === green) hue = (blue - red) / delta + 2;
+		else hue = (red - green) / delta + 4;
+
+		return [Math.round((((hue * 60) % 360) + 360) % 360), Math.round(saturation * 100)];
 	}
 }

--- a/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.ts
+++ b/frontend/src/app/features/events/components/member-selector-modal/member-selector-modal.component.ts
@@ -1,17 +1,21 @@
 import { CommonModule } from "@angular/common";
-import { Component, input, OnInit, signal, ViewChild } from "@angular/core";
+import { Component, computed, input, OnInit, Signal, signal, ViewChild } from "@angular/core";
 import {
 	IonBadge,
 	IonButton,
 	IonButtons,
+	IonIcon,
 	IonItem,
 	IonLabel,
 	IonList,
 	IonSearchbar,
+	IonSpinner,
 	IonToolbar,
 	ModalController,
 	ViewDidEnter,
 } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import { checkbox, checkmarkCircle, ellipseOutline, squareOutline } from "ionicons/icons";
 import { ApiService } from "src/app/core/services/api.service";
 import { InputModalComponent } from "src/app/core/services/modal.service";
 import { MemberItemDetailComponent } from "src/app/shared/components/member-item-detail/member-item-detail.component";
@@ -33,6 +37,8 @@ import { MemberPipe } from "../../../../shared/pipes/member.pipe";
 		IonItem,
 		IonLabel,
 		IonBadge,
+		IonIcon,
+		IonSpinner,
 		MemberItemDetailComponent,
 		GroupPipe,
 		MemberPipe,
@@ -45,11 +51,28 @@ export class MemberSelectorModalComponent
 	members = input<SDK.MemberResponse[]>([]);
 	keepOpenAfterSelect = false;
 	roles?: SDK.MemberRolesEnum[];
-	onSelect?: (member: SDK.MemberResponse) => void;
+	selectedIds?: Signal<number[]>;
+	onSelect?: (member: SDK.MemberResponse) => void | Promise<void>;
+	onDeselect?: (member: SDK.MemberResponse) => void | Promise<void>;
 
 	membersIndex: string[] = [];
 
 	filteredMembers = signal<SDK.MemberResponse[]>([]);
+	pendingIds = signal<number[]>([]);
+	loading = signal(true);
+
+	private selectedIdsSet = computed(() => new Set(this.selectedIds?.() ?? []));
+
+	selectedCount = computed(() => this.selectedIdsSet().size);
+
+	selectedLabel = computed(() => {
+		const count = this.selectedCount();
+		if (count === 0) return "Zatím nikdo není vybraný";
+		if (count === 1) return "Vybrán 1 člověk";
+		if (count < 5) return `Vybráni ${count} lidé`;
+		return `Vybráno ${count} lidí`;
+	});
+
 	private _members: SDK.MemberResponse[] = [];
 
 	@ViewChild("searchBar") searchBar!: IonSearchbar;
@@ -59,6 +82,11 @@ export class MemberSelectorModalComponent
 		modalController: ModalController,
 	) {
 		super(modalController);
+		addIcons({ checkbox, checkmarkCircle, ellipseOutline, squareOutline });
+	}
+
+	get selectable() {
+		return !!this.selectedIds;
 	}
 
 	ngOnInit(): void {
@@ -79,17 +107,40 @@ export class MemberSelectorModalComponent
 		this.createIndex();
 
 		this.searchMembers();
+
+		this.loading.set(false);
 	}
 
 	ionViewDidEnter() {
 		window.setTimeout(() => this.searchBar.setFocus(), 300);
 	}
 
-	selectMember(member: SDK.MemberResponse) {
-		this.onSelect?.(member);
-		if (this.keepOpenAfterSelect) return;
+	isSelected(memberId: number) {
+		return this.selectedIdsSet().has(memberId);
+	}
 
-		this.submit.emit(member);
+	isPending(memberId: number) {
+		return this.pendingIds().includes(memberId);
+	}
+
+	async toggleMember(member: SDK.MemberResponse) {
+		if (this.isPending(member.id)) return;
+
+		const selected = this.isSelected(member.id);
+		if (selected && !this.onDeselect) return;
+
+		const handler = selected ? this.onDeselect : this.onSelect;
+
+		if (handler) {
+			this.setPending(member.id, true);
+			try {
+				await handler(member);
+			} finally {
+				this.setPending(member.id, false);
+			}
+		}
+
+		if (!selected && !this.keepOpenAfterSelect) this.submit.emit(member);
 	}
 
 	searchMembers(searchString?: string) {
@@ -102,6 +153,10 @@ export class MemberSelectorModalComponent
 		const re = new RegExp("(^| )" + searchString, "i");
 
 		this.filteredMembers.set(this._members.filter((member, i) => re.test(this.membersIndex[i])));
+	}
+
+	private setPending(memberId: number, pending: boolean) {
+		this.pendingIds.update((ids) => (pending ? [...ids, memberId] : ids.filter((id) => id !== memberId)));
 	}
 
 	private createIndex() {

--- a/frontend/src/styles/ionic.scss
+++ b/frontend/src/styles/ionic.scss
@@ -95,6 +95,19 @@ ion-modal.dialog.dialog-list {
 	--height: 70vh;
 }
 
+/* people picker: fixed width, tall enough for the list to scroll inside */
+ion-modal.dialog.dialog-picker {
+	--width: 560px;
+	--max-width: calc(100vw - 32px);
+	--max-height: min(720px, 90vh);
+	--max-height: min(720px, 90dvh);
+
+	> .ion-page {
+		max-height: min(720px, 90vh);
+		max-height: min(720px, 90dvh);
+	}
+}
+
 /* fixed-width brand dialogs (the event announcement / closure steps) */
 ion-modal.dialog.dialog-brand {
 	--width: 480px;


### PR DESCRIPTION
# Změny

**Stav výběru v pickeru (#357)**

- Řádky lidí, kteří na akci **už jsou**, mají zaškrtnuté políčko a podbarvení — na první pohled je vidět, koho tam mám.
- Kliknutí na řádek člověka přidá, další kliknutí ho **odebere** — bez zavírání dialogu. Během volání API řádek ukazuje spinner a ignoruje další kliknutí.
- Hláška „Účastník přidán“ zmizela, stav se pozná z pickeru samotného; chybové hlášky zůstaly.

**Nový návrh modalu (design handoff „Výběr lidí“)**

- `bo-modal-layout` zůstává, přepracované jsou vnitřky: nadpis s podtitulkem a křížkem, hledací pole přes celou šířku s ikonou a mazáním dotazu, filtrovací chipy podle oddílů a patička s počtem vybraných, „Odebrat vše“ a „Hotovo“.
- Hledání a chipy zůstávají přilepené nahoře, seznam pod nimi scrolluje, patička je pořád vidět. Modal je 560 px široký (na mobilu přes celou šířku) a max. 720 px vysoký.
- Řádky mají vzdušnější rozestupy, skutečné `<input type="checkbox">` kvůli přístupnosti a jemně podbarvený odznak oddílu místo sytého badge.
- Hledání je bez ohledu na diakritiku a hledá podřetězec v přezdívce i ve jméně („sedy“ najde Gandalfa Šedého). Filtrování nikdy nemění výběr — počet v patičce je zdroj pravdy.
- „Odebrat vše“ odebere všechny účastníky daného typu; na rozdíl od návrhu se **ptá na potvrzení**, protože jde o hromadnou destruktivní akci a zbytek aplikace se u mazání ptá taky.
- Počty jsou v gramaticky správné češtině („Vybrán 1 člověk“ / „Vybráni 3 lidé“ / „Vybráno 6 lidí“) místo doslovného „Vybráno {n} lidi“ z prototypu.
- Jednorázový výběr (propojení člena s účtem v administraci) používá stejný picker bez zaškrtávátek a počtu, s tlačítkem „Zrušit“ a zavřením po výběru.

Odebrání jednoho vedoucího se v pickeru na rozdíl od seznamu nepotvrzuje — je to překliknutí, které jedno další kliknutí vrátí zpět.

Technicky: `MemberSelectorModalComponent` dostal `selectedIds` (signál vlastněný volajícím, aby se stav překresloval při změně seznamu), `onDeselect` a `onClearAll`; handlery můžou být async. Barvy odznaků se počítají z barvy oddílu do CSS proměnných pro světlý i tmavý režim. Popsáno v `CLAUDE.md`.

Ověřeno v běžící aplikaci nad seedovanými daty: přidání i odebrání účastníka a vedoucího, „Odebrat vše“ s potvrzením, hledání s diakritikou i bez, filtr podle oddílu, prázdný výsledek, přilepená hlavička při scrollu, světlý i tmavý režim, mobilní šířka a jednorázový výběr v administraci.

Closes #357