### PR TITLE
style(events): odeber čáru před prvním bodem v přehledu průběhu akce

### DIFF
--- a/frontend/src/app/features/events/components/event-progress/event-progress.component.scss
+++ b/frontend/src/app/features/events/components/event-progress/event-progress.component.scss
@@ -54,7 +54,8 @@
 		background: var(--accent-in, var(--accent));
 	}
 
-	&.edge {
+	&.edge,
+	&.track-in.edge {
 		background: transparent;
 	}
 }


### PR DESCRIPTION
# Změny

 - `bo-event-progress`: příchozí kolejnice prvního bodu už se nikdy nevybarvuje. Třída `.edge` ji sice měla držet průhlednou, ale pravidlo `.track.track-in.filled` má vyšší specificitu, takže u dosaženého prvního kroku vykreslila akcentovanou čáru vedoucí „odnikud" doleva. Doplněn selektor `&.track-in.edge`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016nX9QNHfyQ3aFkW9aZFdjQ)_