### PR TITLE
ci(version): vypsat vyřešenou verzi do shrnutí běhu

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -43,6 +43,22 @@ jobs:
           FORCE_WITHOUT_CHANGES_PRE: true
 
       - name: Print resolved tags
+        env:
+          NEW_TAG: ${{ steps.version.outputs.new_tag }}
+          OLD_TAG: ${{ steps.version.outputs.old_tag }}
+          BUMP: ${{ inputs.semver }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
-          echo "New tag: ${{ steps.version.outputs.new_tag }}"
-          echo "Old tag: ${{ steps.version.outputs.old_tag }}"
+          echo "New tag: $NEW_TAG"
+          echo "Old tag: $OLD_TAG"
+          {
+            echo "## Resolved version"
+            echo
+            echo "### \`$NEW_TAG\`"
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Previous tag | \`$OLD_TAG\` |"
+            echo "| Bump | \`$BUMP\` |"
+            echo "| Prerelease | \`$PRERELEASE\` |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
# Změny

- Krok "Print resolved tags" ve workflow `version.yml` zapisuje vyřešenou verzi do `$GITHUB_STEP_SUMMARY`, takže je v GitHub UI vidět nový tag, předchozí tag, typ bumpu a příznak prerelease.
- Hodnoty se do skriptu předávají přes `env`, ne interpolací do těla shellu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMQrtuSsvBZx6euk1AmLGB)_