### PR TITLE
style(home): adjust top leaders card layout for xl screens

### DIFF
--- a/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.html
+++ b/frontend/src/app/features/home/components/home-dashboard/home-dashboard.component.html
@@ -55,7 +55,7 @@
 					<div class="col-12 col-lg-6">
 						<bo-home-card-noleader-events class="mb-3 mb-lg-3"></bo-home-card-noleader-events>
 					</div>
-					<div class="col-12">
+					<div class="col-12 col-xl-6">
 						<bo-home-card-top-leaders class="mb-3 mb-lg-3"></bo-home-card-top-leaders>
 					</div>
 				</div>


### PR DESCRIPTION
# Změny

- Přidán breakpoint `col-xl-6` na kartu Top Leaders, aby se na XL obrazovkách zobrazovala vedle karty No Leader Events místo pod ní

## Popis

Upravena responsivní třída na `bo-home-card-top-leaders` z `col-12` na `col-12 col-xl-6`. Tato změna umožňuje kartě zaujmout polovinu šířky na extra velkých obrazovkách (≥1200px), zatímco na menších obrazovkách zůstává na plné šířce.

https://claude.ai/code/session_01QF3kGMcSAkT3fbtEecaJeF