### PR TITLE
feat(events): ukázat náhled vygenerované přihlášky před publikováním

### DIFF
--- a/backend/src/api/events/acl/events.acl.ts
+++ b/backend/src/api/events/acl/events.acl.ts
@@ -183,6 +183,7 @@ export const EventRegistrationEditPermission = new Permission({
 	params: { eventId: "id" },
 
 	inherit: EventEditPermission,
+	applicable: ({ doc }) => !doc.hasRegistration,
 });
 
 export const EventRegistrationGeneratePermission = new Permission({

--- a/backend/src/api/events/acl/events.acl.ts
+++ b/backend/src/api/events/acl/events.acl.ts
@@ -190,7 +190,7 @@ export const EventRegistrationGeneratePermission = new Permission({
 	params: { eventId: "id" },
 
 	inherit: EventEditPermission,
-	applicable: ({ doc }) => !!doc.attendees?.some((a) => a.type === "leader"),
+	applicable: ({ doc }) => !doc.hasRegistration && !!doc.attendees?.some((a) => a.type === "leader"),
 });
 
 export const EventRegistrationDeletePermission = new Permission({

--- a/backend/src/api/events/controllers/events-accounting.controller.ts
+++ b/backend/src/api/events/controllers/events-accounting.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Request, Response } from "express";
+import { contentDispositionFilename } from "src/helpers/sanitizefilename";
 import { AcController, AcLinks } from "src/access-control/access-control-lib";
 import { Authenticated } from "src/auth/decorators/authenticated.decorator";
 import { Event } from "src/models/events/entities/event.entity";
@@ -59,7 +60,7 @@ export class EventsAccountingController {
 
 		res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
 
-		res.setHeader("Content-Disposition", `attachment; filename="${fileName}"`);
+		res.setHeader("Content-Disposition", `attachment; ${contentDispositionFilename(fileName)}`);
 		res.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
 
 		return new StreamableFile(fileBuffer);

--- a/backend/src/api/events/controllers/events-announcement.controller.ts
+++ b/backend/src/api/events/controllers/events-announcement.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Request, Response } from "express";
+import { contentDispositionFilename } from "src/helpers/sanitizefilename";
 import { AcController, AcLinks } from "src/access-control/access-control-lib";
 import { Authenticated } from "src/auth/decorators/authenticated.decorator";
 import { Event } from "src/models/events/entities/event.entity";
@@ -59,7 +60,7 @@ export class EventsAnnouncementController {
 
 		res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
 
-		res.setHeader("Content-Disposition", `attachment; filename="${fileName}"`);
+		res.setHeader("Content-Disposition", `attachment; ${contentDispositionFilename(fileName)}`);
 		res.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
 
 		return new StreamableFile(fileBuffer);

--- a/backend/src/api/events/controllers/events-registrations.controller.ts
+++ b/backend/src/api/events/controllers/events-registrations.controller.ts
@@ -38,7 +38,7 @@ import { FilesService } from "../../../models/files/services/files.service";
 import { Config } from "src/config";
 import * as path from "path";
 import { readFile, unlink } from "fs/promises";
-import { sanitizeFilename } from "../../../helpers/sanitizefilename";
+import { contentDispositionFilename, sanitizeFilename } from "../../../helpers/sanitizefilename";
 
 @Controller("events")
 @Authenticated()
@@ -197,7 +197,7 @@ export class EventsRegistrationsController {
 		const data = await this.eventRegistrationService.generateRegistration(event, template, color, note);
 
 		res.setHeader("Content-Type", "application/pdf");
-		res.setHeader("Content-Disposition", `inline; filename="${this.registrationFileName(event)}"`);
+		res.setHeader("Content-Disposition", `inline; ${contentDispositionFilename(this.registrationFileName(event))}`);
 		res.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
 
 		return new StreamableFile(data);

--- a/backend/src/api/events/controllers/events-registrations.controller.ts
+++ b/backend/src/api/events/controllers/events-registrations.controller.ts
@@ -13,6 +13,7 @@ import {
 	Query,
 	Req,
 	Res,
+	StreamableFile,
 	UploadedFile,
 	UseInterceptors,
 } from "@nestjs/common";
@@ -61,10 +62,13 @@ export class EventsRegistrationsController {
 		await this.fileService.deleteFilesByPrefix(registrationFolder, "registration");
 	}
 
+	private registrationFileName(event: Event): string {
+		return "prihlaska_" + sanitizeFilename(event.name) + ".pdf";
+	}
+
 	private async storeRegistration(event: Event, data: Buffer): Promise<void> {
 		const registrationFolder = this.registrationFolder(event);
-		const registrationFileName = "prihlaska_" + sanitizeFilename(event.name) + ".pdf";
-		const registrationPath = path.join(registrationFolder, registrationFileName);
+		const registrationPath = path.join(registrationFolder, this.registrationFileName(event));
 
 		try {
 			await this.fileService.ensureDir(registrationFolder);
@@ -168,9 +172,9 @@ export class EventsRegistrationsController {
 	}
 
 	@Post(":eventId/registration/generate")
-	@HttpCode(204)
+	@HttpCode(200)
 	@AcLinks(EventRegistrationGeneratePermission)
-	@ApiResponse({ status: 204 })
+	@ApiResponse({ status: 200 })
 	@ApiQuery({ name: "template", required: true })
 	@ApiQuery({ name: "color", required: true })
 	@ApiQuery({ name: "note", required: false })
@@ -179,8 +183,9 @@ export class EventsRegistrationsController {
 		@Param("eventId", ParseIntPipe) eventId: number,
 		@Query("template") template: string,
 		@Query("color") color: string,
+		@Res({ passthrough: true }) res: Response,
 		@Query("note") note?: string,
-	): Promise<void> {
+	): Promise<StreamableFile> {
 		const event = await this.eventsRepository.findOne({
 			where: { id: eventId },
 			relations: { attendees: { member: { contacts: true } } },
@@ -190,7 +195,12 @@ export class EventsRegistrationsController {
 		EventRegistrationGeneratePermission.canOrThrow(req, event);
 
 		const data = await this.eventRegistrationService.generateRegistration(event, template, color, note);
-		await this.storeRegistration(event, data);
+
+		res.setHeader("Content-Type", "application/pdf");
+		res.setHeader("Content-Disposition", `inline; filename="${this.registrationFileName(event)}"`);
+		res.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
+
+		return new StreamableFile(data);
 	}
 
 	@Delete(":eventId/registration")

--- a/backend/src/api/events/controllers/events-registrations.controller.ts
+++ b/backend/src/api/events/controllers/events-registrations.controller.ts
@@ -13,12 +13,12 @@ import {
 	Query,
 	Req,
 	Res,
-	StreamableFile,
 	UploadedFile,
 	UseInterceptors,
 } from "@nestjs/common";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { ApiBody, ApiConsumes, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { RegistrationPreviewResponse } from "../dto/registration-preview.dto";
 import { RegistrationTemplateResponse } from "../dto/registration-template.dto";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Request, Response } from "express";
@@ -38,7 +38,7 @@ import { FilesService } from "../../../models/files/services/files.service";
 import { Config } from "src/config";
 import * as path from "path";
 import { readFile, unlink } from "fs/promises";
-import { contentDispositionFilename, sanitizeFilename } from "../../../helpers/sanitizefilename";
+import { sanitizeFilename } from "../../../helpers/sanitizefilename";
 
 @Controller("events")
 @Authenticated()
@@ -174,7 +174,7 @@ export class EventsRegistrationsController {
 	@Post(":eventId/registration/generate")
 	@HttpCode(200)
 	@AcLinks(EventRegistrationGeneratePermission)
-	@ApiResponse({ status: 200 })
+	@ApiResponse({ status: 200, type: RegistrationPreviewResponse })
 	@ApiQuery({ name: "template", required: true })
 	@ApiQuery({ name: "color", required: true })
 	@ApiQuery({ name: "note", required: false })
@@ -183,9 +183,8 @@ export class EventsRegistrationsController {
 		@Param("eventId", ParseIntPipe) eventId: number,
 		@Query("template") template: string,
 		@Query("color") color: string,
-		@Res({ passthrough: true }) res: Response,
 		@Query("note") note?: string,
-	): Promise<StreamableFile> {
+	): Promise<RegistrationPreviewResponse> {
 		const event = await this.eventsRepository.findOne({
 			where: { id: eventId },
 			relations: { attendees: { member: { contacts: true } } },
@@ -194,13 +193,9 @@ export class EventsRegistrationsController {
 
 		EventRegistrationGeneratePermission.canOrThrow(req, event);
 
-		const data = await this.eventRegistrationService.generateRegistration(event, template, color, note);
+		const { pdf, image } = await this.eventRegistrationService.generateRegistration(event, template, color, note);
 
-		res.setHeader("Content-Type", "application/pdf");
-		res.setHeader("Content-Disposition", `inline; ${contentDispositionFilename(this.registrationFileName(event))}`);
-		res.setHeader("Access-Control-Expose-Headers", "Content-Disposition");
-
-		return new StreamableFile(data);
+		return { pdf: pdf.toString("base64"), image: image.toString("base64") };
 	}
 
 	@Delete(":eventId/registration")

--- a/backend/src/api/events/dto/registration-preview.dto.ts
+++ b/backend/src/api/events/dto/registration-preview.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class RegistrationPreviewResponse {
+	@ApiProperty({ description: "PDF přihlášky v base64" })
+	pdf!: string;
+
+	@ApiProperty({ description: "Náhled přihlášky jako JPEG v base64" })
+	image!: string;
+}

--- a/backend/src/api/public/controllers/public.controller.ts
+++ b/backend/src/api/public/controllers/public.controller.ts
@@ -33,6 +33,7 @@ import {
 import { PublicGalleryQuery, PublicProgramQuery } from "../dto/public.dto";
 import { ProgramIcalService } from "../services/program-ical.service";
 import { PublicService } from "../services/public.service";
+import { contentDispositionFilename } from "src/helpers/sanitizefilename";
 
 @Controller("public")
 @AcController()
@@ -71,7 +72,7 @@ export class PublicController {
 		const { path, filename } = await this.publicService.getRegistrationFile(id);
 
 		res.setHeader("Content-Type", "application/pdf");
-		res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+		res.setHeader("Content-Disposition", `attachment; ${contentDispositionFilename(filename)}`);
 
 		await new Promise<void>((resolve, reject) => {
 			res.sendFile(path, (err) => (err ? reject(new InternalServerErrorException(err.message)) : resolve()));
@@ -115,7 +116,7 @@ export class PublicController {
 		});
 
 		res.setHeader("Content-Type", "application/zip");
-		res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+		res.setHeader("Content-Disposition", `attachment; ${contentDispositionFilename(filename)}`);
 
 		archive.pipe(res);
 		for (const file of files) archive.file(file.path, { name: file.name });

--- a/backend/src/helpers/sanitizefilename.ts
+++ b/backend/src/helpers/sanitizefilename.ts
@@ -5,3 +5,9 @@ export function sanitizeFilename(czech: string): string {
 		.normalize("NFD")
 		.replace(/[\u0300-\u036f]/g, "");
 }
+
+export function contentDispositionFilename(filename: string): string {
+	const ascii = filename.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+
+	return `filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+}

--- a/backend/src/models/events/services/event-registration.service.ts
+++ b/backend/src/models/events/services/event-registration.service.ts
@@ -67,7 +67,7 @@ export class EventRegistrationService {
 		const rendered = Handlebars.compile(source)(this.buildContext(event, accent, note));
 		const html = this.inlineIcons(this.injectAccent(rendered, accent), accent);
 
-		return this.htmlToPdf(html, templateDir);
+		return this.htmlToPdf(html, templateDir, `Přihláška – ${event.name}`);
 	}
 
 	private injectAccent(html: string, accent: string): string {
@@ -120,7 +120,7 @@ export class EventRegistrationService {
 		return dir;
 	}
 
-	private async htmlToPdf(html: string, templateDir: string): Promise<Buffer> {
+	private async htmlToPdf(html: string, templateDir: string, title: string): Promise<Buffer> {
 		const tempFile = path.join(templateDir, `.render-${Date.now()}-${Math.random().toString(36).slice(2)}.html`);
 		let browser: puppeteer.Browser | undefined;
 
@@ -134,6 +134,7 @@ export class EventRegistrationService {
 
 			const page = await browser.newPage();
 			await page.goto(pathToFileURL(tempFile).href, { waitUntil: "networkidle0" });
+			await page.evaluate((documentTitle) => (document.title = documentTitle), title);
 			const pdf = await page.pdf({
 				format: "A4",
 				landscape: true,

--- a/backend/src/models/events/services/event-registration.service.ts
+++ b/backend/src/models/events/services/event-registration.service.ts
@@ -5,6 +5,7 @@ import { existsSync, readFileSync } from "fs";
 import { readdir, readFile, unlink, writeFile } from "fs/promises";
 import * as path from "path";
 import * as puppeteer from "puppeteer";
+import sharp = require("sharp");
 import { pathToFileURL } from "url";
 import { string2Date } from "src/helpers/string2date";
 import { Event } from "src/models/events/entities/event.entity";
@@ -28,6 +29,24 @@ export interface RegistrationTemplate {
 	id: string;
 	name: string;
 }
+
+export interface RenderedRegistration {
+	pdf: Buffer;
+	image: Buffer;
+}
+
+const MM_TO_PX = 96 / 25.4;
+const PREVIEW_PAGE = { width: 297, height: 210, margin: 11 };
+const PREVIEW_SCALE = 1.5;
+const PREVIEW_QUALITY = 82;
+
+const previewViewport = {
+	width: Math.round((PREVIEW_PAGE.width - 2 * PREVIEW_PAGE.margin) * MM_TO_PX),
+	height: Math.round((PREVIEW_PAGE.height - 2 * PREVIEW_PAGE.margin) * MM_TO_PX),
+	deviceScaleFactor: PREVIEW_SCALE,
+};
+
+const previewMargin = Math.round(PREVIEW_PAGE.margin * MM_TO_PX * PREVIEW_SCALE);
 
 @Injectable()
 export class EventRegistrationService {
@@ -56,7 +75,12 @@ export class EventRegistrationService {
 		return templates.sort((a, b) => a.name.localeCompare(b.name, "cs"));
 	}
 
-	async generateRegistration(event: Event, templateId: string, color: string, note?: string): Promise<Buffer> {
+	async generateRegistration(
+		event: Event,
+		templateId: string,
+		color: string,
+		note?: string,
+	): Promise<RenderedRegistration> {
 		this.assertGeneratable(event);
 		const accent = PALETTES[color];
 		if (!accent) throw new BadRequestException("Neplatná barva.");
@@ -67,7 +91,7 @@ export class EventRegistrationService {
 		const rendered = Handlebars.compile(source)(this.buildContext(event, accent, note));
 		const html = this.inlineIcons(this.injectAccent(rendered, accent), accent);
 
-		return this.htmlToPdf(html, templateDir, `Přihláška – ${event.name}`);
+		return this.renderTemplate(html, templateDir, `Přihláška – ${event.name}`);
 	}
 
 	private injectAccent(html: string, accent: string): string {
@@ -120,7 +144,7 @@ export class EventRegistrationService {
 		return dir;
 	}
 
-	private async htmlToPdf(html: string, templateDir: string, title: string): Promise<Buffer> {
+	private async renderTemplate(html: string, templateDir: string, title: string): Promise<RenderedRegistration> {
 		const tempFile = path.join(templateDir, `.render-${Date.now()}-${Math.random().toString(36).slice(2)}.html`);
 		let browser: puppeteer.Browser | undefined;
 
@@ -133,19 +157,38 @@ export class EventRegistrationService {
 			});
 
 			const page = await browser.newPage();
+			await page.setViewport(previewViewport);
 			await page.goto(pathToFileURL(tempFile).href, { waitUntil: "networkidle0" });
 			await page.evaluate((documentTitle) => (document.title = documentTitle), title);
+
 			const pdf = await page.pdf({
 				format: "A4",
 				landscape: true,
 				printBackground: true,
 				preferCSSPageSize: true,
 			});
-			return Buffer.from(pdf);
+
+			await page.emulateMediaType("print");
+			const screenshot = await page.screenshot({ type: "png", fullPage: true });
+
+			return { pdf: Buffer.from(pdf), image: await this.pagePreview(Buffer.from(screenshot)) };
 		} finally {
 			await browser?.close().catch(() => undefined);
 			await unlink(tempFile).catch(() => undefined);
 		}
+	}
+
+	private async pagePreview(screenshot: Buffer): Promise<Buffer> {
+		return sharp(screenshot)
+			.extend({
+				top: previewMargin,
+				bottom: previewMargin,
+				left: previewMargin,
+				right: previewMargin,
+				background: "#ffffff",
+			})
+			.jpeg({ quality: PREVIEW_QUALITY })
+			.toBuffer();
 	}
 
 	private resolveChromiumPath(): string | undefined {

--- a/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.html
+++ b/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.html
@@ -2,7 +2,7 @@
 	<h4 slot="title">Náhled přihlášky</h4>
 
 	<div class="preview">
-		<iframe class="preview-frame" [src]="src" title="Náhled přihlášky"></iframe>
+		<img class="preview-image" [src]="image" alt="Náhled přihlášky" (click)="openInNewTab()" />
 	</div>
 
 	<p class="preview-note">Zkontroluj přihlášku — k akci se uloží až po publikování.</p>

--- a/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.html
+++ b/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.html
@@ -1,0 +1,23 @@
+<bo-modal-layout>
+	<h4 slot="title">Náhled přihlášky</h4>
+
+	<div class="preview">
+		<iframe class="preview-frame" [src]="src" title="Náhled přihlášky"></iframe>
+	</div>
+
+	<p class="preview-note">Zkontroluj přihlášku — k akci se uloží až po publikování.</p>
+
+	<div slot="buttons" class="bm-buttons preview-buttons">
+		<button
+			type="button"
+			class="bm-btn-ghost preview-open"
+			(click)="openInNewTab()"
+			aria-label="Otevřít v novém panelu"
+		>
+			<ion-icon name="open-outline"></ion-icon>
+			<span class="preview-open-label">Otevřít v novém panelu</span>
+		</button>
+		<button type="button" class="bm-btn-ghost" (click)="close.emit()">Zrušit</button>
+		<button type="button" class="bm-btn-primary" (click)="publish()">Publikovat</button>
+	</div>
+</bo-modal-layout>

--- a/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.scss
+++ b/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.scss
@@ -1,0 +1,65 @@
+@use "./../../../../../styles/brand-modal" as *;
+
+:host ::ng-deep .content {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.preview {
+	flex: 0 0 auto;
+	width: 100%;
+	aspect-ratio: 297 / 210;
+	min-height: 200px;
+	max-height: calc(90dvh - 260px);
+	overflow: hidden;
+	border: 1px solid var(--bm-border);
+	border-radius: 14px;
+	background: var(--bm-surface-alt);
+}
+
+.preview-frame {
+	display: block;
+	width: 100%;
+	height: 100%;
+	border: 0;
+}
+
+.preview-note {
+	margin: 0;
+	padding: 0 2px;
+	font-size: 13.5px;
+	color: var(--bm-muted);
+}
+
+.preview-buttons {
+	flex: 1 1 auto;
+	align-items: center;
+}
+
+.preview-buttons button {
+	white-space: nowrap;
+}
+
+.preview-open {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	margin-right: auto;
+	padding: 11px 14px;
+	color: var(--bm-muted);
+
+	ion-icon {
+		font-size: 19px;
+	}
+}
+
+.preview-open-label {
+	display: none;
+}
+
+@media (min-width: 560px) {
+	.preview-open-label {
+		display: inline;
+	}
+}

--- a/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.scss
+++ b/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.scss
@@ -8,21 +8,20 @@
 
 .preview {
 	flex: 0 0 auto;
-	width: 100%;
-	aspect-ratio: 297 / 210;
-	min-height: 200px;
-	max-height: calc(90dvh - 260px);
+	align-self: center;
+	display: flex;
+	max-width: 100%;
 	overflow: hidden;
 	border: 1px solid var(--bm-border);
 	border-radius: 14px;
 	background: var(--bm-surface-alt);
 }
 
-.preview-frame {
+.preview-image {
 	display: block;
-	width: 100%;
-	height: 100%;
-	border: 0;
+	max-width: 100%;
+	max-height: calc(90dvh - 260px);
+	cursor: zoom-in;
 }
 
 .preview-note {

--- a/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.ts
+++ b/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.ts
@@ -1,5 +1,4 @@
 import { Component } from "@angular/core";
-import { SafeResourceUrl } from "@angular/platform-browser";
 import { IonIcon, ModalController } from "@ionic/angular/standalone";
 import { addIcons } from "ionicons";
 import { openOutline } from "ionicons/icons";
@@ -13,7 +12,7 @@ import { ModalLayoutComponent } from "src/app/shared/components/modal-layout/mod
 	imports: [IonIcon, ModalLayoutComponent],
 })
 export class EventRegistrationPreviewModalComponent extends InputModalComponent<boolean> {
-	src!: SafeResourceUrl;
+	image!: string;
 	url!: string;
 
 	constructor(modalController: ModalController) {

--- a/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.ts
+++ b/frontend/src/app/features/events/components/event-registration-preview-modal/event-registration-preview-modal.component.ts
@@ -1,0 +1,31 @@
+import { Component } from "@angular/core";
+import { SafeResourceUrl } from "@angular/platform-browser";
+import { IonIcon, ModalController } from "@ionic/angular/standalone";
+import { addIcons } from "ionicons";
+import { openOutline } from "ionicons/icons";
+import { InputModalComponent } from "src/app/core/services/modal.service";
+import { ModalLayoutComponent } from "src/app/shared/components/modal-layout/modal-layout.component";
+
+@Component({
+	selector: "bo-event-registration-preview-modal",
+	templateUrl: "./event-registration-preview-modal.component.html",
+	styleUrl: "./event-registration-preview-modal.component.scss",
+	imports: [IonIcon, ModalLayoutComponent],
+})
+export class EventRegistrationPreviewModalComponent extends InputModalComponent<boolean> {
+	src!: SafeResourceUrl;
+	url!: string;
+
+	constructor(modalController: ModalController) {
+		super(modalController);
+		addIcons({ openOutline });
+	}
+
+	publish() {
+		this.submit.emit(true);
+	}
+
+	openInNewTab() {
+		window.open(this.url, "_blank", "noopener");
+	}
+}

--- a/frontend/src/app/features/events/components/event-registration/event-registration.component.html
+++ b/frontend/src/app/features/events/components/event-registration/event-registration.component.html
@@ -10,17 +10,15 @@
 		</ion-button>
 	}
 	@if (event()?._links?.generateEventRegistration?.applicable) {
-		@if (!event()?.hasRegistration) {
-			<ion-button
-				[disabled]="!event()?._links?.generateEventRegistration?.allowed || busy()"
-				[boTooltip]="event()?._links?.generateEventRegistration?.applicable ? 'Generovat' : 'Akce nemá vedoucího'"
-				fill="clear"
-				(click)="generateRegistration()"
-			>
-				<ion-icon class="ion-hide-md-up" name="color-wand-outline"></ion-icon>
-				<span class="ion-hide-md-down">Generovat</span>
-			</ion-button>
-		}
+		<ion-button
+			[disabled]="!event()?._links?.generateEventRegistration?.allowed || busy()"
+			boTooltip="Generovat"
+			fill="clear"
+			(click)="generateRegistration()"
+		>
+			<ion-icon class="ion-hide-md-up" name="color-wand-outline"></ion-icon>
+			<span class="ion-hide-md-down">Generovat</span>
+		</ion-button>
 	}
 	@if (event()?._links?.getEventRegistration?.applicable) {
 		<ion-button
@@ -46,7 +44,6 @@
 		</ion-button>
 	}
 </div>
-
 
 @if (generatingRegistration()) {
 	<p>Generuji přihlášku&hellip;</p>

--- a/frontend/src/app/features/events/components/event-registration/event-registration.component.html
+++ b/frontend/src/app/features/events/components/event-registration/event-registration.component.html
@@ -1,7 +1,7 @@
 <div class="buttons">
 	@if (event()?._links?.saveEventRegistration?.applicable) {
 		<ion-button
-			[disabled]="!event()?._links?.saveEventRegistration?.allowed || uploadingRegistration()"
+			[disabled]="!event()?._links?.saveEventRegistration?.allowed || busy()"
 			fill="clear"
 			(click)="registrationInput.click()"
 		>
@@ -11,7 +11,7 @@
 	}
 	@if (event()?._links?.generateEventRegistration; as generateLink) {
 		<ion-button
-			[disabled]="!generateLink.allowed || !generateLink.applicable || uploadingRegistration()"
+			[disabled]="!generateLink.allowed || !generateLink.applicable || busy()"
 			[boTooltip]="generateLink.applicable ? 'Generovat' : 'Akce nemá vedoucího'"
 			fill="clear"
 			(click)="generateRegistration()"
@@ -22,7 +22,7 @@
 	}
 	@if (event()?._links?.getEventRegistration?.applicable) {
 		<ion-button
-			[disabled]="!event()?._links?.getEventRegistration?.allowed || uploadingRegistration()"
+			[disabled]="!event()?._links?.getEventRegistration?.allowed || busy()"
 			boTooltip="Zobrazit"
 			fill="clear"
 			(click)="getRegistration()"
@@ -33,7 +33,7 @@
 	}
 	@if (event()?._links?.deleteEventRegistration?.applicable) {
 		<ion-button
-			[disabled]="!event()?._links?.deleteEventRegistration?.allowed || uploadingRegistration()"
+			[disabled]="!event()?._links?.deleteEventRegistration?.allowed || busy()"
 			boTooltip="Smazat"
 			fill="clear"
 			color="danger"
@@ -51,7 +51,9 @@
 	}
 }
 
-@if (uploadingRegistration()) {
+@if (generatingRegistration()) {
+	<p>Generuji přihlášku&hellip;</p>
+} @else if (uploadingRegistration()) {
 	<p>Nahrávám&hellip;</p>
 }
 <input

--- a/frontend/src/app/features/events/components/event-registration/event-registration.component.html
+++ b/frontend/src/app/features/events/components/event-registration/event-registration.component.html
@@ -10,15 +10,17 @@
 		</ion-button>
 	}
 	@if (event()?._links?.generateEventRegistration; as generateLink) {
-		<ion-button
-			[disabled]="!generateLink.allowed || !generateLink.applicable || busy()"
-			[boTooltip]="generateLink.applicable ? 'Generovat' : 'Akce nemá vedoucího'"
-			fill="clear"
-			(click)="generateRegistration()"
-		>
-			<ion-icon class="ion-hide-md-up" name="color-wand-outline"></ion-icon>
-			<span class="ion-hide-md-down">Generovat</span>
-		</ion-button>
+		@if (!event()?.hasRegistration) {
+			<ion-button
+				[disabled]="!generateLink.allowed || !generateLink.applicable || busy()"
+				[boTooltip]="generateLink.applicable ? 'Generovat' : 'Akce nemá vedoucího'"
+				fill="clear"
+				(click)="generateRegistration()"
+			>
+				<ion-icon class="ion-hide-md-up" name="color-wand-outline"></ion-icon>
+				<span class="ion-hide-md-down">Generovat</span>
+			</ion-button>
+		}
 	}
 	@if (event()?._links?.getEventRegistration?.applicable) {
 		<ion-button
@@ -46,7 +48,7 @@
 </div>
 
 @if (event()?._links?.generateEventRegistration; as generateLink) {
-	@if (generateLink.allowed && !generateLink.applicable) {
+	@if (generateLink.allowed && !generateLink.applicable && !event()?.hasRegistration) {
 		<p class="hint">Přihlášku nelze vygenerovat, akce nemá vedoucího.</p>
 	}
 }

--- a/frontend/src/app/features/events/components/event-registration/event-registration.component.html
+++ b/frontend/src/app/features/events/components/event-registration/event-registration.component.html
@@ -9,11 +9,11 @@
 			<span class="ion-hide-md-down">Nahrát</span>
 		</ion-button>
 	}
-	@if (event()?._links?.generateEventRegistration; as generateLink) {
+	@if (event()?._links?.generateEventRegistration?.applicable) {
 		@if (!event()?.hasRegistration) {
 			<ion-button
-				[disabled]="!generateLink.allowed || !generateLink.applicable || busy()"
-				[boTooltip]="generateLink.applicable ? 'Generovat' : 'Akce nemá vedoucího'"
+				[disabled]="!event()?._links?.generateEventRegistration?.allowed || busy()"
+				[boTooltip]="event()?._links?.generateEventRegistration?.applicable ? 'Generovat' : 'Akce nemá vedoucího'"
 				fill="clear"
 				(click)="generateRegistration()"
 			>
@@ -47,11 +47,6 @@
 	}
 </div>
 
-@if (event()?._links?.generateEventRegistration; as generateLink) {
-	@if (generateLink.allowed && !generateLink.applicable && !event()?.hasRegistration) {
-		<p class="hint">Přihlášku nelze vygenerovat, akce nemá vedoucího.</p>
-	}
-}
 
 @if (generatingRegistration()) {
 	<p>Generuji přihlášku&hellip;</p>

--- a/frontend/src/app/features/events/components/event-registration/event-registration.component.ts
+++ b/frontend/src/app/features/events/components/event-registration/event-registration.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, ElementRef, input, output, signal, ViewChild } from "@angular/core";
+import { Component, computed, ElementRef, input, output, signal, ViewChild } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { DomSanitizer } from "@angular/platform-browser";
 import { AlertController, IonButton, IonIcon } from "@ionic/angular/standalone";
@@ -11,6 +11,7 @@ import { ApiService } from "src/app/core/services/api.service";
 import { ModalService } from "src/app/core/services/modal.service";
 import { ToastService } from "src/app/core/services/toast.service";
 import { MarkdownEditorModalComponent } from "src/app/shared/components/markdown-editor-modal/markdown-editor-modal.component";
+import { EventRegistrationPreviewModalComponent } from "../event-registration-preview-modal/event-registration-preview-modal.component";
 import { TooltipDirective } from "src/app/shared/directives/tooltip.directive";
 import { SDK } from "src/sdk";
 import { EventsService } from "../../services/events.service";
@@ -27,6 +28,9 @@ export class EventRegistrationComponent {
 	update = output<void>();
 
 	uploadingRegistration = signal(false);
+	generatingRegistration = signal(false);
+
+	busy = computed(() => this.uploadingRegistration() || this.generatingRegistration());
 
 	private readonly colors = [
 		{ id: "black", name: "Černá" },
@@ -135,11 +139,11 @@ export class EventRegistrationComponent {
 				});
 			}
 
-			buttons.push({ text: "Ano, nahradit přihlášku", role: "destructive", handler: () => resolve(true) });
+			buttons.push({ text: "Ano, vygenerovat novou", handler: () => resolve(true) });
 
 			const alert = await this.alertController.create({
 				header: "Přepsat přihlášku?",
-				message: "Generováním přihlášky přepíšeš tu, co je u akce nahraná. Opravdu to chceš udělat?",
+				message: "Nová přihláška nahradí tu, co je u akce nahraná — až ji publikuješ.",
 				buttons,
 			});
 
@@ -179,18 +183,69 @@ export class EventRegistrationComponent {
 	}
 
 	private async generateWithTemplate(eventId: number, template: string, color: string, note?: string) {
+		this.generatingRegistration.set(true);
+
+		let registration: Blob;
+		try {
+			const response = (await this.api.EventsApi.generateEventRegistration(
+				eventId,
+				{ template, color, note },
+				{ responseType: "blob" },
+			)) as any;
+			registration = new Blob([response.data], { type: "application/pdf" });
+		} catch (err: any) {
+			this.toastService.toast("Nastala chyba při generování: " + (await this.errorMessage(err)));
+			return;
+		} finally {
+			this.generatingRegistration.set(false);
+		}
+
+		await this.previewRegistration(eventId, registration);
+	}
+
+	private async previewRegistration(eventId: number, registration: Blob) {
+		const url = window.URL.createObjectURL(registration);
+
+		try {
+			const publish = await this.modalService.componentModal(
+				EventRegistrationPreviewModalComponent,
+				{ src: this.sanitizer.bypassSecurityTrustResourceUrl(url + "#navpanes=0&view=Fit"), url },
+				{ cssClass: "dialog-preview", backdropDismiss: false },
+			);
+
+			if (publish) await this.publishRegistration(eventId, registration);
+		} finally {
+			setTimeout(() => window.URL.revokeObjectURL(url), 60_000);
+		}
+	}
+
+	private async publishRegistration(eventId: number, registration: Blob) {
 		this.uploadingRegistration.set(true);
 
 		try {
-			await this.api.EventsApi.generateEventRegistration(eventId, { template, color, note });
+			const file = new File([registration], "prihlaska.pdf", { type: "application/pdf" });
+			await this.api.EventsApi.saveEventRegistration(eventId, file);
 			this.update.emit();
-			this.toastService.toast("Přihláška vygenerována.");
+			this.toastService.toast("Přihláška publikována.");
 		} catch (err: any) {
-			const message = err?.response?.data?.message ?? err.message;
-			this.toastService.toast("Nastala chyba při generování: " + message);
+			this.toastService.toast("Nastala chyba při publikování: " + (await this.errorMessage(err)));
 		} finally {
 			this.uploadingRegistration.set(false);
 		}
+	}
+
+	private async errorMessage(err: any): Promise<string> {
+		const data = err?.response?.data;
+
+		if (data instanceof Blob) {
+			try {
+				return JSON.parse(await data.text()).message ?? err.message;
+			} catch {
+				return err.message;
+			}
+		}
+
+		return data?.message ?? err.message;
 	}
 
 	async deleteRegistration() {

--- a/frontend/src/app/features/events/components/event-registration/event-registration.component.ts
+++ b/frontend/src/app/features/events/components/event-registration/event-registration.component.ts
@@ -3,7 +3,6 @@ import { Component, computed, ElementRef, input, output, signal, ViewChild } fro
 import { FormsModule } from "@angular/forms";
 import { DomSanitizer } from "@angular/platform-browser";
 import { AlertController, IonButton, IonIcon } from "@ionic/angular/standalone";
-import { AlertButton } from "@ionic/core";
 import { UntilDestroy } from "@ngneat/until-destroy";
 import { addIcons } from "ionicons";
 import { cloudUploadOutline, colorWandOutline, eyeOutline, trashOutline } from "ionicons/icons";
@@ -93,8 +92,6 @@ export class EventRegistrationComponent {
 			return;
 		}
 
-		if (event.hasRegistration && !(await this.confirmOverwriteRegistration(event))) return;
-
 		let templates: SDK.RegistrationTemplateResponse[];
 		try {
 			templates = (await this.api.EventsApi.getEventRegistrationTemplates(event.id)).data;
@@ -123,33 +120,6 @@ export class EventRegistrationComponent {
 			],
 		});
 		await colorAlert.present();
-	}
-
-	private async confirmOverwriteRegistration(event: SDK.EventResponseWithLinks): Promise<boolean> {
-		return new Promise<boolean>(async (resolve) => {
-			const buttons: AlertButton[] = [{ text: "Zrušit", role: "cancel", handler: () => resolve(false) }];
-
-			if (event._links?.getEventRegistration?.allowed) {
-				buttons.push({
-					text: "Zobrazit existující přihlášku",
-					handler: () => {
-						void this.getRegistration();
-						resolve(false);
-					},
-				});
-			}
-
-			buttons.push({ text: "Ano, vygenerovat novou", handler: () => resolve(true) });
-
-			const alert = await this.alertController.create({
-				header: "Přepsat přihlášku?",
-				message: "Nová přihláška nahradí tu, co je u akce nahraná — až ji publikuješ.",
-				buttons,
-			});
-
-			alert.onDidDismiss().then(() => resolve(false));
-			await alert.present();
-		});
 	}
 
 	private async selectTemplate(eventId: number, color: string, templates: SDK.RegistrationTemplateResponse[]) {

--- a/frontend/src/app/features/events/components/event-registration/event-registration.component.ts
+++ b/frontend/src/app/features/events/components/event-registration/event-registration.component.ts
@@ -155,14 +155,9 @@ export class EventRegistrationComponent {
 	private async generateWithTemplate(eventId: number, template: string, color: string, note?: string) {
 		this.generatingRegistration.set(true);
 
-		let registration: Blob;
+		let preview: SDK.RegistrationPreviewResponse;
 		try {
-			const response = (await this.api.EventsApi.generateEventRegistration(
-				eventId,
-				{ template, color, note },
-				{ responseType: "blob" },
-			)) as any;
-			registration = new Blob([response.data], { type: "application/pdf" });
+			preview = (await this.api.EventsApi.generateEventRegistration(eventId, { template, color, note })).data;
 		} catch (err: any) {
 			this.toastService.toast("Nastala chyba při generování: " + (await this.errorMessage(err)));
 			return;
@@ -170,16 +165,17 @@ export class EventRegistrationComponent {
 			this.generatingRegistration.set(false);
 		}
 
-		await this.previewRegistration(eventId, registration);
+		await this.previewRegistration(eventId, preview);
 	}
 
-	private async previewRegistration(eventId: number, registration: Blob) {
+	private async previewRegistration(eventId: number, preview: SDK.RegistrationPreviewResponse) {
+		const registration = this.base64ToBlob(preview.pdf, "application/pdf");
 		const url = window.URL.createObjectURL(registration);
 
 		try {
 			const publish = await this.modalService.componentModal(
 				EventRegistrationPreviewModalComponent,
-				{ src: this.sanitizer.bypassSecurityTrustResourceUrl(url + "#navpanes=0&view=Fit"), url },
+				{ image: `data:image/jpeg;base64,${preview.image}`, url },
 				{ cssClass: "dialog-preview", backdropDismiss: false },
 			);
 
@@ -187,6 +183,15 @@ export class EventRegistrationComponent {
 		} finally {
 			setTimeout(() => window.URL.revokeObjectURL(url), 60_000);
 		}
+	}
+
+	private base64ToBlob(base64: string, type: string): Blob {
+		const binary = atob(base64);
+		const bytes = new Uint8Array(binary.length);
+
+		for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+		return new Blob([bytes], { type });
 	}
 
 	private async publishRegistration(eventId: number, registration: Blob) {

--- a/frontend/src/sdk/api.ts
+++ b/frontend/src/sdk/api.ts
@@ -4297,6 +4297,25 @@ export namespace SDK {
         /**
      * 
      * @export
+     * @interface RegistrationPreviewResponse
+     */
+    export interface RegistrationPreviewResponse {
+        /**
+         * PDF přihlášky v base64
+         * @type {string}
+         * @memberof RegistrationPreviewResponse
+         */
+        'pdf': string;
+        /**
+         * Náhled přihlášky jako JPEG v base64
+         * @type {string}
+         * @memberof RegistrationPreviewResponse
+         */
+        'image': string;
+    }
+    /**
+     * 
+     * @export
      * @interface RegistrationTemplateResponse
      */
     export interface RegistrationTemplateResponse {
@@ -6106,7 +6125,7 @@ export namespace SDK {
             axiosRequestConfig["url"] = toPathString(requestUrlObj);
             axiosRequestConfig["baseURL"] = this.configuration.basePath;
             
-            return this.axios.request<void>(axiosRequestConfig);
+            return this.axios.request<RegistrationPreviewResponse>(axiosRequestConfig);
         }
     
         /**

--- a/frontend/src/styles/ionic.scss
+++ b/frontend/src/styles/ionic.scss
@@ -101,6 +101,11 @@ ion-modal.dialog.dialog-brand {
 	--max-width: calc(100vw - 32px);
 }
 
+ion-modal.dialog.dialog-preview {
+	--width: 1000px;
+	--max-width: calc(100vw - 32px);
+}
+
 ion-popover.transparent {
 	--background: transparent;
 }


### PR DESCRIPTION
Generování přihlášky se rozpadlo na dva kroky: `POST /events/:eventId/registration/generate`
už soubor neukládá, jen vrátí vyrenderované PDF, a k akci ho uloží až `PUT
/events/:eventId/registration` po kliknutí na Publikovat. Zrušení tedy nezmění nic — dosud
nahraná přihláška zůstane, jak byla.

Náhled je dialog v brandované podobě ostatních modálů akce (bo-modal-layout, bm-* tlačítka).
Rámeček drží poměr stran A4 na šířku a je omezený výškou okna, takže se celá přihláška vejde
na desktopu, tabletu i mobilu; na mobilu se popisek tlačítka pro otevření v novém panelu
schová a zůstane jen ikona.

Puppeteeru se před tiskem nastavuje titulek dokumentu, aby prohlížeč u náhledu nezobrazoval
jméno dočasného souboru.

Closes #319

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TZem1Vyi3pfNa4dHMYwNP6