### PR TITLE
style(albums): ztlumení fotek nepublikovaných alb v dlaždicovém zobrazení

### DIFF
--- a/frontend/src/app/features/albums/pages/albums-list/albums-list.component.html
+++ b/frontend/src/app/features/albums/pages/albums-list/albums-list.component.html
@@ -61,7 +61,7 @@
 			@if (albums(); as albumList) {
 				@for (album of albumList; track album.id) {
 					<a class="albums-grid-item" [routerLink]="rowLink(album)">
-						<div class="albums-grid-photo">
+						<div class="albums-grid-photo" [class.albums-grid-photo-unpublished]="album.status !== 'public'">
 							@if (album.coverPhoto) {
 								<img
 									[src]="album.coverPhoto | photoImageUrl: 'small'"

--- a/frontend/src/app/features/albums/pages/albums-list/albums-list.component.scss
+++ b/frontend/src/app/features/albums/pages/albums-list/albums-list.component.scss
@@ -129,6 +129,13 @@
 		height: 100%;
 		margin: 0;
 	}
+
+	&.albums-grid-photo-unpublished {
+		img,
+		> ion-icon {
+			opacity: 0.45;
+		}
+	}
 }
 
 a.albums-grid-item:hover .albums-grid-photo {


### PR DESCRIPTION
# Změny

- V galerii alb (dlaždicové zobrazení) se titulní fotka nepublikovaného alba zobrazuje ztlumená (`opacity: 0.45`) — týká se i zástupné ikony u alba bez fotky.
- Štítek se stavem alba zůstává plně čitelný, ztlumení se aplikuje jen na obrázek/ikonu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCNvwMkHddtvS7ZzYbXCqR)_