### PR TITLE
style(albums): titulní fotka alba v poměru 350×200 jako na webu

### DIFF
--- a/frontend/src/app/features/albums/pages/albums-view-info/albums-view-info.component.ts
+++ b/frontend/src/app/features/albums/pages/albums-view-info/albums-view-info.component.ts
@@ -28,6 +28,8 @@ import { AlbumInfoComponent } from "../../components/album-info/album-info.compo
 import { PhotosEditComponent } from "../../components/photos-edit/photos-edit.component";
 import { PhotosUploadComponent } from "../../components/photos-upload/photos-upload.component";
 
+const TITLE_PHOTO_ASPECT_RATIO = 350 / 200;
+
 @UntilDestroy()
 @Component({
 	selector: "bo-albums-view-info",
@@ -50,10 +52,9 @@ export class AlbumsViewInfoComponent implements OnInit, AfterViewInit, OnDestroy
 	titlePhoto = computed(() => this.photos()?.find((photo) => photo.titlePhoto));
 
 	titlePhotoWidth = computed(() => {
-		const photo = this.titlePhoto();
 		const height = this.albumInfoHeight();
-		if (!photo?.width || !photo.height || !height) return null;
-		return (height * photo.width) / photo.height;
+		if (!height) return null;
+		return height * TITLE_PHOTO_ASPECT_RATIO;
 	});
 
 	private albumInfo = viewChild.required("albumInfo", { read: ElementRef<HTMLElement> });


### PR DESCRIPTION
# Změny

 - Titulní fotka vedle metadat alba (`albums-view-info`) se nově vykresluje v poměru stran 350 × 200 jako náhledy ve veřejné galerii na bosan.cz. Šířka se dřív dopočítávala z rozměrů konkrétní fotky (`height * photo.width / photo.height`), takže každé album mělo jiný tvar; teď je to `height * 350 / 200`. Výška se dál řídí výškou bloku s metadaty, ořez zajišťuje stávající `object-fit: cover`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BESFdpRJfCJYoGpqB89UzA)_