### PR TITLE
fix(files): nemazat přílohy s chybou, když soubory už neexistují

### DIFF
--- a/backend/src/models/files/services/files.service.ts
+++ b/backend/src/models/files/services/files.service.ts
@@ -3,6 +3,17 @@ import { access, mkdir, readdir, rename, rmdir, unlink, writeFile } from "fs/pro
 import { dirname, join } from "path";
 import { Config } from "src/config";
 
+function isEnoent(err: unknown): boolean {
+	return typeof err === "object" && err !== null && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function ignoreEnoent<T>(fallback: T) {
+	return (err: unknown): T => {
+		if (isEnoent(err)) return fallback;
+		throw err;
+	};
+}
+
 @Injectable()
 export class FilesService implements OnApplicationBootstrap {
 	constructor(private readonly config: Config) {}
@@ -46,10 +57,12 @@ export class FilesService implements OnApplicationBootstrap {
 	}
 
 	async deleteFilesByPrefix(directoryPath: string, prefix: string): Promise<void> {
-		const files = await readdir(directoryPath);
+		const files = await readdir(directoryPath).catch(ignoreEnoent<string[]>([]));
 		const matchingFiles = files.filter((file) => file.startsWith(prefix));
 
-		await Promise.all(matchingFiles.map((file) => unlink(join(directoryPath, file))));
+		await Promise.all(
+			matchingFiles.map((file) => unlink(join(directoryPath, file)).catch(ignoreEnoent<void>(undefined))),
+		);
 	}
 
 	async getFilesByPrefx(directoryPath: string, prefix: string): Promise<string[]> {


### PR DESCRIPTION
# Změny

 - `FilesService.deleteFilesByPrefix()` bere `ENOENT` jako hotovo — chybějící složka se chová jako prázdná a soubor, který zmizí mezi výpisem a `unlink`em, se přeskočí. Ostatní chyby (práva, I/O) padají dál jako dřív.
 - Tím `DELETE /events/:eventId/registration` neskončí chybou 500, když složka akty v datech nikdy nevznikla — smaže se řádek v databázi (`hasRegistration = false`) a endpoint vrátí úspěch.

Původní chyba: `Error: ENOENT: no such file or directory, scandir '/app/data/events/7'` z `FilesService.deleteFilesByPrefix`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016iXemnVFfRd32xaZLvmu5y)_